### PR TITLE
Connects to #56 ft curation central

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "es5-shim": "^4.0.3",
     "es6-promise": "^2.0.1",
     "form-serialize": "^0.6.0",
-    "html5shiv": "^3.7.2",
+    "html5shiv": "git://github.com/aFarkas/html5shiv.git#3.7.2",
     "jquery": "^2.1.4",
     "moment": "^2.10.3",
     "node-ckeditor": "^4.3.2",

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -125,10 +125,10 @@ var CreateGeneDisease = React.createClass({
                     <Panel panelClassName="panel-create-gene-disease">
                         <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                             <div className="row">
-                                <Input type="text" ref="hgncgene" label={<LabelHgncGene />}
+                                <Input type="text" ref="hgncgene" label={<LabelHgncGene />} placeholder="e.g. DICER1"
                                     error={this.getFormError('hgncgene')} clearError={this.clrFormErrors.bind(null, 'hgncgene')}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
-                                <Input type="text" ref="orphanetid" label={<LabelOrphanetId />}
+                                <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15"
                                     error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
                                 <Input type="select" ref="hpo" label="Mode of Inheritance" defaultValue={hpoValues[0].value}

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -8,6 +8,7 @@ var modal = require('../libs/bootstrap/modal');
 var form = require('../libs/bootstrap/form');
 var parseAndLogError = require('./mixins').parseAndLogError;
 var RestMixin = require('./rest').RestMixin;
+var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
 
 var Modal = modal.Modal;
 var ModalMixin = modal.ModalMixin;
@@ -254,7 +255,8 @@ var AddPmidModal = React.createClass({
                 return Promise.resolve(article);
             }, e => {
                 // PubMed article not in our DB; go out to PubMed itself to retrieve it as XML
-                return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(data => {
+                return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
+                    var pubmedData = parsePubmed(xml, enteredPmid);
                     // Retrieved article data from PubMed; convert it to our DB article object format
                     var newArticle = {};
                     var medline = data.PubmedArticleSet.PubmedArticle[0].MedlineCitation[0];

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -256,27 +256,7 @@ var AddPmidModal = React.createClass({
             }, e => {
                 // PubMed article not in our DB; go out to PubMed itself to retrieve it as XML
                 return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
-                    var pubmedData = parsePubmed(xml, enteredPmid);
-                    // Retrieved article data from PubMed; convert it to our DB article object format
-                    var newArticle = {};
-                    var medline = data.PubmedArticleSet.PubmedArticle[0].MedlineCitation[0];
-                    var article = medline.Article[0];
-                    newArticle.pmid = medline.PMID[0]['_'];
-                    newArticle.title = article.ArticleTitle[0];
-                    var journal = article.Journal[0];
-                    var journalIssue = journal.JournalIssue[0];
-                    var pubDateObj = journalIssue.PubDate[0];
-                    var pubDate;
-                    if (pubDateObj.MedlineDate) {
-                        pubDate = pubDateObj.MedlineDate[0];
-                    } else if (pubDateObj.Year || pubDateObj.Month) {
-                        pubDate = pubDateObj.Year[0] + (pubDateObj.Month ? ' ' + pubDateObj.Month[0] : '');
-                    }
-                    newArticle.journal = journal.Title[0];
-                    newArticle.date = (pubDate ? pubDate + ';' : '') + journalIssue.Volume[0] + '(' + journalIssue.Issue[0] + '):' + article.Pagination[0].MedlinePgn[0];
-                    var author = article.AuthorList[0].Author[0];
-                    newArticle.firstAuthor = author.LastName[0] + ' ' + author.Initials[0];
-                    newArticle.abstract = article.Abstract[0].AbstractText[0];
+                    var newArticle = parsePubmed(xml, enteredPmid);
                     return this.postRestData('/articles/', newArticle).then(data => {
                         return Promise.resolve(data['@graph'][0]);
                     });

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -144,7 +144,7 @@ var GeneCurationData = React.createClass({
                     {gene ?
                         <dl>
                             <dt>{gene.symbol}</dt>
-                            <dd>HGNC ID: <a href={external_url_map['HGNC'] + gene.hgncId} target="_blank" title={'HGNC page for ' + gene.hgncId + ' in a new window'}>{gene.hgncId}</a></dd>
+                            <dd>HGNC Symbol: <a href={external_url_map['HGNC'] + gene.hgncId} target="_blank" title={'HGNC page for ' + gene.symbol + ' in a new window'}>{gene.symbol}</a></dd>
                             <dd>NCBI Gene ID: <a href={external_url_map['Entrez'] + gene.entrezId} target="_blank" title={'NCBI page for gene ' + gene.entrezId + ' in a new window'}>{gene.entrezId}</a></dd>
                         </dl>
                     : null}

--- a/src/clincoded/static/components/rest.js
+++ b/src/clincoded/static/components/rest.js
@@ -1,15 +1,16 @@
 'use strict';
 var React = require('react');
 var parseXml = require('xml2js').parseString;
+var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
 
 
 // Promise-generating version of xml2js entry point
 function parseXmlAsync(xml){
     return new Promise(function(resolve, reject){
-         parseXml(xml, function(err, data){
-             if (err !== null) { return reject(err); }
-             resolve(data);
-         });
+        parseXml(xml, function(err, data){
+            if (err !== null) { return reject(err); }
+            resolve(data);
+        });
     });
 }
 
@@ -47,6 +48,8 @@ var RestMixin = module.exports.RestMixin = {
             // Unsuccessful retrieval
             throw error;
         }).then(xml => {
+            var pkg = parsePubmed(xml, 0);
+            console.log(pkg);
             // Successful retrieval of XML
             return parseXmlAsync(xml);
         });

--- a/src/clincoded/static/components/rest.js
+++ b/src/clincoded/static/components/rest.js
@@ -1,18 +1,5 @@
 'use strict';
 var React = require('react');
-var parseXml = require('xml2js').parseString;
-var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
-
-
-// Promise-generating version of xml2js entry point
-function parseXmlAsync(xml){
-    return new Promise(function(resolve, reject){
-        parseXml(xml, function(err, data){
-            if (err !== null) { return reject(err); }
-            resolve(data);
-        });
-    });
-}
 
 
 // Mixin to use REST APIs conveniently. In this project, this is mostly used to read or write data
@@ -47,11 +34,6 @@ var RestMixin = module.exports.RestMixin = {
         }, error => {
             // Unsuccessful retrieval
             throw error;
-        }).then(xml => {
-            var pkg = parsePubmed(xml, 0);
-            console.log(pkg);
-            // Successful retrieval of XML
-            return parseXmlAsync(xml);
         });
     },
 

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -117,6 +117,7 @@ var Input = module.exports.Input = React.createClass({
             React.PropTypes.string,
             React.PropTypes.object
         ]), // <label> for input; string or another React component
+        placeholder: React.PropTypes.string, // <input> placeholder text
         error: React.PropTypes.string, // Error message to display below input
         labelClassName: React.PropTypes.string, // CSS classes to add to labels
         groupClassName: React.PropTypes.string, // CSS classes to add to control groups (label/input wrapper div)
@@ -163,7 +164,7 @@ var Input = module.exports.Input = React.createClass({
                 inputClasses = 'form-control' + (this.props.error ? ' error' : '') + (this.props.inputClassName ? ' ' + this.props.inputClassName : '');
                 var innerInput = (
                     <span>
-                        <input className={inputClasses} type={this.props.type} id={this.props.id} name={this.props.id} ref="input" value={this.props.value} onChange={this.props.clearError} />
+                        <input className={inputClasses} type={this.props.type} id={this.props.id} name={this.props.id} placeholder={this.props.placeholder} ref="input" value={this.props.value} onChange={this.props.clearError} />
                         <div className="form-error">{this.props.error ? <span>{this.props.error}</span> : <span>&nbsp;</span>}</div>
                     </span>
                 );

--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -1,0 +1,547 @@
+'use strict';
+
+var _ = require('underscore');
+
+module.exports.parsePubmed = parsePubmed;
+
+/**
+ * see http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
+ */
+function parsePubmed(xml, pmid){
+    var pkg;
+    var doc = new DOMParser().parseFromString(xml, 'text/xml');
+
+    var $PubmedArticle = doc.getElementsByTagName('PubmedArticle')[0];
+    if($PubmedArticle){
+
+        var $Journal = $PubmedArticle.getElementsByTagName('Journal')[0];
+        var jsDate, periodical;
+        if($Journal){
+            jsDate = pubmedDatePublished($Journal);
+            periodical = pubmedPeriodical($Journal);
+        }
+        var authors = pubmedAuthors($PubmedArticle);
+
+        var pkgId = [];
+
+        if(periodical && periodical.alternateName){
+            pkgId.push(periodical.alternateName.toLowerCase());
+        }
+
+        if(authors.author && authors.author.familyName){
+            pkgId.push(authors.author.familyName.toLowerCase());
+        }
+
+        if(jsDate){
+            pkgId.push(jsDate.getFullYear());
+        }
+
+        if(pkgId.length>=2){
+            pkgId = pkgId.join('-');
+        } else {
+            pkgId = pmid.toString();
+        }
+
+        pkg = {
+            '@context': '',
+            '@id': pkgId,
+            '@type': 'MedicalScholarlyArticle'
+        };
+        pkg.version = '0.0.0';
+
+        var sameAs = ['http://www.ncbi.nlm.nih.gov/pubmed/' + pmid];
+        var doi = pubmedDoi($PubmedArticle);
+        if (doi) { sameAs.push('http://doi.org/' + doi); }
+
+
+        var keywords = pubmedKeywords($PubmedArticle);
+        if(keywords){
+            pkg.keywords = keywords;
+        }
+
+        if(jsDate){ pkg.datePublished = jsDate.toISOString(); }
+
+        var $ArticleTitle = $PubmedArticle.getElementsByTagName('ArticleTitle')[0];
+        if($ArticleTitle){
+            pkg.headline = $ArticleTitle.textContent; //remove [] Cf http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html#articletitle
+        }
+
+        if(authors.author){ pkg.author = authors.author; }
+        if(authors.contributor){ pkg.contributor = authors.contributor; }
+
+        var $CopyrightInformation = $PubmedArticle.getElementsByTagName('CopyrightInformation')[0];
+        if($CopyrightInformation){
+            pkg.copyrightHolder = { description: $CopyrightInformation.textContent };
+        }
+
+        pkg.provider = {
+            '@type': 'Organization',
+            '@id': 'http://www.ncbi.nlm.nih.gov/pubmed/',
+            description: 'From MEDLINE®/PubMed®, a database of the U.S. National Library of Medicine.'
+        };
+
+        var sourceOrganization = pubmedSourceOrganization($PubmedArticle);
+        if(sourceOrganization){
+            pkg.sourceOrganization = sourceOrganization;
+        }
+
+        var abstracts = pubmedAbstract($PubmedArticle);
+        if(abstracts){
+            pkg.abstract = abstracts;
+        }
+
+        //issue, volume, periodical, all nested...
+        if($Journal){
+            var isPartOf;
+
+            var publicationIssue = pubmedPublicationIssue($Journal);
+            if(publicationIssue){
+                isPartOf = publicationIssue;
+            }
+
+            var publicationVolume = pubmedPublicationVolume($Journal);
+            if(publicationVolume){
+                if(publicationIssue){
+                    publicationIssue.isPartOf = publicationVolume;
+                } else {
+                    isPartOf = publicationVolume;
+                }
+            }
+
+            if(periodical){
+                if(publicationVolume){
+                    publicationVolume.isPartOf = periodical;
+                } else if (publicationIssue){
+                    publicationIssue.isPartOf = periodical;
+                } else {
+                    isPartOf = periodical;
+                }
+            }
+
+            if(isPartOf){ pkg.isPartOf = isPartOf; }
+
+            //pages (bibo:pages (bibo:pages <-> schema:pagination) or bibo:pageStart and bibo:pageEnd e.g <Pagination> <MedlinePgn>12-9</MedlinePgn>)
+            var $Pagination = $PubmedArticle.getElementsByTagName('Pagination')[0];
+            if($Pagination){
+                var $MedlinePgn = $Pagination.getElementsByTagName('MedlinePgn')[0];
+                if($MedlinePgn){
+                    var medlinePgn = $MedlinePgn.textContent || '';
+                    var rePage = /^(\d+)-(\d+)$/;
+                    var matchPage = medlinePgn.match(rePage);
+                    if(matchPage){ //fix ranges like 1199-201 or 12-9
+                        var pageStart = matchPage[1];
+                        var pageEnd = matchPage[2];
+                        if(pageEnd.length < pageStart.length){
+                            pageEnd = pageStart.substring(0, pageStart.length - pageEnd.length) + pageEnd;
+                        }
+                        pkg.pageStart = parseInt(pageStart, 10);
+                        pkg.pageEnd = parseInt(pageEnd, 10);
+                    } else {
+                        pkg.pagination = medlinePgn;
+                    }
+                }
+            }
+        }
+
+        var citations = pubmedCitations($PubmedArticle);
+        if (citations) {
+            pkg.citation = citations;
+        }
+
+        var dataset = pubmedDataset($PubmedArticle);
+        if (dataset) {
+            pkg.hasPart = dataset;
+        }
+
+    }
+
+    return pkg;
+}
+
+function pubmedAuthors($PubmedArticle){
+    var authors = {};
+
+    var $AuthorList = $PubmedArticle.getElementsByTagName('AuthorList')[0];
+    if($AuthorList){
+        var $Authors = $AuthorList.getElementsByTagName('Author');
+        if($Authors){
+            Array.prototype.forEach.call($Authors, function($Author, i){
+                var person = { '@type': 'Person' };
+
+                var $LastName = $Author.getElementsByTagName('LastName')[0];
+                if($LastName){
+                    person.familyName = $LastName.textContent;
+                }
+
+                var $ForeName = $Author.getElementsByTagName('ForeName')[0];
+                if($ForeName){
+                    person.givenName = $ForeName.textContent;
+                }
+
+                if(person.familyName && person.givenName ){
+                    person.name = person.givenName + ' ' + person.familyName;
+                }
+
+                var $Affiliation = $Author.getElementsByTagName('Affiliation')[0];
+                if($Affiliation){
+                    person.affiliation = {
+                        '@type': 'Organization',
+                        description: $Affiliation.textContent
+                    };
+                }
+
+                if(Object.keys(person).length > 1){
+                    if(i === 0){
+                        authors.author = person;
+                    } else {
+                        if(!authors.contributor){
+                            authors.contributor = [];
+                        }
+                        authors.contributor.push(person);
+                    }
+                }
+
+            });
+        }
+    }
+    return authors;
+}
+
+function pubmedDoi($PubmedArticle){
+    var $ELocationID = $PubmedArticle.getElementsByTagName('ELocationID');
+    if($ELocationID){
+        for(var i=0; i<$ELocationID.length; i++){
+            if($ELocationID[i].getAttribute('EIdType') === 'doi'){
+                var doiValid = $ELocationID[i].getAttribute('ValidYN');
+                if(!doiValid || doiValid === 'Y'){
+                    return $ELocationID[i].textContent;
+                }
+            }
+        }
+    }
+}
+
+
+function pubmedDatePublished($Journal){
+    var $PubDate = $Journal.getElementsByTagName('PubDate')[0];
+    if($PubDate){
+        var $day = $PubDate.getElementsByTagName('Day')[0];
+        var $month = $PubDate.getElementsByTagName('Month')[0];
+        var $year = $PubDate.getElementsByTagName('Year')[0];
+        var month, jsDate;
+
+        if($month){
+            var abrMonth2int = {
+                'jan': 0,
+                'feb': 1,
+                'mar': 2,
+                'apr': 3,
+                'may': 4,
+                'jun': 5,
+                'july': 6,
+                'aug': 7,
+                'sep': 8,
+                'oct': 9,
+                'nov': 10,
+                'dec': 11
+            };
+
+            month = abrMonth2int[$month.textContent.trim().toLowerCase()];
+        }
+
+        if($year && month && $day){
+            jsDate = Date.UTC($year.textContent, month, $day.textContent, 0, 0, 0, 0);
+        } else if($year && month){
+            jsDate = Date.UTC($year.textContent, month, 1, 0, 0, 0, 0);
+        } else if($year){
+            jsDate = Date.UTC($year.textContent, 0, 1, 0, 0, 0, 0);
+        }
+
+        if(jsDate){
+            jsDate = new Date(jsDate - 1000*5*60*60); //UTC to Eastern Time Zone (UTC-05:00)
+        } else {
+            var $MedlineDate = $PubDate.getElementsByTagName('MedlineDate')[0];
+            if($MedlineDate){
+                try {
+                    jsDate = new Date($MedlineDate.textContent);
+                } catch(e){}
+            }
+        }
+        if(jsDate){
+            return jsDate;
+        }
+    }
+}
+
+function pubmedPublicationIssue($Journal){
+
+    var $issue = $Journal.getElementsByTagName('Issue')[0];
+    if($issue){
+        return {
+            '@type': 'PublicationIssue',
+            issueNumber: parseInt($issue.textContent, 10)
+        };
+    }
+
+}
+
+function pubmedPublicationVolume($Journal){
+
+    var $volume = $Journal.getElementsByTagName('Volume')[0];
+    if($volume){
+        return {
+            '@type': 'PublicationVolume',
+            volumeNumber: parseInt($volume.textContent, 10)
+        };
+    }
+
+}
+
+function pubmedPeriodical($Journal){
+
+    var periodical = { '@type': 'Periodical' };
+
+    var $Title = $Journal.getElementsByTagName('Title')[0];
+    if($Title){
+        periodical.name = $Title.textContent;
+    }
+
+    var $ISOAbbreviation = $Journal.getElementsByTagName('ISOAbbreviation')[0];
+    if($ISOAbbreviation){
+        periodical.alternateName = $ISOAbbreviation.textContent;
+    }
+
+    var $ISSN = $Journal.getElementsByTagName('ISSN')[0];
+    if($ISSN){
+        periodical.issn = $ISSN.textContent;
+    }
+
+    if(Object.keys(periodical).length > 1){
+        return periodical;
+    }
+
+}
+
+
+/**
+ * CF http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html structured abstract.
+ * Abstract can be structured
+ *e.g http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=19897313&rettype=abstract&retmode=xml
+ */
+
+function pubmedAbstract($PubmedArticle){
+
+    var $Abstracts = $PubmedArticle.getElementsByTagName('Abstract');
+    if($Abstracts && $Abstracts.length){
+
+        return Array.prototype.map.call($Abstracts, function($Abstract){
+
+            var myAbstract = { '@type': 'Abstract' };
+
+            var $AbstractTexts = $Abstract.getElementsByTagName('AbstractText');
+            if($AbstractTexts && $AbstractTexts.length){
+
+                var parts = Array.prototype.map.call($AbstractTexts, function($AbstractText){
+                    var part = { '@type': 'Abstract' };
+                    var nlmCategory = $AbstractText.getAttribute('NlmCategory') || $AbstractText.getAttribute('Label');
+                    if(nlmCategory){
+                        part.headline = nlmCategory.trim().toLowerCase();
+                    }
+                    part.abstractBody = $AbstractText.textContent;
+                    return part;
+                });
+
+                if(parts.length === 1){
+                    if(parts[0].headline){
+                        myAbstract.headline = parts[0].headline;
+                    }
+                    myAbstract.abstractBody = parts[0].abstractBody;
+                } else {
+                    myAbstract.hasPart = parts;
+                }
+
+            }
+
+            return myAbstract;
+
+        });
+
+    }
+
+}
+
+
+/**
+ * keywords e.g http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=24920540&rettype=abstract&retmode=xml
+ * TODO: take advandage of Owner attribute Cf http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html#Keyword
+ */
+function pubmedKeywords($PubmedArticle){
+
+    var keywords = [];
+    var $KeywordLists = $PubmedArticle.getElementsByTagName('KeywordList');
+    if($KeywordLists){
+        Array.prototype.forEach.call($KeywordLists, function($KeywordList){
+            var $Keywords = $KeywordList.getElementsByTagName('Keyword');
+            if($Keywords){
+                Array.prototype.forEach.call($Keywords, function($Keyword){
+                    keywords.push($Keyword.textContent).toLowerCase();
+                });
+            }
+        });
+    }
+
+    if(keywords.length){
+        return _.uniq(keywords);
+    }
+
+}
+
+
+
+/**
+ * <Grant> as sourceOrganization (grantId is added TODO fix...)
+ */
+function pubmedSourceOrganization($PubmedArticle){
+
+    var $GrantList = $PubmedArticle.getElementsByTagName('GrantList')[0];
+    var soMap = {}; //re-aggregate grant entries by organizations
+    if($GrantList){
+        var $Grants = $GrantList.getElementsByTagName('Grant');
+        if($Grants){
+            Array.prototype.forEach.call($Grants, function($Grant, gid){
+                var $Agency = $Grant.getElementsByTagName('Agency')[0];
+                var $GrantID = $Grant.getElementsByTagName('GrantID')[0];
+                var $Acronym = $Grant.getElementsByTagName('Acronym')[0];
+                var $Country = $Grant.getElementsByTagName('Country')[0];
+
+                var name;
+                if($Agency){
+                    name = $Agency.textContent;
+                }
+
+                var key = name || gid.toString();
+
+                if($Agency || $GrantID){
+                    var organization = soMap[key] || { '@type': 'Organization' };
+                    if(name){
+                        organization.name = name;
+                    }
+                    if($Acronym){
+                        organization.alternateName = $Acronym.textContent;
+                    }
+                    if($GrantID){ //accumulate grantId(s)...
+                        var grantId = $GrantID.textContent;
+                        if(organization.grantId){
+                            organization.grantId.push(grantId);
+                        } else {
+                            organization.grantId = [grantId];
+                        }
+                    }
+                    if($Country){
+                        organization.address = {
+                            '@type': 'PostalAddress',
+                            'addressCountry': $Country.textContent
+                        };
+                    }
+                    soMap[key] = organization;
+                }
+            });
+        }
+    }
+
+    var sourceOrganizations = [];
+    Object.keys(soMap).forEach(function(key){
+        sourceOrganizations.push(soMap[key]);
+    });
+
+    if(sourceOrganizations.length){
+        return sourceOrganizations;
+    }
+
+
+}
+
+
+function pubmedCitations($PubmedArticle){
+
+    var citations = [];
+    var $CommentsCorrectionsList = $PubmedArticle.getElementsByTagName('CommentsCorrectionsList')[0];
+    if($CommentsCorrectionsList){
+        var $CommentsCorrections = $CommentsCorrectionsList.getElementsByTagName('CommentsCorrections');
+        if($CommentsCorrections){
+            Array.prototype.forEach.call($CommentsCorrections, function($CommentsCorrections){
+                var ref = {};
+
+                //var refType = $CommentsCorrections.getAttribute('RefType'); TODO can we use that to infer @type ??
+
+                ref['@type'] = 'ScholarlyArticle';
+
+                var $RefSource = $CommentsCorrections.getElementsByTagName('RefSource')[0];
+                if($RefSource){
+                    ref.description = $RefSource.textContent;
+                }
+
+                var $PMID = $CommentsCorrections.getElementsByTagName('PMID')[0];
+                if($PMID){
+                    ref.sameAs = 'http://www.ncbi.nlm.nih.gov/pubmed/' + $PMID.textContent;
+                }
+
+                if(Object.keys(ref).length){
+                    citations.push(ref);
+                }
+            });
+        }
+    }
+    if(citations.length){
+        return citations;
+    }
+
+}
+
+
+
+/**
+ * dataset: <DataBankList> e.g pmid: 19237716
+ * TODO add URI from: http://www.nlm.nih.gov/bsd/medline_databank_source.html
+ */
+function pubmedDataset($PubmedArticle){
+
+    var datasets = [];
+    var $DataBankLists = $PubmedArticle.getElementsByTagName('DataBankList');
+    if($DataBankLists){
+        Array.prototype.forEach.call($DataBankLists, function($DataBankList){
+            var $DataBanks = $DataBankList.getElementsByTagName('DataBank');
+            if($DataBanks){
+                Array.prototype.forEach.call($DataBanks, function($DataBank){
+                    var catalogName;
+                    var $DataBankName = $DataBank.getElementsByTagName('DataBankName')[0];
+                    if($DataBankName){
+                        catalogName = $DataBankName.textContent;
+                    }
+
+                    if(catalogName){
+                        var $accessionNumberLists = $DataBank.getElementsByTagName('AccessionNumberList');
+                        if($accessionNumberLists){
+                            Array.prototype.forEach.call($accessionNumberLists, function($accessionNumberList){
+                                var $accessionNumbers = $accessionNumberList.getElementsByTagName('AccessionNumber');
+                                if($accessionNumbers){
+                                    Array.prototype.forEach.call($accessionNumbers, function($accessionNumber){
+                                        datasets.push({
+                                            name: $accessionNumber.textContent,
+                                            catalog: { name: catalogName }
+                                        });
+                                    });
+                                }
+                            });
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    if(datasets.length){
+        return datasets;
+    }
+
+}

--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -3,199 +3,94 @@
 // https://github.com/standard-analytics/pubmed-schema-org/blob/master/lib/pubmed.js
 
 var _ = require('underscore');
+var moment = require('moment');
 
 module.exports.parsePubmed = parsePubmed;
 
 /**
  * see http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html
  */
-function parsePubmed(xml, pmid){
-    var pkg;
+function parsePubmed(xml){
+    var article = {};
     var doc = new DOMParser().parseFromString(xml, 'text/xml');
 
     var $PubmedArticle = doc.getElementsByTagName('PubmedArticle')[0];
     if($PubmedArticle){
+        var publicationData = '';
 
+        // Get the PMID
+        var $PMID = $PubmedArticle.getElementsByTagName('PMID')[0];
+        if($PMID) {
+            article.pmid = $PMID.textContent;
+        }
+
+        // Get the journal name
         var $Journal = $PubmedArticle.getElementsByTagName('Journal')[0];
-        var jsDate, periodical;
         if($Journal){
-            jsDate = pubmedDatePublished($Journal);
-            periodical = pubmedPeriodical($Journal);
-        }
-        var authors = pubmedAuthors($PubmedArticle);
-
-        var pkgId = [];
-
-        if(periodical && periodical.alternateName){
-            pkgId.push(periodical.alternateName.toLowerCase());
+            article.date = pubmedDatePublished($Journal).toISOString();
+            article.date = moment(article.date).format('YYYY-MMM');
+            article.journal = pubmedPeriodical($Journal);
         }
 
-        if(authors.author && authors.author.familyName){
-            pkgId.push(authors.author.familyName.toLowerCase());
-        }
-
-        if(jsDate){
-            pkgId.push(jsDate.getFullYear());
-        }
-
-        if(pkgId.length>=2){
-            pkgId = pkgId.join('-');
-        } else {
-            pkgId = pmid.toString();
-        }
-
-        pkg = {
-            '@context': '',
-            '@id': pkgId,
-            '@type': 'MedicalScholarlyArticle'
-        };
-        pkg.version = '0.0.0';
-
-        var sameAs = ['http://www.ncbi.nlm.nih.gov/pubmed/' + pmid];
-        var doi = pubmedDoi($PubmedArticle);
-        if (doi) { sameAs.push('http://doi.org/' + doi); }
-
-
-        var keywords = pubmedKeywords($PubmedArticle);
-        if(keywords){
-            pkg.keywords = keywords;
-        }
-
-        if(jsDate){ pkg.datePublished = jsDate.toISOString(); }
+        article.firstAuthor = pubmedAuthors($PubmedArticle);
 
         var $ArticleTitle = $PubmedArticle.getElementsByTagName('ArticleTitle')[0];
         if($ArticleTitle){
-            pkg.headline = $ArticleTitle.textContent; //remove [] Cf http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html#articletitle
-        }
-
-        if(authors.author){ pkg.author = authors.author; }
-        if(authors.contributor){ pkg.contributor = authors.contributor; }
-
-        var $CopyrightInformation = $PubmedArticle.getElementsByTagName('CopyrightInformation')[0];
-        if($CopyrightInformation){
-            pkg.copyrightHolder = { description: $CopyrightInformation.textContent };
-        }
-
-        pkg.provider = {
-            '@type': 'Organization',
-            '@id': 'http://www.ncbi.nlm.nih.gov/pubmed/',
-            description: 'From MEDLINE®/PubMed®, a database of the U.S. National Library of Medicine.'
-        };
-
-        var sourceOrganization = pubmedSourceOrganization($PubmedArticle);
-        if(sourceOrganization){
-            pkg.sourceOrganization = sourceOrganization;
+            article.title = $ArticleTitle.textContent; //remove [] Cf http://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html#articletitle
         }
 
         var abstracts = pubmedAbstract($PubmedArticle);
         if(abstracts){
-            pkg.abstract = abstracts;
+            article.abstract = abstracts;
         }
 
         //issue, volume, periodical, all nested...
         if($Journal){
-            var isPartOf;
 
             var publicationIssue = pubmedPublicationIssue($Journal);
-            if(publicationIssue){
-                isPartOf = publicationIssue;
-            }
-
             var publicationVolume = pubmedPublicationVolume($Journal);
-            if(publicationVolume){
-                if(publicationIssue){
-                    publicationIssue.isPartOf = publicationVolume;
-                } else {
-                    isPartOf = publicationVolume;
-                }
-            }
-
-            if(periodical){
-                if(publicationVolume){
-                    publicationVolume.isPartOf = periodical;
-                } else if (publicationIssue){
-                    publicationIssue.isPartOf = periodical;
-                } else {
-                    isPartOf = periodical;
-                }
-            }
-
-            if(isPartOf){ pkg.isPartOf = isPartOf; }
+            var publicationPgn = '';
 
             //pages (bibo:pages (bibo:pages <-> schema:pagination) or bibo:pageStart and bibo:pageEnd e.g <Pagination> <MedlinePgn>12-9</MedlinePgn>)
             var $Pagination = $PubmedArticle.getElementsByTagName('Pagination')[0];
             if($Pagination){
                 var $MedlinePgn = $Pagination.getElementsByTagName('MedlinePgn')[0];
                 if($MedlinePgn){
-                    var medlinePgn = $MedlinePgn.textContent || '';
-                    var rePage = /^(\d+)-(\d+)$/;
-                    var matchPage = medlinePgn.match(rePage);
-                    if(matchPage){ //fix ranges like 1199-201 or 12-9
-                        var pageStart = matchPage[1];
-                        var pageEnd = matchPage[2];
-                        if(pageEnd.length < pageStart.length){
-                            pageEnd = pageStart.substring(0, pageStart.length - pageEnd.length) + pageEnd;
-                        }
-                        pkg.pageStart = parseInt(pageStart, 10);
-                        pkg.pageEnd = parseInt(pageEnd, 10);
-                    } else {
-                        pkg.pagination = medlinePgn;
-                    }
+                    publicationPgn = $MedlinePgn.textContent;
                 }
             }
+            publicationData = publicationVolume + (publicationIssue ? '(' + publicationIssue + ')' : '')  + ':' + publicationPgn;
+        }
+        if (publicationData) {
+            article.date += ';' + publicationData;
         }
     }
 
-    return pkg;
+    return article;
 }
 
 function pubmedAuthors($PubmedArticle){
     var authors = {};
+    var firstAuthor = '';
 
     var $AuthorList = $PubmedArticle.getElementsByTagName('AuthorList')[0];
     if($AuthorList){
         var $Authors = $AuthorList.getElementsByTagName('Author');
-        if($Authors){
-            Array.prototype.forEach.call($Authors, function($Author, i){
-                var person = { '@type': 'Person' };
+        var $FirstAuthor = $Authors[0];
 
-                var $LastName = $Author.getElementsByTagName('LastName')[0];
-                if($LastName){
-                    person.familyName = $LastName.textContent;
-                }
-
-                var $ForeName = $Author.getElementsByTagName('ForeName')[0];
-                if($ForeName){
-                    person.givenName = $ForeName.textContent;
-                }
-
-                if(person.familyName && person.givenName ){
-                    person.name = person.givenName + ' ' + person.familyName;
-                }
-
-                var $Affiliation = $Author.getElementsByTagName('Affiliation')[0];
-                if($Affiliation){
-                    person.affiliation = {
-                        '@type': 'Organization',
-                        description: $Affiliation.textContent
-                    };
-                }
-
-                if(Object.keys(person).length > 1){
-                    if(i === 0){
-                        authors.author = person;
-                    } else {
-                        if(!authors.contributor){
-                            authors.contributor = [];
-                        }
-                        authors.contributor.push(person);
-                    }
-                }
-
-            });
+        var $LastName = $FirstAuthor.getElementsByTagName('LastName')[0];
+        if($LastName){
+            firstAuthor = $LastName.textContent;
         }
+
+        var $Initials = $FirstAuthor.getElementsByTagName('Initials')[0];
+        if($Initials){
+            firstAuthor += (firstAuthor ? ' ' : '') + $Initials.textContent;
+        }
+    } else {
+        firstAuthor = 'Anonymous';
     }
-    return authors;
+    return firstAuthor;
 }
 
 function pubmedDoi($PubmedArticle){
@@ -268,48 +163,27 @@ function pubmedPublicationIssue($Journal){
 
     var $issue = $Journal.getElementsByTagName('Issue')[0];
     if($issue){
-        return {
-            '@type': 'PublicationIssue',
-            issueNumber: parseInt($issue.textContent, 10)
-        };
+        return $issue.textContent;
     }
-
+    return '';
 }
 
 function pubmedPublicationVolume($Journal){
 
     var $volume = $Journal.getElementsByTagName('Volume')[0];
     if($volume){
-        return {
-            '@type': 'PublicationVolume',
-            volumeNumber: parseInt($volume.textContent, 10)
-        };
+        return $volume.textContent;
     }
-
+    return '';
 }
 
 function pubmedPeriodical($Journal){
 
-    var periodical = { '@type': 'Periodical' };
-
     var $Title = $Journal.getElementsByTagName('Title')[0];
     if($Title){
-        periodical.name = $Title.textContent;
+        return $Title.textContent;
     }
-
-    var $ISOAbbreviation = $Journal.getElementsByTagName('ISOAbbreviation')[0];
-    if($ISOAbbreviation){
-        periodical.alternateName = $ISOAbbreviation.textContent;
-    }
-
-    var $ISSN = $Journal.getElementsByTagName('ISSN')[0];
-    if($ISSN){
-        periodical.issn = $ISSN.textContent;
-    }
-
-    if(Object.keys(periodical).length > 1){
-        return periodical;
-    }
+    return '';
 
 }
 
@@ -321,43 +195,20 @@ function pubmedPeriodical($Journal){
  */
 
 function pubmedAbstract($PubmedArticle){
+    var abstractText = '';
 
     var $Abstracts = $PubmedArticle.getElementsByTagName('Abstract');
     if($Abstracts && $Abstracts.length){
 
-        return Array.prototype.map.call($Abstracts, function($Abstract){
+        var $AbstractTexts = $Abstracts[0].getElementsByTagName('AbstractText');
+        if($AbstractTexts && $AbstractTexts.length){
 
-            var myAbstract = { '@type': 'Abstract' };
+            abstractText = $AbstractTexts[0].textContent;
 
-            var $AbstractTexts = $Abstract.getElementsByTagName('AbstractText');
-            if($AbstractTexts && $AbstractTexts.length){
-
-                var parts = Array.prototype.map.call($AbstractTexts, function($AbstractText){
-                    var part = { '@type': 'Abstract' };
-                    var nlmCategory = $AbstractText.getAttribute('NlmCategory') || $AbstractText.getAttribute('Label');
-                    if(nlmCategory){
-                        part.headline = nlmCategory.trim().toLowerCase();
-                    }
-                    part.abstractBody = $AbstractText.textContent;
-                    return part;
-                });
-
-                if(parts.length === 1){
-                    if(parts[0].headline){
-                        myAbstract.headline = parts[0].headline;
-                    }
-                    myAbstract.abstractBody = parts[0].abstractBody;
-                } else {
-                    myAbstract.hasPart = parts;
-                }
-
-            }
-
-            return myAbstract;
-
-        });
+        }
 
     }
+    return abstractText;
 
 }
 

--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -1,4 +1,6 @@
 'use strict';
+// Derived from:
+// https://github.com/standard-analytics/pubmed-schema-org/blob/master/lib/pubmed.js
 
 var _ = require('underscore');
 
@@ -142,17 +144,6 @@ function parsePubmed(xml, pmid){
                 }
             }
         }
-
-        var citations = pubmedCitations($PubmedArticle);
-        if (citations) {
-            pkg.citation = citations;
-        }
-
-        var dataset = pubmedDataset($PubmedArticle);
-        if (dataset) {
-            pkg.hasPart = dataset;
-        }
-
     }
 
     return pkg;
@@ -458,90 +449,5 @@ function pubmedSourceOrganization($PubmedArticle){
         return sourceOrganizations;
     }
 
-
-}
-
-
-function pubmedCitations($PubmedArticle){
-
-    var citations = [];
-    var $CommentsCorrectionsList = $PubmedArticle.getElementsByTagName('CommentsCorrectionsList')[0];
-    if($CommentsCorrectionsList){
-        var $CommentsCorrections = $CommentsCorrectionsList.getElementsByTagName('CommentsCorrections');
-        if($CommentsCorrections){
-            Array.prototype.forEach.call($CommentsCorrections, function($CommentsCorrections){
-                var ref = {};
-
-                //var refType = $CommentsCorrections.getAttribute('RefType'); TODO can we use that to infer @type ??
-
-                ref['@type'] = 'ScholarlyArticle';
-
-                var $RefSource = $CommentsCorrections.getElementsByTagName('RefSource')[0];
-                if($RefSource){
-                    ref.description = $RefSource.textContent;
-                }
-
-                var $PMID = $CommentsCorrections.getElementsByTagName('PMID')[0];
-                if($PMID){
-                    ref.sameAs = 'http://www.ncbi.nlm.nih.gov/pubmed/' + $PMID.textContent;
-                }
-
-                if(Object.keys(ref).length){
-                    citations.push(ref);
-                }
-            });
-        }
-    }
-    if(citations.length){
-        return citations;
-    }
-
-}
-
-
-
-/**
- * dataset: <DataBankList> e.g pmid: 19237716
- * TODO add URI from: http://www.nlm.nih.gov/bsd/medline_databank_source.html
- */
-function pubmedDataset($PubmedArticle){
-
-    var datasets = [];
-    var $DataBankLists = $PubmedArticle.getElementsByTagName('DataBankList');
-    if($DataBankLists){
-        Array.prototype.forEach.call($DataBankLists, function($DataBankList){
-            var $DataBanks = $DataBankList.getElementsByTagName('DataBank');
-            if($DataBanks){
-                Array.prototype.forEach.call($DataBanks, function($DataBank){
-                    var catalogName;
-                    var $DataBankName = $DataBank.getElementsByTagName('DataBankName')[0];
-                    if($DataBankName){
-                        catalogName = $DataBankName.textContent;
-                    }
-
-                    if(catalogName){
-                        var $accessionNumberLists = $DataBank.getElementsByTagName('AccessionNumberList');
-                        if($accessionNumberLists){
-                            Array.prototype.forEach.call($accessionNumberLists, function($accessionNumberList){
-                                var $accessionNumbers = $accessionNumberList.getElementsByTagName('AccessionNumber');
-                                if($accessionNumbers){
-                                    Array.prototype.forEach.call($accessionNumbers, function($accessionNumber){
-                                        datasets.push({
-                                            name: $accessionNumber.textContent,
-                                            catalog: { name: catalogName }
-                                        });
-                                    });
-                                }
-                            });
-                        }
-                    }
-                });
-            }
-        });
-    }
-
-    if(datasets.length){
-        return datasets;
-    }
 
 }


### PR DESCRIPTION
Removed PubMed XML-parsing code and instead using one adapted from [an external GitHub project](https://github.com/standard-analytics/pubmed-schema-org/blob/master/lib/pubmed.js). This hopefully will make us more reliably parse PubMed XML when adding articles to the GDM.

Updated the Curation Central Gene header links to be clearer to Curators.

Loading html5shiv library from GitHub instead of npm because it was removed from the npm directory.