### PR TITLE
Connects to #138. Create demo indicator for demo release

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -107,6 +107,7 @@ var App = module.exports = React.createClass({
                     }}></script>
                     <div>
                         <Header session={this.state.session} />
+                        <Notice noticeType='danger' noticeMessage={<span><strong>Note:</strong> This is a demo version of the site. Any data you enter will not be permanently saved.</span>} />
                         {content}
                     </div>
                 </body>
@@ -144,6 +145,33 @@ var Header = React.createClass({
                 <NavbarMain portal={portal} session={this.props.session} />
             </header>
         );
+    }
+});
+
+
+// Render the notice bar, under header, if needed
+// Usage: <Notice noticeType='[TYPE]' noticeMessage={<span>[MESSAGE]</span>} />
+// Appropriate noticeTypes: success, info, warning, danger (bootstrap defaults)
+var Notice = React.createClass({
+    getInitialState: function () {
+        return { noticeVisible: true }
+    },
+    onClick: function() {
+        this.setState({ noticeVisible: false });
+    },
+    render: function() {
+        var noticeClass = 'alert alert-' + this.props.noticeType;
+        if (this.state.noticeVisible) {
+            return (
+                <div className={noticeClass} role="alert">
+                    <div className="container">
+                        {this.props.noticeMessage}
+                        <button type="button" className="close" onClick={this.onClick}>&times;</button>
+                    </div>
+                </div>
+            );
+        }
+        else { return (null); }
     }
 });
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/9017294/dfab9810-378a-11e5-8847-303a9b474107.png)
Pressing on the 'X' gets rid of the notice until a page is refreshed.

Also added Notice class to app.js for the ability to create similar notices as needed:
![image](https://cloud.githubusercontent.com/assets/4326866/9017371/52d278b8-378b-11e5-9371-32601953d98c.png)
![image](https://cloud.githubusercontent.com/assets/4326866/9017486/b569290e-378b-11e5-818d-8e87dcb3cf53.png)
![image](https://cloud.githubusercontent.com/assets/4326866/9017505/d99c3514-378b-11e5-8612-a997e0615b08.png)