### PR TITLE
Connects to #144 prevent enter/return from closing add PMID/OMIM ID modals

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -313,7 +313,13 @@ var AddPmidModal = React.createClass({
     // nothing happened.
     cancelForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-        this.props.closeModal();
+        
+        //only a mouse click on cancel button closes modal
+        //(do not let the enter key [which evaluates to 0 mouse 
+        //clicks] be accepted to close modal)
+        if (e.detail >= 1){
+            this.props.closeModal();
+        }
     },
 
     render: function() {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -357,7 +357,13 @@ var AddOmimIdModal = React.createClass({
     // nothing happened.
     cancelForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-        this.props.closeModal();
+        
+        //only a mouse click on cancel button closes modal
+        //(do not let the enter key [which evaluates to 0 mouse 
+        //clicks] be accepted to close modal)
+        if (e.detail >= 1){
+            this.props.closeModal();
+        }
     },
 
     render: function() {


### PR DESCRIPTION
In this implementation for the PMID and OMIM ID add/change modals the "Cancel" button (or first button after input field  [if the "Submit" button were before the Cancel button that would be the default instead]) becomes the new target after a user has clicked in the input field (even if the input field is still highlighted as "active"). Subsequently hitting "enter" (which is then being interpreted as a "mouse click" event on the cancel button) then triggers the modal to close without submitting any info present in the input field  or warning that the info entered is being discarded (the "Cancel" button is linked to the "cancelForm" method which only closes the modal).

Using the event.detail property in cancelForm we can determine if the user has actually clicked the cancel button (not just the hit return/enter [we are unable to capture the keycode of the keypress currently]) because there are no actual mouse clicks on "Cancel" if you just hit return/enter. https://developer.mozilla.org/en-US/docs/Web/API/Event/detail

This PR adds a check that the number of clicks is more than 1 to prevent the form from being submitted on "Return/Enter". The React SyntheticMouseEvent.detail associated with pressing return/enter has a value of 0 while an actual click is 1 (double click would be 2). The SyntheticMouseEvent does not have keypress charcode info (to check for charcode===13) which can be used in this case.

To test PMID:
-Create GDM
-Click button to add PMID (modal opens)
-Click "Cancel" (modal closes)
-Click button to add PMID (modal opens)
-Click inside text box, hit "Enter" (modal remains open)
-Click inside text box, enter numbers, hit "Enter" (modal remains open)
-Click "Cancel" (PMID modal closes)
-Click button to add PMID (modal opens)
-Click inside text box, add numbers, hit "Enter" (modal remains open)
-Click "Add Article" (pmid is added, modal closes, new pmid info is selected/displayed on GDM)

To test OMIM ID modal:
-Create GDM
-Click "Add" to add OMIM (modal opens)
-Click "Cancel" (modal closes)
-Click button to add OMIM (modal opens)
-Click inside text box, hit "Enter" (modal remains open)
-Click inside text box, enter numbers, hit "Enter" (modal remains open)
-Click "Cancel" (OMIM modal closes)
-Click button to add OMIM (modal opens)
-Click inside text box, add numbers, hit "Enter" (modal remains open)
-Click "Add OMIM" (OMIM is added, modal closes, new OMIM info is displayed on GDM)








