### PR TITLE
Connects to #355 allow dev persona login from clinicalgenome.org

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -9,7 +9,7 @@ sqlalchemy.url = postgresql://postgres@:5432/postgres?host=/tmp/clincoded/pgdata
 load_test_only = true
 create_tables = true
 testing = true
-persona.audiences = http://localhost:6543
+persona.audiences = localhost:6543 *.clinicalgenome.org:6543
 postgresql.statement_timeout = 20
 
 pyramid.reload_templates = true


### PR DESCRIPTION
Building on ticket #304/PR #353 (conditional display of demo notice), allow login from testing URL 

To test:
 -`sudo nano /etc/hosts`
 -add the line:
`127.0.0.1       curation.clinicalgenome.org`
 -start app
 -go to http://curation.clinicalgenome.org:6543
 -comment out later or you won't be able to access the production site from your machine

User can login using either  http://localhost:6543 or http://curation.clinicalgenome.org:6543 and will be able to access app.

from http://localhost:6543  (see demo notice)
![image](https://cloud.githubusercontent.com/assets/1878194/10259946/3d9035a2-6923-11e5-8787-1f57cc34b6ee.png)

from http://curation.clinicalgenome.org:6543/  (do not see demo notice)
![image](https://cloud.githubusercontent.com/assets/1878194/10259953/567edc76-6923-11e5-9b66-c8fa09d307e1.png)

