### PR TITLE
Connects to #254. Gray out 'View all GDM' link on Dashboard

### DIFF
--- a/src/clincoded/static/components/dashboard.js
+++ b/src/clincoded/static/components/dashboard.js
@@ -148,7 +148,7 @@ var Dashboard = React.createClass({
                             <h3>Tools</h3>
                             <ul>
                                 <li><a href="/create-gene-disease/">Create Gene-Disease Record</a></li>
-                                <li>View list of all Gene-Disease Records</li>
+                                <li><span className="disabled">View list of all Gene-Disease Records</span></li>
                             </ul>
                         </Panel>
                         <Panel panelClassName="panel-dashboard">

--- a/src/clincoded/static/components/dashboard.js
+++ b/src/clincoded/static/components/dashboard.js
@@ -148,7 +148,7 @@ var Dashboard = React.createClass({
                             <h3>Tools</h3>
                             <ul>
                                 <li><a href="/create-gene-disease/">Create Gene-Disease Record</a></li>
-                                <li><a href="/gdm/">View list of all Gene-Disease Records</a></li>
+                                <li>View list of all Gene-Disease Records</li>
                             </ul>
                         </Panel>
                         <Panel panelClassName="panel-dashboard">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -316,3 +316,7 @@
         margin-bottom: 40px;
     }
 }
+
+.disabled {
+    color: $gray-light;
+}


### PR DESCRIPTION
As brought up and discussed in #95 and #254:
![image](https://cloud.githubusercontent.com/assets/4326866/9389642/fb2d88be-4720-11e5-8e1d-2343a7a22196.png)
