### PR TITLE
Connects to #249. Fix creation of multiple evidences w/ same article for same GDM

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -248,19 +248,24 @@ var AddPmidModal = React.createClass({
     validateForm: function() {
         // Start with default validation
         var valid = this.validateDefault();
+        var formInput = this.getFormValue('pmid').replace(/^[0]+/g,"");
 
         if (valid) {
-            // valid if the field has only numbers
-            valid = this.getFormValue('pmid').match(/^[0-9]*$/i);
-            if (!valid) this.setFormErrors('pmid', 'Only numbers allowed');
+            valid = formInput.length > 0;
+            if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
             else {
-                valid = this.getFormValue('pmid').length < 9;
-                if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
+                // valid if the field has only numbers
+                valid = formInput.match(/^[0-9]*$/i);
+                if (!valid) this.setFormErrors('pmid', 'Only numbers allowed');
                 else {
-                    for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
-                        if (this.props.currGdm.annotations[i].article.pmid == this.getFormValue('pmid')) {
-                            valid = false;
-                            this.setFormErrors('pmid', 'This article has already been associated with this GDM');
+                    valid = formInput.length < 9;
+                    if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
+                    else {
+                        for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
+                            if (this.props.currGdm.annotations[i].article.pmid == formInput) {
+                                valid = false;
+                                this.setFormErrors('pmid', 'This article has already been associated with this GDM');
+                            }
                         }
                     }
                 }
@@ -286,9 +291,7 @@ var AddPmidModal = React.createClass({
                 return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
                     var newArticle = parsePubmed(xml, enteredPmid);
                     // if the PubMed article for this PMID doesn't exist, display an error
-                    if (newArticle.length == undefined) {
-                        this.setFormErrors('pmid', 'This PMID does not exist');
-                    }
+                    if (newArticle.length == undefined) this.setFormErrors('pmid', 'This PMID does not exist');
                     return this.postRestData('/articles/', newArticle).then(data => {
                         return Promise.resolve(data['@graph'][0]);
                     });
@@ -319,10 +322,8 @@ var AddPmidModal = React.createClass({
                 </div>
                 <div className='modal-footer'>
                     <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
-                    {this.getFormError('pmid') === null || this.getFormError('pmid') === undefined || this.getFormError('pmid') === '' ?
-                        <Input type="submit" inputClassName="btn-primary btn-inline-spacer" title="Add Article" />
-                        : <Input type="submit" inputClassName="btn-primary btn-inline-spacer disabled" title="Add Article" />
-                    }
+                    <Input type="submit" inputClassName={this.getFormError('pmid') === null || this.getFormError('pmid') === undefined || this.getFormError('pmid') === '' ?
+                        "btn-primary btn-inline-spacer" : "btn-primary btn-inline-spacer disabled"} title="Add Article" />
                 </div>
             </Form>
         );

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -248,38 +248,33 @@ var AddPmidModal = React.createClass({
     validateForm: function() {
         // Start with default validation
         var valid = this.validateDefault();
-        var rawInput = this.getFormValue('pmid');
-        var strippedInput = this.getFormValue('pmid').replace(/^[0]+/g,""); // strip leading 0s
+        var formInput = this.getFormValue('pmid');
 
+        // valid if input isn't zero-filled or is not longer than 8 characters
+        if (valid && (formInput.match(/^0+$/) || formInput.length > 8)) {
+            valid = false;
+            this.setFormErrors('pmid', 'This PMID does not exist');
+        }
+        // valid if input isn't zero-leading
+        if (valid && formInput.match(/^0+/)) {
+            valid = false;
+            this.setFormErrors('pmid', 'Please re-enter PMID without any leading 0\'s');
+        }
+        // valid if the input only has numbers
+        if (valid && !formInput.match(/^[0-9]*$/)) {
+            valid = false;
+            this.setFormErrors('pmid', 'Only numbers allowed');
+        }
+        // valid if input isn't already associated with GDM
         if (valid) {
-            // valid if input isn't zero-filled
-            valid = strippedInput.length > 0;
-            if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
-            else {
-                // valid if input isn't zero-leading (but not zero-filled)
-                valid = rawInput.length == strippedInput.length;
-                if (!valid) this.setFormErrors('pmid', 'Please re-enter PMID without any leading 0\'s');
-                else {
-                    // valid if the input has only numbers
-                    valid = rawInput.match(/^[0-9]*$/i);
-                    if (!valid) this.setFormErrors('pmid', 'Only numbers allowed');
-                    else {
-                        // valid if the input is at most 8 numbers long
-                        valid = rawInput.length < 9;
-                        if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
-                        else {
-                            // valid if input isn't already associated with GDM
-                            for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
-                                if (this.props.currGdm.annotations[i].article.pmid == rawInput) {
-                                    valid = false;
-                                    this.setFormErrors('pmid', 'This article has already been associated with this Gene-Disease Record');
-                                }
-                            }
-                        }
-                    }
+            for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
+                if (this.props.currGdm.annotations[i].article.pmid == formInput) {
+                    valid = false;
+                    this.setFormErrors('pmid', 'This article has already been associated with this Gene-Disease Record');
                 }
             }
         }
+
         return valid;
     },
 

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -258,7 +258,7 @@ var AddPmidModal = React.createClass({
             else {
                 // valid if input isn't zero-leading (but not zero-filled)
                 valid = rawInput.length == strippedInput.length;
-                if (!valid) this.setFormErrors('pmid', 'Please re-enter PubMed ID without any leading 0\'s');
+                if (!valid) this.setFormErrors('pmid', 'Please re-enter PMID without any leading 0\'s');
                 else {
                     // valid if the input has only numbers
                     valid = rawInput.match(/^[0-9]*$/i);
@@ -325,7 +325,7 @@ var AddPmidModal = React.createClass({
         return (
             <Form submitHandler={this.submitForm} formClassName="form-std">
                 <div className="modal-body">
-                    <Input type="text" ref="pmid" label="Enter a PubMed ID"
+                    <Input type="text" ref="pmid" label="Enter a PMID"
                         error={this.getFormError('pmid')} clearError={this.clrFormErrors.bind(null, 'pmid')}
                         labelClassName="control-label" groupClassName="form-group" required />
                 </div>

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -258,7 +258,7 @@ var AddPmidModal = React.createClass({
             else {
                 // valid if input isn't zero-leading (but not zero-filled)
                 valid = rawInput.length == strippedInput.length;
-                if (!valid) this.setFormErrors('pmid', 'Did you mean the PMID "' + strippedInput + '"? Please remove any leading 0\'s from your PMID');
+                if (!valid) this.setFormErrors('pmid', 'Please re-enter PubMed ID without any leading 0\'s');
                 else {
                     // valid if the input has only numbers
                     valid = rawInput.match(/^[0-9]*$/i);
@@ -272,7 +272,7 @@ var AddPmidModal = React.createClass({
                             for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
                                 if (this.props.currGdm.annotations[i].article.pmid == rawInput) {
                                     valid = false;
-                                    this.setFormErrors('pmid', 'This article has already been associated with this GDM');
+                                    this.setFormErrors('pmid', 'This article has already been associated with this Gene-Disease Record');
                                 }
                             }
                         }

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -248,23 +248,32 @@ var AddPmidModal = React.createClass({
     validateForm: function() {
         // Start with default validation
         var valid = this.validateDefault();
-        var formInput = this.getFormValue('pmid').replace(/^[0]+/g,"");
+        var rawInput = this.getFormValue('pmid');
+        var strippedInput = this.getFormValue('pmid').replace(/^[0]+/g,""); // strip leading 0s
 
         if (valid) {
-            valid = formInput.length > 0;
+            // valid if input isn't zero-filled
+            valid = strippedInput.length > 0;
             if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
             else {
-                // valid if the field has only numbers
-                valid = formInput.match(/^[0-9]*$/i);
-                if (!valid) this.setFormErrors('pmid', 'Only numbers allowed');
+                // valid if input isn't zero-leading (but not zero-filled)
+                valid = rawInput.length == strippedInput.length;
+                if (!valid) this.setFormErrors('pmid', 'Did you mean the PMID "' + strippedInput + '"? Please remove any leading 0\'s from your PMID');
                 else {
-                    valid = formInput.length < 9;
-                    if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
+                    // valid if the input has only numbers
+                    valid = rawInput.match(/^[0-9]*$/i);
+                    if (!valid) this.setFormErrors('pmid', 'Only numbers allowed');
                     else {
-                        for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
-                            if (this.props.currGdm.annotations[i].article.pmid == formInput) {
-                                valid = false;
-                                this.setFormErrors('pmid', 'This article has already been associated with this GDM');
+                        // valid if the input is at most 8 numbers long
+                        valid = rawInput.length < 9;
+                        if (!valid) this.setFormErrors('pmid', 'This PMID does not exist');
+                        else {
+                            // valid if input isn't already associated with GDM
+                            for (var i = 0; i < this.props.currGdm.annotations.length; i++) {
+                                if (this.props.currGdm.annotations[i].article.pmid == rawInput) {
+                                    valid = false;
+                                    this.setFormErrors('pmid', 'This article has already been associated with this GDM');
+                                }
                             }
                         }
                     }

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -319,7 +319,10 @@ var AddPmidModal = React.createClass({
                 </div>
                 <div className='modal-footer'>
                     <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
-                    <Input type="submit" inputClassName={this.getFormError('pmid') === null || this.getFormError('pmid') === undefined || this.getFormError('pmid') === '' ? "btn-primary btn-inline-spacer" : "btn-primary btn-inline-spacer disabled"} title="Add Article" />
+                    {this.getFormError('pmid') === null || this.getFormError('pmid') === undefined || this.getFormError('pmid') === '' ?
+                        <Input type="submit" inputClassName="btn-primary btn-inline-spacer" title="Add Article" />
+                        : <Input type="submit" inputClassName="btn-primary btn-inline-spacer disabled" title="Add Article" />
+                    }
                 </div>
             </Form>
         );

--- a/src/clincoded/static/components/dashboard.js
+++ b/src/clincoded/static/components/dashboard.js
@@ -42,7 +42,6 @@ var Dashboard = React.createClass({
         // loop through an gdmSubItem and map its subitems' UUIDs to the GDM UUID and Disease/Gene/Mode data
         if (gdmSubItem.length > 0) {
             for (var i = 0; i < gdmSubItem.length; i++) {
-                var tempExtraInfo = {};
                 // create mapping object
                 gdmMapping[gdmSubItem[i].uuid] = {
                     uuid: gdmUuid,
@@ -198,7 +197,7 @@ var Dashboard = React.createClass({
                             <h3>Tools</h3>
                             <ul>
                                 <li><a href="/create-gene-disease/">Create Gene-Disease Record</a></li>
-                                <li><span className="disabled">View list of all Gene-Disease Records</span></li>
+                                <li><span className="disabled-gray">View list of all Gene-Disease Records</span></li>
                             </ul>
                         </Panel>
                         <Panel panelClassName="panel-dashboard">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -332,6 +332,6 @@
     color: #c0c0c0;
 }
 
-.disabled {
+.disabled-gray {
     color: $gray-light;
 }


### PR DESCRIPTION
No visible change, but a user should not be able to re-add an article if it has been already associated with a GDM, regardless of ownership (this might change in the future).

Testing:
1. Create GDM
2. Add a PMID to GDM.
3. Check the GDM's JSON object. The size of `annotations` should be 1.
4. Add a new/different PMID to GDM. The size of `annotations` should be 2.
5. Add the first PMID again. The interface should select that particular PMID, but the size of the JSON's `annotations` should remain 2.