### PR TITLE
Connected to #7 Wording changes

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -169,7 +169,7 @@ var CurationPalette = module.exports.CurationPalette = React.createClass({
                                     <p>{moment(group.date_created).format('YYYY MMM DD, h:mm a')}</p>
                                 </div>
                                 <a href={'/group/' + group.uuid} target="_blank" title="View group in a new tab">View</a>{curatorMatch ? <span> | <a href={'/group-curation/?gdm=' + this.props.gdm.uuid + '&evidence=' + annotation.uuid + '&group=' + group.uuid} title="Edit this group">Edit</a></span> : null}
-                                {curatorMatch ? <div><a href={familyUrl + '&group=' + group.uuid} title="Add a new family associated with this group">Add family information</a></div> : null}
+                                {curatorMatch ? <div><a href={familyUrl + '&group=' + group.uuid} title="Add a new family associated with this group">Add new Family to this Group</a></div> : null}
                             </div>
                         );
                     }.bind(this))}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1001,7 +1001,7 @@ var FamilySegregation = function() {
                 <option>Inferred</option>
                 <option>Confirmed</option>
             </Input>
-            <Input type="select" ref="unaffectedcarriers" label="Are parents unaffected carriers?" defaultValue="none" value={segregation.numberOfParentsUnaffectedCarriers}
+            <Input type="select" ref="unaffectedcarriers" label="# parents who are unaffected carriers" defaultValue="none" value={segregation.numberOfParentsUnaffectedCarriers}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
@@ -1015,7 +1015,7 @@ var FamilySegregation = function() {
             <Input type="text" ref="noaffected1" label="# affected with 1 variant:" format="number" value={segregation.numberOfAffectedWithOneVariant}
                 error={this.getFormError('noaffected1')} clearError={this.clrFormErrors.bind(null, 'noaffected1')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="text" ref="noaffected2" label="# affected with 2 variants or homozygous for 1:" format="number" value={segregation.numberOfAffectedWithTwoVariants}
+            <Input type="text" ref="noaffected2" label="# affected with 2 different variants or homozygous for 1:" format="number" value={segregation.numberOfAffectedWithTwoVariants}
                 error={this.getFormError('noaffected2')} clearError={this.clrFormErrors.bind(null, 'noaffected2')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="text" ref="nounaffectedcarriers" label="# unaffected carriers:" format="number" value={segregation.numberOfUnaffectedCarriers}
@@ -1306,7 +1306,7 @@ var FamilyViewer = React.createClass({
                             </div>
 
                             <div>
-                                <dt>Are parents unaffected carriers</dt>
+                                <dt># parents who are unaffected carriers</dt>
                                 <dd>{segregation && segregation.numberOfParentsUnaffectedCarriers}</dd>
                             </div>
 
@@ -1321,7 +1321,7 @@ var FamilyViewer = React.createClass({
                             </div>
 
                             <div>
-                                <dt># affected with 2 variants or homozygous for 1</dt>
+                                <dt># affected with 2 different variants or homozygous for 1</dt>
                                 <dd>{segregation && segregation.numberOfAffectedWithTwoVariants}</dd>
                             </div>
 


### PR DESCRIPTION
Just text changes to correct/improve wording:

* Curator palette nows shows “Add new Family to this Group” instead of “Add family information.”
* Family curation page now shows “# parents who are unaffected carriers” instead of “Are parents unaffected carriers?” for both creating/editing and viewing.
* Also, it now shows “# affected with 2 different variants or homozygous for 1” instead of “# affected with 2 variants or homozygous for 1.”