### PR TITLE
Connects to #246 Add date_created to annotation properties

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -543,7 +543,7 @@ function cloneSimpleProps(obj, props) {
 }
 
 
-var annotationSimpleProps = ["active"];
+var annotationSimpleProps = ["active", "date_created"];
 
 function flattenAnnotation(annotation) {
     // First copy everything before fixing the special properties


### PR DESCRIPTION
GDMs, groups, and families were all carrying over the date_created value between writes to the DB, but annotations were not. This adds annotations to the objects that do that.

# Testing procedure

1. Create a GDM.
2. Add a PMID; any will do, but note what PMID you use for the next step.
3. Open a window with ```/evidence``` and look through the list until you find one matching your PMID. Open that in its own window to see its JSON, and just keep it open.
4. Record the date_created and last_modified of the annotation.
4. Back on your ClinGen window, add a family.
5. Go back to the /evidence object for your PMID and refresh it.
6. Compare date_created and last_modified with what you had recorded before. The date_created doesn’t change, and last_modified does.
7. If you like, do the same with adding a group.