### PR TITLE
Connects to #292 Don’t write to <option> in DOM

### DIFF
--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -242,19 +242,11 @@ var Input = module.exports.Input = React.createClass({
     },
 
     resetSelectedOption: function() {
-        var optionNodes = this.refs.input.getDOMNode().getElementsByTagName('option');
-
-        // Get the DOM node for the selected <option>
-        var selectedOptionNode = _(optionNodes).find(function(option) {
-            return option.selected;
-        });
-
-        // Clear the selected option and set it to the first option
-        if (selectedOptionNode) {
-            selectedOptionNode.selected = false;
-            optionNodes[0] = true;
+        var selectNode = this.refs.input.getDOMNode();
+        var optionNodes = selectNode.getElementsByTagName('option');
+        if (optionNodes && optionNodes.length) {
+            selectNode.value = optionNodes[0].value;
         }
-
     },
 
     // Get the selected option from a <select> list


### PR DESCRIPTION
To text fix, follow @mrmin123 procedure:

1. Navigate to site in Firefox browser (I’m using FF 37.0.2)
2. Create/navigate to GDM
3. Add/select evidence
4. Click button to add Group, Family, Individual, or Experimental Data item
5. Fill out form
6. Hit Submit

With this fix, you’ll now go to the appropriate submit results page.