### PR TITLE
Connect to #150 kl variantPathogenic in gdm

### DIFF
--- a/src/clincoded/schemas/gdm.json
+++ b/src/clincoded/schemas/gdm.json
@@ -4,7 +4,7 @@
     "description": "Schema for storing gene:disease:mode data.",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
-    "required": ["gene", "disease", "modeInheritance", "owner", "status", "dateTime"],
+    "required": ["gene", "disease", "modeInheritance", "owner", "dateTime"],
     "identifyingProperties": ["uuid"],
     "additionalProperties": false,
     "mixinProperties": [
@@ -62,19 +62,6 @@
             "descripton": "Curator's email",
             "type": "string"
         },
-        "status": {
-            "title": "Status",
-            "descripton": "Currant status of the gdm",
-            "type": "string",
-            "enum": [
-                "Creation",
-                "Evidence",
-                "Summary",
-                "Provisional Assertion",
-                "Draft of Final",
-                "Final"
-            ]
-        },
         "dateTime": {
             "title": "Date and Time",
             "description": "Date and time stemp",
@@ -93,15 +80,129 @@
                 "linkTo": "annotation"
             }
         },
-        "summary": {
-            "title": "Summary",
-            "description": "Summary of evidence",
+        "variantPathogenic": {
+            "title": "Variant Pathogenic Data",
+            "description": "List of associated variants, their pathogenic data and assessments",
             "type": "array",
             "default": [],
-            "uniqueItems": true,
             "items": {
-                "title": "Summary",
-                "type": "string"
+                "title": "Variant And Pathogenic",
+                "description": "Variant pathogenic data",
+                "type": "object",
+                "properties": {
+                    "variant": {
+                        "title": "Varaint uuid",
+                        "type": "string",
+                        "linkTo": "variant"
+                    },
+                    "consistentWithDiseaseMechanism": {
+                        "title": "Is Variant Consistent with Disease Mechanism?",
+                        "description": "Is variant consistent with disease mechanism?",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "withinFunctionalDomain": {
+                        "title": "Variant within Functional Domain",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "frequencySupportPathogenicity": {
+                        "title": "Does Frequency Data Support Pathogenicity",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "previouslyReported": {
+                        "title": "Previously Reported",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "denovoType": {
+                        "title": "de novo Type",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Inferred",
+                            "Confirmed"
+                        ]
+                    },
+                    "intransWithAnotherVariant": {
+                         "title": "in trans with Another Variant",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "supportingSegregation": {
+                         "title": "Supporting Segregation Data",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "supportingStatistic": {
+                         "title": "Supporting Statistical Data",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "SupportingFunctional": {
+                         "title": "Supporting Functional Data",
+                        "type": "string",
+                        "default": "",
+                        "enum": [
+                            "",
+                            "Yes",
+                            "No"
+                        ]
+                    },
+                    "comment": {
+                        "title": "Comment",
+                        "type": "string",
+                        "default": ""
+                    },
+                    "assessments": {
+                        "title": "Assessments",
+                        "description": "uuid list of assessments",
+                        "type": "array",
+                        "default": [],
+                        "items": {
+                            "title": "Assessment",
+                            "type": "string",
+                            "linkTo": "assessment"
+                        }
+                    }
+                }
             }
         },
         "provisionalClassifications": {
@@ -165,8 +266,12 @@
             "title": "Evidence",
             "type": "string"
         },
-        "summary": {
-            "title": "Summary",
+        "variantPathogenic": {
+            "title": "Variants",
+            "type": "string"
+        },
+        "provisionalClassifications": {
+            "title": "Provisional Assertion",
             "type": "string"
         },
         "draftClassification": {
@@ -175,10 +280,6 @@
         },
         "finalClassification": {
             "title": "Final Assertion",
-            "type": "string"
-        },
-        "status": {
-            "title": "Status",
             "type": "string"
         },
         "dateTime": {

--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -44,124 +44,6 @@
             "description": "List of other descriptions",
             "type": "string",
             "default": ""
-        },
-        "consistentWithDiseaseMechanism": {
-            "title": "Is Variant Consistent with Disease Mechanism?",
-            "description": "Is variant consistent with disease mechanism?",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "withinFunctionalDomain": {
-            "title": "Variant within Functional Domain",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "frequencySupportPathogenicity": {
-            "title": "Does Frequency Data Support Pathogenicity",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "previouslyReported": {
-            "title": "Previously Reported",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "denovoType": {
-            "title": "de novo Type",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "consistentWithDiseaseMechanism": {
-            "title": "Is Variant Consistent with Disease Mechanism?",
-            "description": "Is variant consistent with disease mechanism?",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "intransWithAnotherVariant": {
-             "title": "in trans with Another Variant",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "supportingSegregation": {
-             "title": "Supporting Segregation Data",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "supportingStatistic": {
-             "title": "Supporting Statistical Data",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "SupportingFunctional": {
-             "title": "Supporting Functional Data",
-            "type": "string",
-            "default": "",
-            "enum": [
-                "",
-                "Yes",
-                "No"
-            ]
-        },
-        "comment": {
-            "title": "Comment",
-            "type": "string",
-            "default": ""
-        },
-        "assessments": {
-            "title": "Assessments",
-            "description": "uuid list of assessments",
-            "type": "array",
-            "default": [],
-            "items": {
-                "title": "Assessment",
-                "type": "string",
-                "linkTo": "assessment"
-            }
         }
     },
     "columns": {
@@ -183,10 +65,6 @@
         },
         "otherDescription": {
             "title": "Other Description",
-            "type": "string"
-        },
-        "assessments": {
-            "title": "Assessments",
             "type": "string"
         }
     }

--- a/src/clincoded/tests/data/inserts/gdm.json
+++ b/src/clincoded/tests/data/inserts/gdm.json
@@ -7,7 +7,6 @@
         "omimId": "609054",
         "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-02-27T08:35:18-08:00",
-        "status": "Creation",
         "active": true
     },
     {
@@ -18,7 +17,6 @@
         "omimId": "601200",
         "owner": "selinad@stanford.edu",
         "dateTime": "2015-03-19T16:52:38-07:00",
-        "status": "Evidence",
         "active": true
     },
     {
@@ -28,11 +26,28 @@
         "modeInheritance": "Autosomal recessive inheritance (HP:0000007)",
         "omimId": "100800",
         "owner": "tsneddon@stanford.edu",
-        "status": "Evidence",
         "dateTime": "2015-03-20T10:02:09-07:00",
         "annotations": [
             "bb3432ca-1788-11e5-aefb-60f81dc5b05a",
             "5cd72a73-189e-11e5-9db5-60f81dc5b05a"
+        ],
+        "variantPathogenic": [
+            {
+                "variant": "3b3af7f0-2685-11e5-bc56-60f81dc5b05a",
+                "consistentWithDiseaseMechanism": "Yes",
+                "withinFunctionalDomain": "Yes",
+                "frequencySupportPathogenicity": "No",
+                "previouslyReported": "No",
+                "denovoType": "Confirmed",
+                "intransWithAnotherVariant": "No",
+                "supportingSegregation": "Yes",
+                "supportingStatistic": "No",
+                "SupportingFunctional": "Yes",
+                "assessments": [
+                    "4f94a226-2a4c-11e5-887c-60f81dc5b05a",
+                    "550d702b-2a4c-11e5-856d-60f81dc5b05a"
+                ]
+            }
         ]
     },
     {
@@ -43,7 +58,6 @@
         "omimId": "613795",
         "owner": "kgliu@stanford.edu",
         "dateTime": "2015-03-13T17:23:22-07:00",
-        "status": "Evidence",
         "active": true
     },
     {
@@ -54,7 +68,6 @@
         "omimId": "300046",
         "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-02-25T14:55:54-08:00",
-        "status": "Evidence",
         "active": true
     },
     {
@@ -65,7 +78,6 @@
         "omimId": "",
         "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-05-04T08:11:18-07:00",
-        "status": "Evidence",
         "active": true
     },
     {
@@ -76,7 +88,6 @@
         "omimId": "609054",
         "owner": "tsneddon@stanford.edu",
         "dateTime": "2015-03-19T15:25:49-07:00",
-        "status": "Evidence",
         "active": true
     }
 ]

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -106,9 +106,6 @@ class Variant(Item):
     item_type = 'variant'
     schema = load_schema('clincoded:schemas/variant.json')
     name_key = 'uuid'
-    embedded = [
-        "assessments"
-    ]
 
 @collection(
     name='gdm',
@@ -173,7 +170,9 @@ class Gdm(Item):
         'annotations.experimentalData.proteinIneractions.assessments',
         'annotations.experimentalData.functionalAleration.assessments',
         'annotations.experimentalData.modelSystems.assessments',
-        'annotations.experimentalData.rescue.assessments'
+        'annotations.experimentalData.rescue.assessments',
+        'variantPathogenic.variant',
+        'variantPathogenic.assessments'
     ]
 
 @collection(


### PR DESCRIPTION
Summary of changes
1. Add “variantPathogenic” property in gym to store variant pathogenic
data and assessments.
2. Remove pathogenic and assessment properties from variant object