### PR TITLE
Connects to #128 Handle CollectiveName author tag in PubMed XML

### DIFF
--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -76,13 +76,18 @@ function pubmedAuthors($PubmedArticle){
         var $Authors = $AuthorList.getElementsByTagName('Author');
         for (var i = 0; i < $Authors.length; ++i) {
             var author = '';
-            var $LastName = $Authors[i].getElementsByTagName('LastName')[0];
-            if ($LastName){
-                author = $LastName.textContent;
-            }
-            var $Initials = $Authors[i].getElementsByTagName('Initials')[0];
-            if ($Initials){
-                author += (author ? ' ' : '') + $Initials.textContent;
+            var $CollectiveName = $Authors[i].getElementsByTagName('CollectiveName')[0];
+            if ($CollectiveName) {
+                author = $CollectiveName.textContent;
+            } else {
+                var $LastName = $Authors[i].getElementsByTagName('LastName')[0];
+                if ($LastName){
+                    author = $LastName.textContent;
+                }
+                var $Initials = $Authors[i].getElementsByTagName('Initials')[0];
+                if ($Initials){
+                    author += (author ? ' ' : '') + $Initials.textContent;
+                }                
             }
             authors.push(author);
         }


### PR DESCRIPTION
CollectiveName XML tag now maps to our author field so that we don’t have empty author properties when receiving this kind of PubMed XML.

Before this change, PubMed ID 12345678 would give us an empty author property in our article object because their author information was in the CollectiveName tag, and we only processed the LastName and FirstName tags. With this change, we get a full author property with PubMed ID 12345678.