### PR TITLE
Connects to #362. Experimental Data Assessment evidenceType

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -471,7 +471,7 @@ var ExperimentalCuration = React.createClass({
             if (stateObj.experimental) {
                 tempEvidenceType = stateObj.experimental.evidenceType;
             }
-            var assessmentTracker = this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, 'experimental');
+            var assessmentTracker = this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, tempEvidenceType);
             this.setAssessmentValue(assessmentTracker);
 
             // Set all the state variables we've collected


### PR DESCRIPTION
Testing
1. Create GDM
2. Add PMID
3. Add Experimental Data item WITHOUT assessment
4. Edit/View the item and assess.
5. Confirm at `/assessment/` that the new assessment has the correct evidenceType ('Evidence' column) of the experimental data type, not the text 'experimental':
![image](https://cloud.githubusercontent.com/assets/4326866/10297315/20717bb0-6b86-11e5-8415-ca59e05b41a5.png)
