### PR TITLE
Connects to #162 Remove "status" from GDM-creation JS code

### DIFF
--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -105,7 +105,6 @@ var CreateGeneDisease = React.createClass({
                             disease: orphaId,
                             modeInheritance: mode,
                             owner: this.props.session['auth.userid'],
-                            status: 'Creation',
                             dateTime: moment().format()
                         };
 


### PR DESCRIPTION
Removed the ```status``` property from the code that POSTs a gdm object. Confirmed this successfully creates a gdm on submit without a 422 error.