### PR TITLE
Connects to #7 ft group header

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -797,31 +797,48 @@ var FamilyCount = function() {
 var FamilyCommonDiseases = function() {
     var family = this.state.family;
     var group = this.state.group;
-    var orphanetidVal, hpoidVal, nothpoidVal;
+    var orphanetidVal, hpoidVal, nothpoidVal, associatedGroups;
 
-    if (family) {
+    // If we're editing a family, make editable values of the complex properties
+    if (family && Object.keys(family).length) {
         orphanetidVal = family.commonDiagnosis ? family.commonDiagnosis.map(function(disease) { return 'ORPHA' + disease.orphaNumber; }).join() : null;
         hpoidVal = family.hpoIdInDiagnosis ? family.hpoIdInDiagnosis.join() : null;
         nothpoidVal = family.hpoIdInElimination ? family.hpoIdInElimination.join() : null;
     }
 
+    // Make a list of diseases from the group, either from the given group,
+    // or the family if we're editing one that has associated groups.
+    if (Object.keys(group).length) {
+        // We have a group, so get the disease array from it.
+        associatedGroups = [group];
+    } else if (family && family.associatedGroups && family.associatedGroups.length) {
+        // We have a family with associated groups. Combine the diseases from all groups.
+        associatedGroups = family.associatedGroups;
+    }
+
     return (
         <div className="row">
-            {Object.keys(group).length ?
-                <div className="form-group">
-                    <div className="col-sm-5">
-                        <strong className="pull-right">Orphanet Disease Associated with Group:</strong>
-                    </div>
-                    <div className="col-sm-7">
-                        {group.commonDiagnosis.map(function(disease, i) {
-                            return (
-                                <span key={disease.orphaNumber}>
-                                    {i > 0 ? ', ' : ''}
-                                    {'ORPHA' + disease.orphaNumber}
-                                </span>
-                            );
-                        })}
-                    </div>
+            {associatedGroups && associatedGroups.length ?
+                <div>
+                    {associatedGroups.map(function(associatedGroup) {
+                        return (
+                            <div key={associatedGroup.uuid} className="form-group">
+                                <div className="col-sm-5">
+                                    <strong className="pull-right">Orphanet Diseases Associated with {associatedGroup.label}</strong>
+                                </div>
+                                <div className="col-sm-7">
+                                    {associatedGroup.commonDiagnosis.map(function(disease, i) {
+                                        return (
+                                            <span key={disease.orphaNumber}>
+                                                {i > 0 ? ', ' : ''}
+                                                {'ORPHA' + disease.orphaNumber}
+                                            </span>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        );
+                    })}
                 </div>
             : null}
             <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15"

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -810,7 +810,7 @@ var FamilyCommonDiseases = function() {
             {Object.keys(group).length ?
                 <div className="form-group">
                     <div className="col-sm-5">
-                        <strong className="pull-right">Orphanet Disease Associate with Group:</strong>
+                        <strong className="pull-right">Orphanet Disease Associated with Group:</strong>
                     </div>
                     <div className="col-sm-7">
                         {group.commonDiagnosis.map(function(disease, i) {

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -796,6 +796,7 @@ var FamilyCount = function() {
 // as the calling component.
 var FamilyCommonDiseases = function() {
     var family = this.state.family;
+    var group = this.state.group;
     var orphanetidVal, hpoidVal, nothpoidVal;
 
     if (family) {
@@ -806,6 +807,23 @@ var FamilyCommonDiseases = function() {
 
     return (
         <div className="row">
+            {Object.keys(group).length ?
+                <div className="form-group">
+                    <div className="col-sm-5">
+                        <strong className="pull-right">Orphanet Disease Associate with Group:</strong>
+                    </div>
+                    <div className="col-sm-7">
+                        {group.commonDiagnosis.map(function(disease, i) {
+                            return (
+                                <span key={disease.orphaNumber}>
+                                    {i > 0 ? ', ' : ''}
+                                    {'ORPHA' + disease.orphaNumber}
+                                </span>
+                            );
+                        })}
+                    </div>
+                </div>
+            : null}
             <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -344,6 +344,7 @@ class Family(Item):
         'individualIncluded.submitted_by',
         'individualIncluded.variants',
         'associatedGroups',
+        'associatedGroups.commonDiagnosis',
         'individualIncluded.variants.submitted_by',
     ]
     rev = {


### PR DESCRIPTION
To test this change (screen shot of difference at https://github.com/ClinGen/clincoded/issues/7):

1. From Curation Central, create a new group and fill in all required fields. Note what diseases you’re entering because that becomes relevant on the family curation page later.
1. Back at Curation Central, click **Add family information**.
1. The new line in the “Family – Common Disease & Phenotypes” panel appears, titled **Orphanet Disease Associated with Group** and displaying the diseases you entered for the group in the first step.
1. Go back to Curation Central (either by creating the family, or just clicking the back button).
1. Click **Family +** to create an unassociated family.
1. The **Orphanet Disease Associated with Group** is missing, as we have no associated group to contribute its diseases.

Passed all local test, and first pass of Saucelabs tests.