### PR TITLE
Connects to #251. Fix search sorting to use new date_created field

### DIFF
--- a/src/clincoded/search.py
+++ b/src/clincoded/search.py
@@ -68,7 +68,7 @@ def get_sort_order():
     specifies sort order for elasticsearch results
     """
     return {
-        'embedded.dateTime': {
+        'embedded.date_created': {
             'order': 'desc',
             'ignore_unmapped': True,
         }


### PR DESCRIPTION
Recent History items should now sort properly on dashboard.

![image](https://cloud.githubusercontent.com/assets/4326866/9388904/0fcd0442-471d-11e5-88ae-b0b12490e595.png)
