### PR TITLE
Connects to #169. Change Homepage behavior

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -184,11 +184,13 @@ var NavbarMain = React.createClass({
     },
 
     render: function() {
+        var headerUrl = '/';
+        if (this.props.session['auth.userid'] !== undefined) headerUrl = '/dashboard/';
         return (
             <div>
                 <div className="container">
                     <NavbarUser portal={this.props.portal} session={this.props.session} />
-                    <a href="/" className='navbar-brand'>ClinGen Dashboard</a>
+                    <a href={headerUrl} className='navbar-brand'>ClinGen Dashboard</a>
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -19,7 +19,9 @@ var SignIn = module.exports.SignIn = React.createClass({
 
 var Home = module.exports.Home = React.createClass({
     render: function() {
-        var hidden = !this.props.session || this.props.session['auth.userid'];
+        if (this.props.session['auth.userid'] !== undefined) {
+            window.location.href = '/dashboard/';
+        }
         return (
             <div className="container">
                 <div className="homepage-main-box panel-gray">


### PR DESCRIPTION
* Header ClinGen logo URL changes between '/' or '/dashboard/' depending on login status
* Navigating to the Homepage ('/') after login forwards you to /dashboard/ (kinda buggy still). Triggers on logging in, and manually navigating to /.
  * Bugs/caveats: forwarding from / to /dashboard/ happens after rendering the page, so there is a delay; on Firefox, a 'Network request failed' error is displayed before the forwarding to dashboard kicks in.