### PR TITLE
Connects to #145. Hide menu items when logged out

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -22,7 +22,7 @@ var portal = {
     portal_title: 'ClinGen',
     navUser: [
         {id: 'dashboard', title: 'Dashboard', icon: 'icon-home', url: '/dashboard/'},
-        {id: 'account', title: 'Account', url: '/account/'},
+        //{id: 'account', title: 'Account', url: '/account/'},
         {id: 'loginout', title: 'Login'}
     ]
 };
@@ -175,8 +175,10 @@ var NavbarUser = React.createClass({
             <Nav navbarStyles='navbar-user' styles='navbar-right nav-user'>
                 {this.props.portal.navUser.map(function(menu) {
                     if (menu.url) {
-                        // Normal menu item
-                        return <NavItem key={menu.id} href={menu.url} icon={menu.icon}>{menu.title}</NavItem>;
+                        // Normal menu item; disabled if user is not logged in
+                        if (session && session['auth.userid']) {
+                            return <NavItem key={menu.id} href={menu.url} icon={menu.icon}>{menu.title}</NavItem>;
+                        }
                     } else {
                         // Trigger menu item; set <a> data attribute to login or logout
                         var attrs = {};


### PR DESCRIPTION
* Hides menu items other than 'Login' when logged out
* Hides 'Account' menu item across the board as the page does not exist at the moment
Logged out:
![image](https://cloud.githubusercontent.com/assets/4326866/8966465/595245de-35e6-11e5-9f25-9d7b4989bc3b.png)
Logged in:
![image](https://cloud.githubusercontent.com/assets/4326866/8966452/4d9488ba-35e6-11e5-9d02-ff0024ba71e1.png)
