### PR TITLE
Connects to #134. Convert dateTime fields in test data to ISO format

### DIFF
--- a/src/clincoded/tests/data/inserts/annotation.json
+++ b/src/clincoded/tests/data/inserts/annotation.json
@@ -2,7 +2,7 @@
     {
         "owner": "tsneddon@stanford.edu",
         "article": "7913883",
-        "dateTime": "Tue Feb 24 2015 12:52:27 GMT-0800 (PST)",
+        "dateTime": "2015-02-24T12:52:27-08:00",
         "groups":[
             "eab0dd0a-1d05-11e5-8d2d-60f81dc5b05a",
             "edea98e3-25cc-11e5-9019-60f81dc5b05a"
@@ -23,7 +23,7 @@
     {
         "owner": "tsneddon@stanford.edu",
         "article": "8078586",
-        "dateTime": "Tue Feb 24 2015 12:54:07 GMT-0800 (PST)",
+        "dateTime": "2015-02-24T12:54:07-08:00",
         "families": [
             "a20e9182-18fa-11e5-96d1-60f81dc5b05a",
             "ab9a37ba-18fa-11e5-bad8-60f81dc5b05a"
@@ -39,7 +39,7 @@
     {
         "owner": "tsneddon@stanford.edu",
         "article": "7847369",
-        "dateTime": "Tue Feb 24 2015 12:55:04 GMT-0800 (PST)",
+        "dateTime": "2015-02-24T12:55:04-08:00",
         "functionalData": [
             "d06dae6b-2cb8-11e5-8e3e-60f81dc5b05a"
         ],
@@ -49,7 +49,7 @@
     {
         "owner": "tsneddon@stanford.edu",
         "article": "9001669",
-        "dateTime": "Tue Feb 24 2015 12:56:10 GMT-0800 (PST)",
+        "dateTime": "2015-02-24T12:56:10-08:00",
         "active": true,
         "uuid": "75ed0680-189e-11e5-9cf0-60f81dc5b05a"
     }

--- a/src/clincoded/tests/data/inserts/assessment.json
+++ b/src/clincoded/tests/data/inserts/assessment.json
@@ -3,42 +3,42 @@
         "uuid": "3ecaaf6b-2a4c-11e5-ab2d-60f81dc5b05a",
         "owner": "kgliu@stanford.edu",
         "value": "Supports",
-        "dateTime": "date and time 01",
+        "dateTime": "2015-02-31T12:52:27-08:00",
         "active": true
     },
     {
         "uuid": "4519985e-2a4c-11e5-96a0-60f81dc5b05a",
         "owner": "tsneddon@stanford.edu",
         "value": "Review",
-        "dateTime": "date and time 02",
+        "dateTime": "2015-03-01T12:52:27-08:00",
         "active": true
     },
     {
         "uuid": "4aec0dae-2a4c-11e5-a66f-60f81dc5b05a",
         "owner": "selinad@stanford.edu",
         "value": "Review",
-        "dateTime": "date and time 03",
+        "dateTime": "2015-03-02T12:52:27-08:00",
         "active": true
     },
     {
         "uuid": "4f94a226-2a4c-11e5-887c-60f81dc5b05a",
         "owner": "fytanaka@stanford.edu",
         "value": "Supports",
-        "dateTime": "date and time 04",
+        "dateTime": "2015-03-03T12:52:27-08:00",
         "active": true
     },
     {
         "uuid": "550d702b-2a4c-11e5-856d-60f81dc5b05a",
         "owner": "kdalton@stanford.edu",
         "value": "Contradicts",
-        "dateTime": "date and time 05",
+        "dateTime": "2015-03-04T12:52:27-08:00",
         "active": true
     },
     {
         "uuid": "5a5cefba-2a4c-11e5-9f97-60f81dc5b05a",
         "owner": "minyoung.choi@stanford.edu",
         "value": "Review",
-        "dateTime": "date and time 06",
+        "dateTime": "2015-03-05T12:52:27-08:00",
         "active": true
     }
 ]

--- a/src/clincoded/tests/data/inserts/functional.json
+++ b/src/clincoded/tests/data/inserts/functional.json
@@ -2,7 +2,7 @@
     {
         "uuid": "79ba2b61-2a6e-11e5-93f9-60f81dc5b05a",
         "owner": "tsneddon@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 10:10:37 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T10:10:37-07:00",
         "active": true,
         "evidenceType": "Expression",
         "expression": {
@@ -20,7 +20,7 @@
     {
         "uuid": "72341d2e-2a6e-11e5-bdd7-60f81dc5b05a",
         "owner": "selinad@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 12:32:57 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T12:32:57-07:00",
         "active": true,
         "evidenceType": "Protein Interactions",
         "proteinIneractions": {
@@ -39,7 +39,7 @@
     {
         "uuid": "6be668d4-2a6e-11e5-804a-60f81dc5b05a",
         "owner": "selinad@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 16:43:12 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T16:43:12-07:00",
         "active": true,
         "evidenceType": "Biochemical function",
         "biochemicalFunction": {
@@ -78,7 +78,7 @@
     {
         "uuid": "1ca71459-2cb5-11e5-a26a-60f81dc5b05a",
         "owner": "selinad@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 16:43:12 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T16:43:12-07:00",
         "active": true,
         "evidenceType": "Rescue",
         "rescue": {
@@ -102,7 +102,7 @@
     {
         "uuid": "ca353d87-2cb8-11e5-85c1-60f81dc5b05a",
         "owner": "selinad@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 16:43:12 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T16:43:12-07:00",
         "active": true,
         "evidenceType": "Functional alteration of gene/gene product",
         "functionalAleration": {
@@ -124,7 +124,7 @@
     {
         "uuid": "d06dae6b-2cb8-11e5-8e3e-60f81dc5b05a",
         "owner": "fytanaka@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 16:43:12 GMT-0700 (PDT)",
+        "dateTime": "2015-04-13T16:43:12-07:00",
         "active": true,
         "evidenceType": "Model systems",
         "modelSystems": {

--- a/src/clincoded/tests/data/inserts/gdm.json
+++ b/src/clincoded/tests/data/inserts/gdm.json
@@ -52,7 +52,7 @@
         "disease": "777",
         "modeInheritance": "Autosomal dominant inheritance with paternal imprinting (HP:0012274)",
         "omimId": "300046",
-        "owner": "tsneddon@stanford",
+        "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-02-25T14:55:54-08:00",
         "status": "Evidence",
         "active": true
@@ -63,7 +63,7 @@
         "disease": "183660",
         "modeInheritance": "Codominant",
         "omimId": "",
-        "owner": "tsneddon@stanford",
+        "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-05-04T08:11:18-07:00",
         "status": "Evidence",
         "active": true
@@ -74,7 +74,7 @@
         "disease": "84",
         "modeInheritance": "Other",
         "omimId": "609054",
-        "owner": "tsneddon@stanford",
+        "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-03-19T15:25:49-07:00",
         "status": "Evidence",
         "active": true

--- a/src/clincoded/tests/data/inserts/gdm.json
+++ b/src/clincoded/tests/data/inserts/gdm.json
@@ -6,7 +6,7 @@
         "modeInheritance": "Autosomal dominant inheritance (HP:0000006)",
         "omimId": "609054",
         "owner": "tsneddon@stanford.edu",
-        "dateTime": "Fri Feb 27 2015 08:35:18 PST",
+        "dateTime": "2015-02-27T08:35:18-08:00",
         "status": "Creation",
         "active": true
     },
@@ -17,7 +17,7 @@
         "modeInheritance": "Autosomal dominant inheritance with maternal imprinting (HP:0012275)",
         "omimId": "601200",
         "owner": "selinad@stanford.edu",
-        "dateTime": "Thu Mar 19 2015 16:52:38 PDT",
+        "dateTime": "2015-03-19T16:52:38-07:00",
         "status": "Evidence",
         "active": true
     },
@@ -29,7 +29,7 @@
         "omimId": "100800",
         "owner": "tsneddon@stanford.edu",
         "status": "Evidence",
-        "dateTime": "Fri Mar 20 2015 10:02:09 PDT",
+        "dateTime": "2015-03-20T10:02:09-07:00",
         "annotations": [
             "bb3432ca-1788-11e5-aefb-60f81dc5b05a",
             "5cd72a73-189e-11e5-9db5-60f81dc5b05a"
@@ -42,7 +42,7 @@
         "modeInheritance": "Autosomal unknown",
         "omimId": "613795",
         "owner": "kgliu@stanford.edu",
-        "dateTime": "Mon Apr 13 2015 17:23:22 PDT",
+        "dateTime": "2015-03-13T17:23:22-07:00",
         "status": "Evidence",
         "active": true
     },
@@ -53,7 +53,7 @@
         "modeInheritance": "Autosomal dominant inheritance with paternal imprinting (HP:0012274)",
         "omimId": "300046",
         "owner": "tsneddon@stanford",
-        "dateTime": "Wed Feb 25 2015 14:55:54 PST",
+        "dateTime": "2015-02-25T14:55:54-08:00",
         "status": "Evidence",
         "active": true
     },
@@ -64,7 +64,7 @@
         "modeInheritance": "Codominant",
         "omimId": "",
         "owner": "tsneddon@stanford",
-        "dateTime": "Mon May 04 2015 08:11:18 PDT",
+        "dateTime": "2015-05-04T08:11:18-07:00",
         "status": "Evidence",
         "active": true
     },
@@ -75,7 +75,7 @@
         "modeInheritance": "Other",
         "omimId": "609054",
         "owner": "tsneddon@stanford",
-        "dateTime": "Thu Mar 19 2015 15:25:49 PDT",
+        "dateTime": "2015-03-19T15:25:49-07:00",
         "status": "Evidence",
         "active": true
     }

--- a/src/clincoded/tests/data/inserts/segregation.json
+++ b/src/clincoded/tests/data/inserts/segregation.json
@@ -2,7 +2,7 @@
     {
         "uuid": "08b61bb3-2a5b-11e5-b2e4-60f81dc5b05a",
         "owner": "tsneddon@stanford.edu",
-        "dateTime": "date time 01",
+        "dateTime": "2015-02-27T09:35:18-08:00",
         "pedigreeDescription": "K8725",
         "pedigreeSize": "15",
         "numberOfGenerationInPedigree": "3",

--- a/src/clincoded/tests/data/inserts/statistic.json
+++ b/src/clincoded/tests/data/inserts/statistic.json
@@ -1,7 +1,7 @@
 [
     {
         "owner": "kgliu@stanford.edu",
-        "dateTime": "time stamp 01",
+        "dateTime": "2015-02-27T05:35:18-08:00",
         "analysisType": "type1",
         "description": "some thing about type1",
         "oddsRatio": "5:4",
@@ -16,7 +16,7 @@
     },
     {
         "owner": "selinad@stanford.edu",
-        "dateTime": "time stamp 02",
+        "dateTime": "2015-02-27T06:35:18-08:00",
         "analysisType": "type2",
         "description": "some thing about type2",
         "oddsRatio": "100:150",


### PR DESCRIPTION
* Fixes momentjs warning mentioned by @kilodalton in #129.
* Existing test data sorts by date properly now (@tsneddon's records being displayed):
![image](https://cloud.githubusercontent.com/assets/4326866/8939894/fb9f67c0-351b-11e5-8206-b2ae8f63723f.png)
* Corrected ownership of some of @tsneddon's test data ('tsneddon@stanford' -> 'tsneddon@stanford.edu')