### PR TITLE
Connects to #327 kd googleanalytics beta tag

### DIFF
--- a/src/clincoded/static/inline.js
+++ b/src/clincoded/static/inline.js
@@ -8,23 +8,32 @@ var cookie = require('cookie-monster')(document);
 window.stats_cookie = cookie.get('X-Stats') || '';
 cookie.set('X-Stats', '', {path: '/', expires: new Date(0)});
 
-// Use a separate tracker for dev / test
+
 var ga = require('google-analytics');
 
-var analyticsTrackerHostname = document.location.hostname;
+//existing trackers for gene curation app
 var trackers = {
     'curation.clinicalgenome.org': 'UA-49947422-4',
     'curation-beta.clinicalgenome.org': 'UA-49947422-6',
     'curation-demo.clinicalgenome.org': 'UA-49947422-5'
 };
 
-if (/^curation-beta(.*)/.test(analyticsTrackerHostname)){
+//determine current hostname
+var analyticsTrackerHostname = document.location.hostname;
+
+//match hostname to google analytics domain identified for tracker
+if (/^(www\.)?curation.clinicalgenome.org/.test(analyticsTrackerHostname)) {
+    //production app
+    analyticsTrackerHostname = 'curation.clinicalgenome.org';
+} else if (/^curation-beta.*.clinicalgenome.org/.test(analyticsTrackerHostname)){
+    //all curation-beta variants
     analyticsTrackerHostname = 'curation-beta.clinicalgenome.org';
-} else if (/^.*.demo.clinicalgenome.org/.test(analyticsTrackerHostname) || /^localhost/.test(analyticsTrackerHostname){
+} else {
+    //catch-all
     analyticsTrackerHostname = 'curation-demo.clinicalgenome.org';
 }
 
-//var tracker = trackers[hostname];
+//use correct tracker based on hostname
 var tracker = trackers[analyticsTrackerHostname];
 
 ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});

--- a/src/clincoded/static/inline.js
+++ b/src/clincoded/static/inline.js
@@ -10,8 +10,23 @@ cookie.set('X-Stats', '', {path: '/', expires: new Date(0)});
 
 // Use a separate tracker for dev / test
 var ga = require('google-analytics');
-var trackers = {'curation.clinicalgenome.org': 'UA-49947422-4'};
-var tracker = trackers[document.location.hostname] || 'UA-49947422-5';
+
+var analyticsTrackerHostname = document.location.hostname;
+var trackers = {
+    'curation.clinicalgenome.org': 'UA-49947422-4',
+    'curation-beta.clinicalgenome.org': 'UA-49947422-6',
+    'curation-demo.clinicalgenome.org': 'UA-49947422-5'
+};
+
+if (/^curation-beta(.*)/.test(analyticsTrackerHostname)){
+    analyticsTrackerHostname = 'curation-beta.clinicalgenome.org';
+} else if (/^.*.demo.clinicalgenome.org/.test(analyticsTrackerHostname) || /^localhost/.test(analyticsTrackerHostname){
+    analyticsTrackerHostname = 'curation-demo.clinicalgenome.org';
+}
+
+//var tracker = trackers[hostname];
+var tracker = trackers[analyticsTrackerHostname];
+
 ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});
 ga('send', 'pageview');
 


### PR DESCRIPTION
Google Analytics tag added for beta instances.

New tag shows correct tracking ID in Google Analytics debugger plugin for various instances

Beta URLS (use beta tracker: UA-49947422-6) info in console shown using Chrome Google Analytics debugger plugin:
![image](https://cloud.githubusercontent.com/assets/1878194/10234448/7ed494ca-6849-11e5-8e27-4d1268d4393c.png)

All other non-production URLs (default to demo tracker: UA-49947422-5) info in console shown using Chrome Google Analytics debugger plugin:

![image](https://cloud.githubusercontent.com/assets/1878194/10234494/bd815a50-6849-11e5-9c54-8f7b68d1bc6d.png)

Google Analytics shows beta tracker being used on test "beta" site (not the real beta site):
![image](https://cloud.githubusercontent.com/assets/1878194/10234657/f67e1072-684a-11e5-8d23-0398c259b075.png)
