### PR TITLE
Connects to #214 Fix Curation Central note bug

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -23,6 +23,7 @@ var CurationPalette = curator.CurationPalette;
 var PmidSummary = curator.PmidSummary;
 var queryKeyValue = globals.queryKeyValue;
 var external_url_map = globals.external_url_map;
+var userMatch = globals.userMatch;
 
 
 // Curator page content
@@ -162,7 +163,7 @@ var BetaNote = React.createClass({
     render: function() {
         var annotation = this.props.annotation;
         var session = this.props.session;
-        var curatorMatch = annotation.owner === (session && session.user_properties && session.user_properties.email);
+        var curatorMatch = annotation && userMatch(annotation.submitted_by, session);
 
         return (
             <div>


### PR DESCRIPTION
One place was still using the old method (owner property) to decide whether to display the message, “Currently, only the curator who adds a paper…” above the abstract. This caused this message to always display even when the current user has selected a paper they added.

This fixes that to use the newer method to detect and compare users.

![fix](https://cloud.githubusercontent.com/assets/1181324/9309427/6b61f0b2-44be-11e5-8b90-d6c13af0bd90.png)
