### PR TITLE
Connects to #111. Allow for pmid specification via url in curation central

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -37,6 +37,9 @@ var CurationCentral = React.createClass({
     // Called when currently selected PMID changes
     currPmidChange: function(pmid) {
         this.setState({currPmid: pmid, selectionListOpen: false});
+        if (pmid !== undefined) {
+            window.history.pushState(null, '', '/curation-central/?gdm=' + this.state.currGdm.uuid + '&pmid=' + pmid);
+        }
     },
 
     // Retrieve the GDM object from the DB with the given uuid


### PR DESCRIPTION
If 'gdm' and 'pmid' are defined in the curation-central url (/curation-central/?gdm={gdm_id}&pmid={pmid}) the specified pmid will be automatically selected on page load.

Example: http://localhost:6543/curation-central/?gdm=9ffd7c1e-16d9-11e5-b283-60f81dc5b05a&pmid=7913883
![image](https://cloud.githubusercontent.com/assets/4326866/8815536/4f305a22-2fcf-11e5-8030-2d24a7639e66.png)