### PR TITLE
Connects to #158. Reenable elasticsearch dateTime sort

### DIFF
--- a/src/clincoded/search.py
+++ b/src/clincoded/search.py
@@ -71,12 +71,7 @@ def get_sort_order():
         'embedded.dateTime': {
             'order': 'desc',
             'ignore_unmapped': True,
-        },
-        'embedded.label': {
-            'order': 'asc',
-            'missing': '_last',
-            'ignore_unmapped': True,
-        },
+        }
     }
 
 

--- a/src/clincoded/search.py
+++ b/src/clincoded/search.py
@@ -68,7 +68,7 @@ def get_sort_order():
     specifies sort order for elasticsearch results
     """
     return {
-        'embedded.date_created': {
+        'embedded.dateTime': {
             'order': 'desc',
             'ignore_unmapped': True,
         },


### PR DESCRIPTION
Previous natural sorting of search results on dashboard (localhost:6543/dashboard):
![image](https://cloud.githubusercontent.com/assets/4326866/8994035/ba369120-36bd-11e5-876e-730785977aea.png)

New natural sorting of search results (note the dates):
![image](https://cloud.githubusercontent.com/assets/4326866/8994041/c7e8cb12-36bd-11e5-8177-8ce9385696ee.png)

This fix also frees up the dashboard page from having to sort the data on every load.