### PR TITLE
Connects to #137. Updated Logged out page and warning messages

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -159,7 +159,7 @@ var NavbarMain = React.createClass({
             <div>
                 <div className="container">
                     <NavbarUser portal={this.props.portal} session={this.props.session} />
-                    <a href="/dashboard" className='navbar-brand'>ClinGen Dashboard</a>
+                    <a href="/" className='navbar-brand'>ClinGen Dashboard</a>
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/errors.js
+++ b/src/clincoded/static/components/errors.js
@@ -57,7 +57,7 @@ var HTTPForbidden = module.exports.HTTPForbidden = React.createClass({
                 <div className={itemClass}>
                     <div className="row">
                         <div className="col-sm-12">
-                            <h1>Not available</h1>
+                            <h1>ClinGen Curator Interface</h1>
                             <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>
                             <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
                         </div>

--- a/src/clincoded/static/components/errors.js
+++ b/src/clincoded/static/components/errors.js
@@ -8,9 +8,11 @@ var Error = module.exports.Error = React.createClass({
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'panel-gray');
         return (
-            <div className={itemClass}>
-                <h1>{context.title}</h1>
-                <p>{context.description}</p>
+            <div className="container">
+                <div className={itemClass}>
+                    <h1>{context.title}</h1>
+                    <p>{context.description}</p>
+                </div>
             </div>
         );
     }
@@ -24,11 +26,13 @@ var HTTPNotFound = module.exports.HTTPNotFound = React.createClass({
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'panel-gray');
         return (
-            <div className={itemClass}>
-                <div className="row">
-                    <div className="col-sm-12">
-                        <h1>Not found</h1>
-                        <p>The page could not be found.</p>
+            <div className="container">
+                <div className={itemClass}>
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <h1>Not found</h1>
+                            <p>The requested page could not be found.</p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -49,12 +53,14 @@ var HTTPForbidden = module.exports.HTTPForbidden = React.createClass({
             </div>
         );
         return (
-            <div className={itemClass}>
-                <div className="row">
-                    <div className="col-sm-12">
-                        <h1>Not available</h1>
-                        <p>Please sign in to view this page.</p>
-                        <p>Or <a href='mailto:clingen-helpdesk@lists.stanford.edu'>Request an account.</a></p>
+            <div className="container">
+                <div className={itemClass}>
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <h1>Not available</h1>
+                            <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>
+                            <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -78,13 +84,14 @@ var LoginDenied = module.exports.LoginDenied = React.createClass({
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'panel-gray');
         return (
-            <div className={itemClass}>
-                <div className="row">
-                    <div className="col-sm-12">
-                        <h1>Login failure</h1>
-                        <p>Access is restricted to ClinGen curators.</p>
-                        <p><a href='mailto:clingen-helpdesk@lists.stanford.edu'>Request an account</a></p>
-
+            <div className="container">
+                <div className={itemClass}>
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <h1>Login failure</h1>
+                            <p>Access is restricted to ClinGen curators.</p>
+                            <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -100,10 +107,12 @@ var RenderingError = module.exports.RenderingError = React.createClass({
         var context = this.props.context;
         var itemClass = globals.itemClass(context, 'panel-gray');
         return (
-            <div className={itemClass}>
-                <h1>{context.title}</h1>
-                <p>{context.description}</p>
-                <pre>{context.detail}</pre>
+            <div className="container">
+                <div className={itemClass}>
+                    <h1>{context.title}</h1>
+                    <p>{context.description}</p>
+                    <pre>{context.detail}</pre>
+                </div>
             </div>
         );
     }

--- a/src/clincoded/static/components/errors.js
+++ b/src/clincoded/static/components/errors.js
@@ -57,7 +57,7 @@ var HTTPForbidden = module.exports.HTTPForbidden = React.createClass({
                 <div className={itemClass}>
                     <div className="row">
                         <div className="col-sm-12">
-                            <h1>ClinGen Curator Interface</h1>
+                            <h1>Not available</h1>
                             <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>
                             <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
                         </div>

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -27,7 +27,7 @@ var Home = module.exports.Home = React.createClass({
                         <div className="col-sm-12">
                             <div className="project-info site-title">
                                 <h1>ClinGen Curator Interface</h1>
-                                <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>,
+                                <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>
                                 <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
                             </div>
                         </div>

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -20,13 +20,21 @@ var SignIn = module.exports.SignIn = React.createClass({
 var Home = module.exports.Home = React.createClass({
     render: function() {
         var hidden = !this.props.session || this.props.session['auth.userid'];
+        if (hidden) {
+            window.location.replace("/dashboard/");
+        }
+        else {
+            var message = [<p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>,
+                <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>]
+        }
         return (
-            <div>
+            <div className="container">
                 <div className="homepage-main-box panel-gray">
                     <div className="row">
                         <div className="col-sm-12">
                             <div className="project-info site-title">
-                                <h1>ClinGen Curator Portal</h1>
+                                <h1>ClinGen Curator Interface</h1>
+                                {message}
                             </div>
                         </div>
                     </div>

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -20,13 +20,6 @@ var SignIn = module.exports.SignIn = React.createClass({
 var Home = module.exports.Home = React.createClass({
     render: function() {
         var hidden = !this.props.session || this.props.session['auth.userid'];
-        if (hidden) {
-            window.location.replace("/dashboard/");
-        }
-        else {
-            var message = [<p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>,
-                <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>]
-        }
         return (
             <div className="container">
                 <div className="homepage-main-box panel-gray">
@@ -34,7 +27,8 @@ var Home = module.exports.Home = React.createClass({
                         <div className="col-sm-12">
                             <div className="project-info site-title">
                                 <h1>ClinGen Curator Interface</h1>
-                                {message}
+                                <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>,
+                                <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
* Updated text on homepage (visible on / regardless of login status):
![image](https://cloud.githubusercontent.com/assets/4326866/8969836/b6179468-35fa-11e5-82d0-79c1f401a276.png)
* Pressing the ClinGen icon on upper left takes you to homepage
* Updated text on access denied/not available page (primarily for attempting to access the Dashboard while logged out):
![image](https://cloud.githubusercontent.com/assets/4326866/8969870/e1f966c4-35fa-11e5-9384-919a418b74f5.png)
* Updated error messages + homepage text to be encapsulated in 'container' div element so the text aligns with left edge of logo image, instead of left edge of browser window (ex: 404 page):
![image](https://cloud.githubusercontent.com/assets/4326866/8969905/2541fa86-35fb-11e5-894b-52c4187470c6.png)
