### PR TITLE
Connects to #174 ft http

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -44,40 +44,47 @@ var App = module.exports = React.createClass({
         };
     },
 
+    currentAction: function() {
+        var href_url = url.parse(this.props.href);
+        var hash = href_url.hash || '';
+        var name;
+        if (hash.slice(0, 2) === '#!') {
+            name = hash.slice(2);
+        }
+        return name;
+    },
+
     render: function() {
         var content;
         var context = this.props.context;
         var href_url = url.parse(this.props.href);
-        var hash = href_url.hash || '';
-        var name;
-        var context_actions = [];
-        if (hash.slice(0, 2) === '#!') {
-            name = hash.slice(2);
-        }
-
+        // Switching between collections may leave component in place
         var key = context && context['@id'];
+        var current_action = this.currentAction();
+        if (!current_action && context.default_page) {
+            context = context.default_page;
+        }
         if (context) {
-            Array.prototype.push.apply(context_actions, context.actions || []);
-            if (!name && context.default_page) {
-                context = context.default_page;
-                var actions = context.actions || [];
-                for (var i = 0; i < actions.length; i++) {
-                    var action = actions[i];
-                    if (action.href[0] == '#') {
-                        action.href = context['@id'] + action.href;
-                    }
-                    context_actions.push(action);
-                }
-            }
-
-            var ContentView = globals.content_views.lookup(context, name);
+            var ContentView = globals.content_views.lookup(context, current_action);
             content = <ContentView {...this.props} context={context}
                 loadingComplete={this.state.loadingComplete} session={this.state.session}
-                portal={this.state.portal} navigate={this.navigate} />;
+                portal={this.state.portal} navigate={this.navigate} href_url={href_url} />;
         }
         var errors = this.state.errors.map(function (error) {
             return <div className="alert alert-error"></div>;
         });
+
+        var appClass = 'done';
+        if (this.props.slow) {
+            appClass = 'communicating'; 
+        }
+
+        var title = context.title || context.name || context.accession || context['@id'];
+        if (title && title != 'Home') {
+            title = title + ' – ' + portal.portal_title;
+        } else {
+            title = portal.portal_title;
+        }
 
         var canonical = this.props.href;
         if (context.canonical_uri) {
@@ -154,7 +161,7 @@ var Header = React.createClass({
 // Appropriate noticeTypes: success, info, warning, danger (bootstrap defaults)
 var Notice = React.createClass({
     getInitialState: function () {
-        return { noticeVisible: true }
+        return { noticeVisible: true };
     },
     onClick: function() {
         this.setState({ noticeVisible: false });

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -125,7 +125,7 @@ var CurationCentral = React.createClass({
                     <div className="row curation-content">
                         <div className="col-md-3">
                             <PmidSelectionList annotations={gdm.annotations} currPmid={pmid} currPmidChange={this.currPmidChange}
-                                    updateGdmArticles={this.updateGdmArticles} />
+                                    protocol={this.props.href_url.protocol} updateGdmArticles={this.updateGdmArticles} />
                         </div>
                         <div className="col-md-6">
                             {currArticle ?
@@ -182,6 +182,7 @@ var PmidSelectionList = React.createClass({
 
     propTypes: {
         annotations: React.PropTypes.array, // List of PubMed items
+        protocol: React.PropTypes.string, // Protocol to use to access PubMed ('http:' or 'https:')
         currPmid: React.PropTypes.string, // PMID of currently selected article
         currPmidChange: React.PropTypes.func, // Function to call when currently selected article changes
         updateGdmArticles: React.PropTypes.func // Function to call when we have an article to add to the GDM
@@ -197,7 +198,7 @@ var PmidSelectionList = React.createClass({
             <div>
                 <div className="pmid-selection-add">
                     <Modal title='Add new PubMed Article'>
-                        <button className="btn btn-primary pmid-selection-add-btn" modal={<AddPmidModal closeModal={this.closeModal} updateGdmArticles={this.props.updateGdmArticles} />}>
+                        <button className="btn btn-primary pmid-selection-add-btn" modal={<AddPmidModal protocol={this.props.protocol} closeModal={this.closeModal} updateGdmArticles={this.props.updateGdmArticles} />}>
                             Add New PMID(s)
                         </button>
                     </Modal>
@@ -230,6 +231,7 @@ var AddPmidModal = React.createClass({
 
     propTypes: {
         closeModal: React.PropTypes.func, // Function to call to close the modal
+        protocol: React.PropTypes.string, // Protocol to use to access PubMed ('http:' or 'https:')
         updateGdmArticles: React.PropTypes.func // Function to call when we have an article to add to the GDM
     },
 
@@ -264,6 +266,7 @@ var AddPmidModal = React.createClass({
                 // Close the modal; update the GDM with this article.
                 return Promise.resolve(article);
             }, e => {
+                var url = this.props.protocol + external_url_map['PubMedSearch'];
                 // PubMed article not in our DB; go out to PubMed itself to retrieve it as XML
                 return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
                     var newArticle = parsePubmed(xml, enteredPmid);

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -126,7 +126,7 @@ module.exports.dbxref_prefix_map = {
 };
 
 module.exports.external_url_map = {
-    'PubMedSearch': 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=PubMed&retmode=xml&id=',
+    'PubMedSearch': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=PubMed&retmode=xml&id=',
     'PubMed': 'https://www.ncbi.nlm.nih.gov/pubmed/',
     'OrphaNet': 'http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=',
     'HGNC': 'http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=',


### PR DESCRIPTION
GET requests to external sites now use the protocol (http/https) of the current site. Also bring back a lot of app.js code from ENCODE; had ripped out a lot when I had a dummy mechanism for loading curation pages. My mods aren’t needed anymore, and we can use something more ENCODE-like.