### PR TITLE
Connects to #265 allow grunt unminified JS, update docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,9 @@ module.exports = function(grunt) {
         return '../../' + p;
     }
 
+    grunt.config('env', grunt.option('env') || process.env.GRUNT_ENV || 'production');
+    var minifyEnabled = grunt.config('minifyEnabled', grunt.config('env') === 'production');
+
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         browserify: {
@@ -25,6 +28,7 @@ module.exports = function(grunt) {
                 ],
                 plugin: [
                     ['minifyify', {
+                        minify: minifyEnabled,
                         map: 'brace.js.map',
                         output: './src/clincoded/static/build/brace.js.map',
                         compressPath: compressPath,
@@ -48,6 +52,7 @@ module.exports = function(grunt) {
                 ],
                 plugin: [
                     ['minifyify', {
+                        minify: minifyEnabled,
                         map: '/static/build/inline.js.map',
                         output: './src/clincoded/static/build/inline.js.map',
                         compressPath: compressPath,
@@ -77,6 +82,7 @@ module.exports = function(grunt) {
                 ],
                 plugin: [
                     ['minifyify', {
+                        minify: minifyEnabled,
                         map: 'bundle.js.map',
                         output: './src/clincoded/static/build/bundle.js.map',
                         compressPath: compressPath,
@@ -97,8 +103,9 @@ module.exports = function(grunt) {
                     'envify',
                 ],
                 plugin: [
-                    ['minifyify', {map:
-                        'renderer.js.map',
+                    ['minifyify', {
+                        minify: minifyEnabled,
+                        map:'renderer.js.map',
                         output: './src/clincoded/static/build/renderer.js.map',
                         compressPath: compressPath,
                         uglify: {mangle: process.env.NODE_ENV == 'production'},

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Note: These will all be installed locally for the application and should never c
 Step 1b: Run buildout::
 
     $ python3.4 bootstrap.py -v 2.3.1 --setuptools-version 15.2
-    $ bin/buildout
+    $ bin/buildout -c buildout-dev.cfg
 
 If you see a clang error like this::
 
@@ -140,8 +140,8 @@ If you wish a clean db wipe for DEVELOPMENT::
 
 Database setup on VMs::
 
-    # service postgresql-9.3 initdb
-    # service postgresql-9.3 start
+    # service postgresql-9.4 initdb
+    # service postgresql-9.4 start
     # sudo -u postgres createuser --createdb clincoded
 
 Then as the clincoded user::

--- a/buildout-dev.cfg
+++ b/buildout-dev.cfg
@@ -1,0 +1,13 @@
+[buildout]
+extends = buildout.cfg
+
+
+[grunt]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/sh
+    export NODE_PATH=${buildout:directory}/node_modules
+    ulimit -n 1024
+    exec ${buildout:directory}/node_modules/.bin/grunt --env=development $@
+output = ${buildout:bin-directory}/grunt
+mode = 755


### PR DESCRIPTION
For development it is more helpful to be able to look at unminified JS.

To test:

`bin/buildout -c buildout-dev.cfg`

This sets the new default for grunt to have an env of development (you can still run `bin/grunt --env=production` to have JS be minified, or alternatively run buildout without the dev config file `bin/buildout` as before which make `bin/grunt` no longer default to "development" unminified mode)


Results:

--on the filesystem:  `src/clincoded/static/build/bundle.js`   will no longer be minified  (code should be readable)


--on browser: 
-Launch site after running buildout as above
-Open "Chrome Dev Tools" in Chrome
-Navigate to "Sources" and look for bundle.js and click on it (static/build/bundle.js)
-bundle.js should be readable and maintain original formatting (i.e. it is compiled still but readable)
-http://localhost:6543/static/build/bundle.js


Readme file has also been updated to reflect using `bin/buildout -c buildout-dev.cfg` for local development (and updated references from Postgres 9.3 to 9.4)
