### PR TITLE
Connects to #304. Conditional handling of demo notice bar

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -40,7 +40,8 @@ var App = module.exports = React.createClass({
     getInitialState: function() {
         return {
             errors: [],
-            portal: portal
+            portal: portal,
+            demoWarning: !/^(www\.)?curation.clinicalgenome.org/.test(url.parse(this.props.href).hostname)
         };
     },
 
@@ -76,7 +77,7 @@ var App = module.exports = React.createClass({
 
         var appClass = 'done';
         if (this.props.slow) {
-            appClass = 'communicating'; 
+            appClass = 'communicating';
         }
 
         var title = context.title || context.name || context.accession || context['@id'];
@@ -114,7 +115,9 @@ var App = module.exports = React.createClass({
                     }}></script>
                     <div>
                         <Header session={this.state.session} />
+                        {this.state.demoWarning ?
                         <Notice noticeType='danger' noticeMessage={<span><strong>Note:</strong> This is a demo version of the site. Any data you enter will not be permanently saved.</span>} />
+                        : null}
                         {content}
                     </div>
                 </body>


### PR DESCRIPTION
The red 'Note: This is a demo version of the site. Any data you enter will not be permanently saved.' notice bar should disappear when on a production URL (curation.clinicalgenome.org). 

Domain matches production URL:
![image](https://cloud.githubusercontent.com/assets/4326866/10257389/e4d221f8-690b-11e5-8590-20b5ea423410.png)

Domain does not match production URL:
![image](https://cloud.githubusercontent.com/assets/4326866/10257393/ee9099e0-690b-11e5-9d64-d9d3d830df3d.png)

Note: this was tested by changing the regex matching to localhost and testing locally, as we do not have the production site to test against.