### PR TITLE
Connects to #30 Enable Persona login system

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var globals = require('./globals');
+var mixins = require('./mixins');
 var navbar = require('./navbar');
 var jsonScriptEscape = require('../libs/jsonScriptEscape');
 var url = require('url');
@@ -26,6 +27,12 @@ var portal = {
 
 // Renders HTML common to all pages.
 var App = module.exports = React.createClass({
+    mixins: [mixins.Persona, mixins.HistoryAndTriggers],
+    triggers: {
+        login: 'triggerLogin',
+        logout: 'triggerLogout',
+    },
+
     getInitialState: function() {
         return {
             errors: [],
@@ -94,7 +101,7 @@ var App = module.exports = React.createClass({
                         __html: '\n\n' + jsonScriptEscape(JSON.stringify(this.props.context)) + '\n\n'
                     }}></script>
                     <div>
-                        <Header />
+                        <Header session={this.state.session} />
                         {content}
                     </div>
                 </body>
@@ -127,8 +134,25 @@ var App = module.exports = React.createClass({
 // Render the common page header.
 var Header = React.createClass({
     render: function() {
+        var session = this.props.session;
+        var sessionRender;
+
+        if (!(session && session['auth.userid'])) {
+            sessionRender = (
+                <a data-trigger="login" href="#">Sign in</a>
+            );
+        } else {
+            var fullname = (session.user_properties && session.user_properties.title) || 'unknown';
+            sessionRender = (
+                <a data-trigger="logout" href="#">{'Sign Out ' + fullname}</a>
+            );
+        }
+
         return (
             <header className="site-header">
+                <div className="session-temp">
+                    {sessionRender}
+                </div>
                 <Navbar portal={portal} />
             </header>
         );

--- a/src/clincoded/static/scss/clincoded/_base.scss
+++ b/src/clincoded/static/scss/clincoded/_base.scss
@@ -27,6 +27,7 @@ p {
 }
 
 .site-header {
+    position: relative;
     border-top: 6px solid $color-trim;
     border-bottom: 2px solid $color-trim;
     background: white;

--- a/src/clincoded/static/scss/clincoded/modules/_navbar.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_navbar.scss
@@ -69,3 +69,19 @@
         }
     }
 }
+
+.session-temp {
+    position: absolute;
+    padding: 2px 5px;
+    background-color: $color-trim;
+    color: #000;
+    top: 0;
+    right: 10px;
+    z-index: 100;
+
+    a {
+        font-weight: bold;
+        color: #000;
+        text-decoration: none;
+    }
+}


### PR DESCRIPTION
This is a temporary UI to enable Persona login/logout. It appears in a little window-relative tab in the upper right of the header area.

As part of #29, I’m refactoring the navigation components to be more general, and I’ll implement the navigation you see in the upper right of the Tam/Selina UI document as a proposed final UI, including Persona login.

Sorry about the temporary PR confusion. I realized I used the ENCODED branch naming “standard” (which doesn’t actually exist) instead of the ClinGen one (which does), so I renamed it which closed the previous PR.