### PR TITLE
Connects to #140. Add instruction text when empty PMID list in curation-central

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -128,9 +128,6 @@ var CurationCentral = React.createClass({
                                     protocol={this.props.href_url.protocol} updateGdmArticles={this.updateGdmArticles} />
                         </div>
                         <div className="col-md-6">
-                            <div className="notice-bar-embed alert alert-info">
-                                <div className="container">Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</div>
-                            </div>
                             {currArticle ?
                                 <div className="curr-pmid-overview">
                                     <PmidSummary article={currArticle} displayJournal />
@@ -222,6 +219,9 @@ var PmidSelectionList = React.createClass({
                         })}
                     </div>
                 : null}
+                <div>
+                    <i>Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</i>
+                </div>
             </div>
         );
     }

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -219,9 +219,11 @@ var PmidSelectionList = React.createClass({
                         })}
                     </div>
                 : null}
-                <div>
-                    <i>Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</i>
-                </div>
+                {annotations.length == 0 ?
+                    <div>
+                        <i>Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</i>
+                    </div>
+                :null }
             </div>
         );
     }

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -122,6 +122,10 @@ var CurationCentral = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
                 <div className="container">
+                    <div className="notice-bar-embed alert alert-info">
+                    <div className="container">Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</div>
+                </div>
+
                     <div className="row curation-content">
                         <div className="col-md-3">
                             <PmidSelectionList annotations={gdm.annotations} currPmid={pmid} currPmidChange={this.currPmidChange}

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -122,16 +122,15 @@ var CurationCentral = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} />
                 <div className="container">
-                    <div className="notice-bar-embed alert alert-info">
-                    <div className="container">Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</div>
-                </div>
-
                     <div className="row curation-content">
                         <div className="col-md-3">
                             <PmidSelectionList annotations={gdm.annotations} currPmid={pmid} currPmidChange={this.currPmidChange}
                                     protocol={this.props.href_url.protocol} updateGdmArticles={this.updateGdmArticles} />
                         </div>
                         <div className="col-md-6">
+                            <div className="notice-bar-embed alert alert-info">
+                                <div className="container">Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</div>
+                            </div>
                             {currArticle ?
                                 <div className="curr-pmid-overview">
                                     <PmidSummary article={currArticle} displayJournal />

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -276,3 +276,7 @@
     font-size: 1.1rem;
     text-align: center;
 }
+
+.notice-bar-embed {
+    margin: 15px 0 15px 0;
+}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -133,7 +133,7 @@
 }
 
 .pmid-selection-list {
-    margin-bottom: 50px;
+    margin-bottom: 20px;
     max-height: 250px;
     overflow-y: scroll;
     border: 1px solid #e0e0e0;
@@ -275,8 +275,4 @@
     border: 1px solid $group-curation-trim;
     font-size: 1.1rem;
     text-align: center;
-}
-
-.notice-bar-embed {
-    margin: 15px 0 15px 0;
 }


### PR DESCRIPTION
When literature list is empty in curation central the instruction text displays:
![image](https://cloud.githubusercontent.com/assets/4326866/9140932/c061db9a-3ce9-11e5-9b49-badcc8dc2b39.png)

When literature list is not empty, the text is not displayed:
![image](https://cloud.githubusercontent.com/assets/4326866/9140955/d4593576-3ce9-11e5-8d48-a64c54ba58df.png)
