### PR TITLE
Connects to #135 ft record header

### DIFF
--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -73,7 +73,6 @@ var CreateGeneDisease = React.createClass({
 
     // When the form is submitted...
     submitForm: function(e) {
-        console.log(e);
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
 
         // Get values from form and validate them

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -8,6 +8,7 @@ var modal = require('../libs/bootstrap/modal');
 var form = require('../libs/bootstrap/form');
 var parseAndLogError = require('./mixins').parseAndLogError;
 var RestMixin = require('./rest').RestMixin;
+var CurationMixin = require('./curator').CurationMixin;
 var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
 
 var Modal = modal.Modal;
@@ -16,20 +17,20 @@ var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
 var PmidDoiButtons = curator.PmidDoiButtons;
-var CurationData = curator.CurationData;
+var RecordHeader = curator.RecordHeader;
 var CurationPalette = curator.CurationPalette;
 var PmidSummary = curator.PmidSummary;
 var queryKeyValue = globals.queryKeyValue;
 var external_url_map = globals.external_url_map;
 
+
 // Curator page content
 var CurationCentral = React.createClass({
-    mixins: [RestMixin],
+    mixins: [RestMixin, CurationMixin],
 
     getInitialState: function() {
         return {
             currPmid: queryKeyValue('pmid', this.props.href),
-            currOmimId: '',
             currGdm: {}
         };
     },
@@ -106,22 +107,6 @@ var CurationCentral = React.createClass({
         }).catch(parseAndLogError.bind(undefined, 'putRequest'));
     },
 
-    updateOmimId: function(omimId) {
-        this.getRestData(
-            '/gdm/' + this.state.currGdm.uuid + '/?frame=object'
-        ).then(gdmObj => {
-            // We'll get 422 (Unprocessible entity) if we PUT any of these fields:
-            delete gdmObj.uuid;
-            delete gdmObj['@id'];
-            delete gdmObj['@type'];
-
-            gdmObj.omimId = omimId;
-            return this.putRestData('/gdm/' + this.state.currGdm.uuid, gdmObj);
-        }).then(data => {
-            this.setState({currOmimId: omimId});
-        }).catch(parseAndLogError.bind(undefined, 'putRequest'));
-    },
-
     render: function() {
         var gdm = this.state.currGdm;
         var pmid = this.state.currPmid;
@@ -134,7 +119,7 @@ var CurationCentral = React.createClass({
 
         return (
             <div>
-                <CurationData gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
+                <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
                 <div className="container">
                     <div className="row curation-content">
                         <div className="col-md-3">

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -110,20 +110,24 @@ var PmidSummary = module.exports.PmidSummary = React.createClass({
     render: function() {
         var authors;
         var article = this.props.article;
-        var date = (/^([\d]{4})(.*?)$/).exec(article.date);
+        if (article && Object.keys(article).length) {
+            var date = (/^([\d]{4})(.*?)$/).exec(article.date);
 
-        if (article.authors && article.authors.length) {
-            authors = article.authors[0] + (article.authors.length > 1 ? ' et al. ' : '. ');
+            if (article.authors && article.authors.length) {
+                authors = article.authors[0] + (article.authors.length > 1 ? ' et al. ' : '. ');
+            }
+
+            return (
+                <p>
+                    {authors}
+                    {article.title + ' '}
+                    {this.props.displayJournal ? <i>{article.journal + '. '}</i> : null}
+                    <strong>{date[1]}</strong>{date[2]}
+                </p>
+            );
+        } else {
+            return null;
         }
-
-        return (
-            <p>
-                {authors}
-                {article.title + ' '}
-                {this.props.displayJournal ? <i>{article.journal + '. '}</i> : null}
-                <strong>{date[1]}</strong>{date[2]}
-            </p>
-        );
     }
 });
 

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -28,14 +28,13 @@ var CurationMixin = module.exports.CurationMixin = {
         this.getRestData(
             '/gdm/' + gdmUuid + '/?frame=object'
         ).then(gdmObj => {
-            console.log(gdmObj.uuid);
             // We'll get 422 (Unprocessible entity) if we PUT any of these fields:
             if (gdmObj.uuid) { delete gdmObj.uuid; }
             if (gdmObj['@id']) { delete gdmObj['@id']; }
             if (gdmObj['@type']) { delete gdmObj['@type']; }
 
             gdmObj.omimId = newOmimId;
-            return this.putRestData('/gdm/' + this.state.currGdm.uuid, gdmObj);
+            return this.putRestData('/gdm/' + gdmUuid, gdmObj);
         }).then(data => {
             this.setState({currOmimId: newOmimId});
         }).catch(e => {

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -38,6 +38,7 @@ var GroupCuration = React.createClass({
         return {
             gdm: {}, // GDM object given in UUID
             annotation: {}, // Annotation object given in UUID
+            article: {}, // Article from the annotation
             group: {} // If we're editing a group, this gets the fleshed-out group object we're editing
         };
     },
@@ -49,7 +50,11 @@ var GroupCuration = React.createClass({
             '/gdm/' + gdmUuid,
             '/evidence/' + annotationUuid + '?frame=object' // Use flattened object because it can be updated
         ]).then(data => {
-            this.setState({gdm: data[0], annotation: data[1], currOmimId: data[0].omimId});
+            var annotation = data[1];
+            this.setState({gdm: data[0], annotation: annotation, currOmimId: data[0].omimId});
+            return this.getRestData(annotation.article);
+        }).then(article => {
+            return this.setState({article: article});
         }).catch(parseAndLogError.bind(undefined, 'putRequest'));
     },
 
@@ -409,6 +414,10 @@ var GroupCuration = React.createClass({
                     <div>
                         <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
                         <div className="container">
+                            <div className="curation-pmid-summary">
+                                <PmidSummary article={this.state.article} displayJournal />
+                            </div>
+                            <h1>Curate Group Information</h1>
                             <div className="row group-curation-content">
                                 <div className="col-sm-12">
                                     <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -9,7 +9,8 @@ var curator = require('./curator');
 var parseAndLogError = require('./mixins').parseAndLogError;
 var RestMixin = require('./rest').RestMixin;
 
-var CurationData = curator.CurationData;
+var CurationMixin = curator.CurationMixin;
+var RecordHeader = curator.RecordHeader;
 var CurationPalette = curator.CurationPalette;
 var PmidSummary = curator.PmidSummary;
 var PanelGroup = panel.PanelGroup;
@@ -24,7 +25,7 @@ var country_codes = globals.country_codes;
 
 
 var GroupCuration = React.createClass({
-    mixins: [FormMixin, RestMixin],
+    mixins: [FormMixin, RestMixin, CurationMixin],
 
     contextTypes: {
         navigate: React.PropTypes.func
@@ -45,10 +46,10 @@ var GroupCuration = React.createClass({
     // state to the retrieved objects to cause a rerender of the component.
     getGdmAnnotation: function(gdmUuid, annotationUuid) {
         this.getRestDatas([
-            '/gdm/' + gdmUuid + '?frame=object',
-            '/evidence/' + annotationUuid + '?frame=object'
+            '/gdm/' + gdmUuid,
+            '/evidence/' + annotationUuid + '?frame=object' // Use flattened object because it can be updated
         ]).then(data => {
-            this.setState({gdm: data[0], annotation: data[1]});
+            this.setState({gdm: data[0], annotation: data[1], currOmimId: data[0].omimId});
         }).catch(parseAndLogError.bind(undefined, 'putRequest'));
     },
 
@@ -406,7 +407,7 @@ var GroupCuration = React.createClass({
             <div>
                 {(!this.queryValues.groupUuid || Object.keys(this.state.group).length > 0) ?
                     <div>
-                        <CurationData />
+                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
                         <div className="container">
                             <div className="row group-curation-content">
                                 <div className="col-sm-12">

--- a/src/clincoded/static/scss/clincoded/_variables.scss
+++ b/src/clincoded/static/scss/clincoded/_variables.scss
@@ -17,3 +17,7 @@ $font-size-h3: 1.7rem;
 $font-size-h4: 1.25rem;
 $font-size-h5: 1rem;
 $font-size-h6: 0.85rem;
+
+$group-curation: #FFFF00;
+$group-curation-bg: desaturate(lighten($group-curation,45%),50%);
+$group-curation-trim: darken($group-curation,10%);

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -273,4 +273,6 @@
     padding: 10px 20px 0 20px;
     background-color: $group-curation-bg;
     border: 1px solid $group-curation-trim;
+    font-size: 1.1rem;
+    text-align: center;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -267,3 +267,10 @@
 .edit-omim-modal {
     display: inline;
 }
+
+.curation-pmid-summary {
+    margin-top: 5px;
+    padding: 10px 20px 0 20px;
+    background-color: $group-curation-bg;
+    border: 1px solid $group-curation-trim;
+}


### PR DESCRIPTION
* Added Record Header to group curation, displaying the current gene and disease details, and the curator history, just as you see at the top of the content of the Curation Central page.
* Made the OMIM ID adding/editing functional on all pages it will appear on, including the existing Group Curation page.
* Displaying the current article summary below the record header.

![screen shot 2015-07-30 at 08 45 49](https://cloud.githubusercontent.com/assets/1181324/8987742/6bc2f3ce-3697-11e5-9c39-b36538136a83.png)