### PR TITLE
Connects to #282 ft prealpha2

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -813,7 +813,7 @@ var FamilyCuration = React.createClass({
                                             </Panel>
                                         </PanelGroup>
                                         <PanelGroup accordion>
-                                            <Panel title="Family — Variant(s) segregating with Proband" open>
+                                            <Panel title="Family — Variant(s) Segregating with Proband" open>
                                                 {FamilyVariant.call(this)}
                                             </Panel>
                                         </PanelGroup>
@@ -1234,7 +1234,7 @@ var FamilyViewer = React.createClass({
                             </h2>
                         : null}
                     </div>
-                    <Panel title="Common diseases &amp; phenotypes" panelClassName="panel-data">
+                    <Panel title="Common Diseases &amp; Phenotypes" panelClassName="panel-data">
                         <dl className="dl-horizontal">
                             <div>
                                 <dt>Orphanet Common Diagnosis</dt>
@@ -1439,7 +1439,7 @@ var FamilyViewer = React.createClass({
                         </dl>
                     </Panel>
 
-                    <Panel title="Family - Variant(s) associated with Proband" panelClassName="panel-data">
+                    <Panel title="Family - Variant(s) Associated with Proband" panelClassName="panel-data">
                         {variants.map(function(variant, i) {
                             return (
                                 <div className="variant-view-panel">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -262,7 +262,7 @@ var FamilyCuration = React.createClass({
             if (value) {
                 valid = value.match(/^\s*(\d{1,10})\s*$/i);
                 if (!valid) {
-                    this.setFormErrors('VARclinvarid' + i, 'Use ClinVar VariantIDs (e.g. 177676)');
+                    this.setFormErrors('VARclinvarid' + i, 'Use ClinVar VariationIDs (e.g. 177676)');
                     anyInvalid = true;
                 }
             }
@@ -949,7 +949,7 @@ var LabelHpoId = React.createClass({
         return (
             <span>
                 {this.props.not ? <span style={{color: 'red'}}>NOT </span> : <span>Shared </span>}
-                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://www.human-phenotype-ontology.org/hpoweb/showterm?id=HP:0000118" target="_blank" title="HPO Browser in a new tab">HPO Browser</a>)</span>:
+                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://bioportal.bioontology.org/ontologies/HP?p=classes&conceptid=root" target="_blank" title="Bioportal Human Phenotype Ontology in a new tab">HPO lookup at Bioportal</a>)</span>:
             </span>
         );
     }
@@ -1131,7 +1131,7 @@ var FamilyVariant = function() {
                         following submission of Family information.
                     </p>
                     <p className="col-sm-7 col-sm-offset-5">
-                        ClinVar VariantID should be provided in all instances it exists. This is the only way to associate probands from different studies with
+                        ClinVar VariationID should be provided in all instances it exists. This is the only way to associate probands from different studies with
                         the same variant, and ensures the accurate counting of probands.
                     </p>
                 </div>
@@ -1149,7 +1149,7 @@ var FamilyVariant = function() {
                             error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                             labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
                         <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                            The VariantID is the number found after <strong>/variation/</strong> in the URL for a variant in ClinVar (<a href="http://www.ncbi.nlm.nih.gov/clinvar/variation/139214/" target="_blank">example</a>: 139214).
+                            The VariationID is the number found after <strong>/variation/</strong> in the URL for a variant in ClinVar (<a href="http://www.ncbi.nlm.nih.gov/clinvar/variation/139214/" target="_blank">example</a>: 139214).
                         </p>
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                             labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
@@ -1180,7 +1180,7 @@ var FamilyVariant = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariantID:</span>;
+        return <span><a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:</span>;
     }
 });
 
@@ -1446,7 +1446,7 @@ var FamilyViewer = React.createClass({
                                     <h5>Variant {i + 1}</h5>
                                     <dl className="dl-horizontal">
                                         <div>
-                                            <dt>ClinVar VariantID</dt>
+                                            <dt>ClinVar VariationID</dt>
                                             <dd>{variant.clinvarVariantId}</dd>
                                         </div>
 

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -514,7 +514,7 @@ var LabelHpoId = React.createClass({
         return (
             <span>
                 {this.props.not ? <span style={{color: 'red'}}>NOT </span> : <span>Shared </span>}
-                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://www.human-phenotype-ontology.org/hpoweb/showterm?id=HP:0000118" target="_blank" title="HPO Browser home page in a new tab">HPO Browser</a>)</span>:
+                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://bioportal.bioontology.org/ontologies/HP?p=classes&conceptid=root" target="_blank" title="Bioportal Human Phenotype Ontology in a new tab">HPO lookup at Bioportal</a>)</span>:
             </span>
         );
     }

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -407,7 +407,7 @@ var GroupCuration = React.createClass({
                                             {GroupName.call(this)}
                                         </Panel>
                                         <PanelGroup accordion>
-                                            <Panel title="Common diseases &amp; phenotypes" open>
+                                            <Panel title="Common Diseases &amp; Phenotypes" open>
                                                 {GroupCommonDiseases.call(this)}
                                             </Panel>
                                         </PanelGroup>
@@ -688,7 +688,7 @@ var GroupViewer = React.createClass({
             <div className="container">
                 <div className="row curation-content-viewer">
                     <h1>View Group: {context.label}</h1>
-                    <Panel title="Common diseases &amp; phenotypes" panelClassName="panel-data">
+                    <Panel title="Common Diseases &amp; Phenotypes" panelClassName="panel-data">
                         <dl className="dl-horizontal">
                             <div>
                                 <dt>Orphanet Common Diagnosis</dt>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1125,7 +1125,7 @@ var IndividualViewer = React.createClass({
         var i = 0;
         var groupRenders = [];
         var probandLabel = (individual && individual.proband ? ' [proband]' : '');
-        var variantTitle = (individual && !individual.proband) ? 'Individual — Associated Variant(s)' : 'Individual' + probandLabel + ' – Variant(s) Segregating with Proband';
+        var variantTitle = (individual && individual.associatedFamilies.length && individual.proband) ? 'Individual' + probandLabel + ' – Variant(s) segregating with Proband' : 'Individual — Associated Variant(s)';
 
         // Collect all families to render, as well as groups associated with these families
         var familyRenders = individual.associatedFamilies.map(function(family, j) {

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -653,7 +653,7 @@ var IndividualCuration = React.createClass({
         var method = (individual && individual.method && Object.keys(individual.method).length) ? individual.method : {};
         var submitErrClass = 'submit-err pull-right' + (this.anyFormErrors() ? '' : ' hidden');
         var probandLabel = (individual && individual.proband ? ' [proband]' : '');
-        var variantTitle = (individual && !individual.proband) ? 'Individual — Associated Variant(s)' : 'Individual' + probandLabel + ' – Variant(s) segregating with Proband';
+        var variantTitle = (individual && individual.associatedFamilies.length && individual.proband) ? 'Individual' + probandLabel + ' – Variant(s) segregating with Proband' : 'Individual — Associated Variant(s)';
 
         // Get a list of associated groups if editing an individual, or the group in the query string if there was one, or null.
         var groups = (individual && individual.associatedGroups) ? individual.associatedGroups :
@@ -1180,7 +1180,7 @@ var IndividualViewer = React.createClass({
                             : null}
                         </h2>
                     </div>
-                    <Panel title={'Individual' + probandLabel + ' — Common diseases &amp; phenotypes'} panelClassName="panel-data">
+                    <Panel title={'Individual' + probandLabel + ' — Common diseases & phenotypes'} panelClassName="panel-data">
                         <dl className="dl-horizontal">
                             <div>
                                 <dt>Orphanet Common Diagnosis</dt>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -736,7 +736,7 @@ var IndividualCuration = React.createClass({
                                             {IndividualName.call(this)}
                                         </Panel>
                                         <PanelGroup accordion>
-                                            <Panel title={'Individual' + probandLabel + ' – Disease & Phenotype(s)'} open>
+                                            <Panel title={'Individual' + probandLabel + ' – Disease & Phenotypes'} open>
                                                 {IndividualCommonDiseases.call(this)}
                                             </Panel>
                                         </PanelGroup>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1125,7 +1125,7 @@ var IndividualViewer = React.createClass({
         var i = 0;
         var groupRenders = [];
         var probandLabel = (individual && individual.proband ? ' [proband]' : '');
-        var variantTitle = (individual && !individual.proband) ? 'Individual — Associated Variant(s)' : 'Individual' + probandLabel + ' – Variant(s) segregating with Proband';
+        var variantTitle = (individual && !individual.proband) ? 'Individual — Associated Variant(s)' : 'Individual' + probandLabel + ' – Variant(s) Segregating with Proband';
 
         // Collect all families to render, as well as groups associated with these families
         var familyRenders = individual.associatedFamilies.map(function(family, j) {
@@ -1180,7 +1180,7 @@ var IndividualViewer = React.createClass({
                             : null}
                         </h2>
                     </div>
-                    <Panel title={'Individual' + probandLabel + ' — Diseases & phenotype(s)'} panelClassName="panel-data">
+                    <Panel title={'Individual' + probandLabel + ' — Diseases & Phenotype(s)'} panelClassName="panel-data">
                         <dl className="dl-horizontal">
                             <div>
                                 <dt>Orphanet Common Diagnosis</dt>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -277,7 +277,7 @@ var IndividualCuration = React.createClass({
             if (value) {
                 valid = value.match(/^\s*(\d{1,10})\s*$/i);
                 if (!valid) {
-                    this.setFormErrors('VARclinvarid' + i, 'Use ClinVar VariantIDs (e.g. 177676)');
+                    this.setFormErrors('VARclinvarid' + i, 'Use ClinVar VariationIDs (e.g. 177676)');
                     anyInvalid = true;
                 }
             }
@@ -901,7 +901,7 @@ var LabelHpoId = React.createClass({
         return (
             <span>
                 {this.props.not ? <span style={{color: 'red'}}>NOT </span> : ''}
-                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://www.human-phenotype-ontology.org/hpoweb/showterm?id=HP:0000118" target="_blank" title="HPO Browser in a new tab">HPO Browser</a>)</span>:
+                Phenotype(s) <span style={{fontWeight: 'normal'}}>(HPO ID(s); <a href="http://bioportal.bioontology.org/ontologies/HP?p=classes&conceptid=root" target="_blank" title="Bioportal Human Phenotype Ontology in a new tab">HPO lookup at Bioportal</a>)</span>:
             </span>
         );
     }
@@ -1017,7 +1017,7 @@ var IndividualVariantInfo = function() {
                                 <h5>Variant {i + 1}</h5>
                                 <dl className="dl-horizontal">
                                     <div>
-                                        <dt>ClinVar VariantID</dt>
+                                        <dt>ClinVar VariationID</dt>
                                         <dd>{variant.clinvarVariantId}</dd>
                                     </div>
 
@@ -1043,7 +1043,7 @@ var IndividualVariantInfo = function() {
                                 <option>No</option>
                             </Input>
                             <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                                ClinVar VariantID should be provided in all instances it exists. This is the only way to associate probands from different studies with
+                                ClinVar VariationID should be provided in all instances it exists. This is the only way to associate probands from different studies with
                                 the same variant, and ensures the accurate counting of probands.
                             </p>
                         </div>
@@ -1062,7 +1062,7 @@ var IndividualVariantInfo = function() {
                                     error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
                                 <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                                    The VariantID is the number found after <strong>/variation/</strong> in the URL for a variant in ClinVar (<a href="http://www.ncbi.nlm.nih.gov/clinvar/variation/139214/" target="_blank">example</a>: 139214).
+                                    The VariationID is the number found after <strong>/variation/</strong> in the URL for a variant in ClinVar (<a href="http://www.ncbi.nlm.nih.gov/clinvar/variation/139214/" target="_blank">example</a>: 139214).
                                 </p>
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
@@ -1082,7 +1082,7 @@ var IndividualVariantInfo = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariantID:</span>;
+        return <span><a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:</span>;
     }
 });
 
@@ -1308,7 +1308,7 @@ var IndividualViewer = React.createClass({
                                     <h5>Variant {i + 1}</h5>
                                     <dl className="dl-horizontal">
                                         <div>
-                                            <dt>ClinVar VariantID</dt>
+                                            <dt>ClinVar VariationID</dt>
                                             <dd>{variant.clinvarVariantId}</dd>
                                         </div>
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -573,7 +573,7 @@ var IndividualCuration = React.createClass({
             newIndividual.diagnosis = individualDiseases['@graph'].map(function(disease) { return disease['@id']; });
         }
 
-        // Fill in the individual fields from the Common Diseases & Phenotypes panel
+        // Fill in the individual fields from the Diseases & Phenotypes panel
         if (hpoids && hpoids.length) {
             newIndividual.hpoIdInDiagnosis = hpoids;
         }
@@ -736,7 +736,7 @@ var IndividualCuration = React.createClass({
                                             {IndividualName.call(this)}
                                         </Panel>
                                         <PanelGroup accordion>
-                                            <Panel title={'Individual' + probandLabel + ' – Common Disease & Phenotypes'} open>
+                                            <Panel title={'Individual' + probandLabel + ' – Disease & Phenotype(s)'} open>
                                                 {IndividualCommonDiseases.call(this)}
                                             </Panel>
                                         </PanelGroup>
@@ -825,7 +825,7 @@ var IndividualCount = function() {
 };
 
 
-// Common diseases individual curation panel. Call with .call(this) to run in the same context
+// Diseases individual curation panel. Call with .call(this) to run in the same context
 // as the calling component.
 var IndividualCommonDiseases = function() {
     var individual = this.state.individual;
@@ -1180,7 +1180,7 @@ var IndividualViewer = React.createClass({
                             : null}
                         </h2>
                     </div>
-                    <Panel title={'Individual' + probandLabel + ' — Common diseases & phenotypes'} panelClassName="panel-data">
+                    <Panel title={'Individual' + probandLabel + ' — Diseases & phenotype(s)'} panelClassName="panel-data">
                         <dl className="dl-horizontal">
                             <div>
                                 <dt>Orphanet Common Diagnosis</dt>


### PR DESCRIPTION
#### Testing Procedure

###### Family Variants

1. From the Record Curation page, click **Family +**. You’ll go to the Family Curation page.
2. Scroll down to the “Family — Variants segregating with Proband” panel. All instructional text within that panel uses “VariationID” instead of the previous “VariantID,” as does the “ClinVar VariationID” field title.

###### Family Variants / “Common” Removal

1. Again from the Record Curation page, click **Individual +**. You’ll go to the Individual Curation page.
2. Scroll down to the “Family — Associated Variant(s) panel. All instructional text within that panel uses “VariationID” instead of the previous “VariantID,” as does the “ClinVar VariationID” field title.
3. Scroll back to the top panel and note that it says “Diseases & Phenotypes” instead of “Common Diseases & Phenotypes.”
3. Create an Individual for the next step, and go back to Record Curation.


###### ```&amp;``` HTML Entity / “Common” Removal

1. Click the **View** link panel.
2. The panel used to say “Common Diseases ```&amp;``` Phenotypes.” It now says “Diseases and Phenotypes.”


###### HPO Browser Link Change

1. Go to each of Group, Family, and Individual Curation.
2. The top collapsable panel (diseases and phenotypes) of each has two HPO fields. Assure that each link text is “HPO lookup at Bioportal” and links to [here](http://bioportal.bioontology.org/ontologies/HP?p=classes&conceptid=root), and has the tooltip “Bioportal Human Phenotype Ontology in a new tab.”


###### Individual View Title

1. From Record Curation, click the **View** link for the non-proband individual you created above.
2. Scroll down to its Variants panel and note the panel’s title says, “Individual — Associated Variant(s)” instead of “Variant(s) segregating with Proband.”