### PR TITLE
Connects to #366. Connects to #367. Connects to #358. Connects to #320. Fix assessments from View page + others

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2055,14 +2055,12 @@ var ExperimentalViewer = React.createClass({
                 // Find the assessment belonging to the logged-in curator, if any.
                 userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
             }
-
             this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, updatedExperimental.evidenceType);
 
             // Wrote the experimental data, so update the assessments state to the new assessment list
             if (updatedExperimental && updatedExperimental.assessments && updatedExperimental.assessments.length) {
                 this.setState({assessments: updatedExperimental.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
-
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('EXPERIMENTAL DATA VIEW UPDATE ERROR: %s', e);
@@ -2084,7 +2082,8 @@ var ExperimentalViewer = React.createClass({
             var experimental = this.props.context;
             var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
             var user = nextProps.session && nextProps.session.user_properties;
-                    // Make an assessment tracker object once we get the logged in user info
+
+            // Make an assessment tracker object once we get the logged in user info
             if (!this.cv.assessmentTracker && user) {
                 var userAssessment;
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2016,36 +2016,54 @@ var ExperimentalViewer = React.createClass({
     assessmentSubmit: function(e) {
         var updatedExperimental;
 
-        // Write the assessment to the DB, if there was one.
-        this.saveAssessment(this.cv.assessmentTracker, this.cv.gdmUuid, this.props.context.uuid).then(assessmentInfo => {
-            var experimental = this.props.context;
+        // GET the experimental object to have the most up-to-date version
+        this.getRestData('/experimental/' + this.props.context.uuid).then(data => {
+            var experimental = data;
 
-            // If we made a new assessment, add it to the experimental data's assessments
-            if (assessmentInfo.assessment && !assessmentInfo.update) {
-                updatedExperimental = curator.flatten(experimental);
-                if (!updatedExperimental.assessments) {
-                    updatedExperimental.assessments = [];
+            return this.saveAssessment(this.cv.assessmentTracker, this.cv.gdmUuid, this.props.context.uuid).then(assessmentInfo => {
+                // If we made a new assessment, add it to the experimental data's assessments
+                if (assessmentInfo.assessment && !assessmentInfo.update) {
+                    updatedExperimental = curator.flatten(experimental);
+                    if (!updatedExperimental.assessments) {
+                        updatedExperimental.assessments = [];
+                    }
+                    updatedExperimental.assessments.push(assessmentInfo.assessment['@id']);
+
+                    // Write the updated experimental data object to the DB
+                    return this.putRestData('/experimental/' + experimental.uuid, updatedExperimental).then(data => {
+                        return this.getRestData('/experimental/' + data['@graph'][0].uuid);
+                    });
                 }
-                updatedExperimental.assessments.push(assessmentInfo.assessment['@id']);
 
-                // Write the updated experimental data object to the DB
-                return this.putRestData('/experimental/' + experimental.uuid, updatedExperimental).then(data => {
-                    return this.getRestData('/experimental/' + data['@graph'][0].uuid);
-                });
-            }
+                // Didn't update the experimental data object; if updated the assessment, reload the experimental data
+                if (assessmentInfo.update) {
+                    return this.getRestData('/experimental/' + experimental.uuid);
+                }
 
-            // Didn't update the experimental data object; if updated the assessment, reload the experimental data
-            if (assessmentInfo.update) {
-                return this.getRestData('/experimental/' + experimental.uuid);
-            }
+                // Not updating the experimental data
+                return Promise.resolve(experimental);
+            });
+        // Write the assessment to the DB, if there was one.
 
-            // Not updating the experimental data
-            return Promise.resolve(experimental);
         }).then(updatedExperimental => {
+            // update the assessmentTracker object so it accounts for any new assessments
+            var userAssessment;
+            var assessments = updatedExperimental.assessments;
+            var user = this.props.session && this.props.session.user_properties;
+
+            // Find if any assessments for the segregation are owned by the currently logged-in user
+            if (assessments && assessments.length) {
+                // Find the assessment belonging to the logged-in curator, if any.
+                userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
+            }
+
+            this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, updatedExperimental.evidenceType);
+
             // Wrote the experimental data, so update the assessments state to the new assessment list
             if (updatedExperimental && updatedExperimental.assessments && updatedExperimental.assessments.length) {
                 this.setState({assessments: updatedExperimental.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
+
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('EXPERIMENTAL DATA VIEW UPDATE ERROR: %s', e);
@@ -2062,6 +2080,25 @@ var ExperimentalViewer = React.createClass({
         }
     },
 
+    componentWillReceiveProps: function(nextProps) {
+        if (typeof nextProps.session.user_properties !== undefined && nextProps.session.user_properties != this.props.session.user_properties) {
+            var experimental = this.props.context;
+            var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
+            var user = nextProps.session && nextProps.session.user_properties;
+                    // Make an assessment tracker object once we get the logged in user info
+            if (!this.cv.assessmentTracker && user) {
+                var userAssessment;
+
+                // Find if any assessments for the segregation are owned by the currently logged-in user
+                if (assessments && assessments.length) {
+                    // Find the assessment belonging to the logged-in curator, if any.
+                    userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
+                }
+                this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
+            }
+        }
+    },
+
     render: function() {
         var experimental = this.props.context;
         var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
@@ -2070,18 +2107,6 @@ var ExperimentalViewer = React.createClass({
         var experimentalUserAssessed = false; // TRUE if logged-in user doesn't own the experimental data, but the experimental data's owner assessed it
         var othersAssessed = false; // TRUE if we own this experimental data, and others have assessed it
         var updateMsg = this.state.updatedAssessment ? 'Assessment updated to ' + this.state.updatedAssessment : '';
-
-        // Make an assessment tracker object once we get the logged in user info
-        if (!this.cv.assessmentTracker && user) {
-            var userAssessment;
-
-            // Find if any assessments for the segregation are owned by the currently logged-in user
-            if (assessments && assessments.length) {
-                // Find the assessment belonging to the logged-in curator, if any.
-                userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
-            }
-            this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
-        }
 
         // See if others have assessed
         if (userExperimental) {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1571,7 +1571,7 @@ var TypeExpressionA = function() {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
                 checked={this.state.expressedInTissue} defaultChecked="false" handleChange={this.handleChange} inputDisabled={this.cv.othersAssessed} />
             <p className="col-sm-7 col-sm-offset-5 hug-top"><strong>Note:</strong> If the gene is not normally expressed in the above tissue, the criteria for counting this experimental evidence has not been met and cannot be submitted. Proceed to section B below or return to <a href={"/curation-central/?gdm=" + this.state.gdm.uuid + "&pmid=" + this.state.annotation.article.pmid}>Curation Central</a>.</p>
-            <Input type="textarea" ref="normalExpression.evidence" label="Change Evidence for normal expression in disease tissue:"
+            <Input type="textarea" ref="normalExpression.evidence" label="Evidence for normal expression in disease tissue:"
                 error={this.getFormError('normalExpression.evidence')} clearError={this.clrFormErrors.bind(null, 'normalExpression.evidence')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
                 rows="5" value={expression.normalExpression.evidence} inputDisabled={!this.state.expressedInTissue || this.cv.othersAssessed} required={this.state.expressedInTissue} />
@@ -2255,7 +2255,7 @@ var ExperimentalViewer = React.createClass({
                             </div>
 
                             <div>
-                                <dt>Change Evidence for normal expression in disease tissue</dt>
+                                <dt>Evidence for normal expression in disease tissue</dt>
                                 <dd>{experimental.expression.normalExpression.evidence}</dd>
                             </div>
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2020,6 +2020,7 @@ var ExperimentalViewer = React.createClass({
         this.getRestData('/experimental/' + this.props.context.uuid).then(data => {
             var experimental = data;
 
+            // Write the assessment to the DB, if there was one.
             return this.saveAssessment(this.cv.assessmentTracker, this.cv.gdmUuid, this.props.context.uuid).then(assessmentInfo => {
                 // If we made a new assessment, add it to the experimental data's assessments
                 if (assessmentInfo.assessment && !assessmentInfo.update) {
@@ -2043,8 +2044,6 @@ var ExperimentalViewer = React.createClass({
                 // Not updating the experimental data
                 return Promise.resolve(experimental);
             });
-        // Write the assessment to the DB, if there was one.
-
         }).then(updatedExperimental => {
             // update the assessmentTracker object so it accounts for any new assessments
             var userAssessment;

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -792,6 +792,7 @@ var LabelPanelTitle = React.createClass({
 // as the calling component.
 var IndividualName = function(displayNote) {
     var individual = this.state.individual;
+    var family = this.state.family;
     var probandLabel = (individual && individual.proband ? <i className="icon icon-proband"></i> : null);
 
     return (
@@ -801,6 +802,21 @@ var IndividualName = function(displayNote) {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
             {displayNote ?
                 <p className="col-sm-7 col-sm-offset-5">Note: If there is more than one individual with IDENTICAL information, you can indicate this at the bottom of this form.</p>
+            : null}
+            {!family ?
+                <div className="clearfix">
+                    <Input type="select" ref="proband" label="Is this Individual a proband:" value={individual && individual.proband ? "Yes" : (individual ? "No" : "none")}
+                        error={this.getFormError('proband')} clearError={this.clrFormErrors.bind(null, 'proband')}
+                        labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required>
+                        <option value="none">No Selection</option>
+                        <option disabled="disabled"></option>
+                        <option>Yes</option>
+                        <option>No</option>
+                    </Input>
+                    <p className="col-sm-7 col-sm-offset-5 input-note-below">
+                        Note: Probands are indicated by the following icon: <i className="icon icon-proband"></i>
+                    </p>
+                </div>
             : null}
         </div>
     );
@@ -1049,22 +1065,6 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
-                    {!family ?
-                        <div className="clearfix">
-                            <Input type="select" ref="proband" label="Is this Individual a proband:" value={individual && individual.proband ? "Yes" : (individual ? "No" : "none")}
-                                error={this.getFormError('proband')} clearError={this.clrFormErrors.bind(null, 'proband')}
-                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required>
-                                <option value="none">No Selection</option>
-                                <option disabled="disabled"></option>
-                                <option>Yes</option>
-                                <option>No</option>
-                            </Input>
-                            <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                                Note: Probands are indicated by the following icon: <i className="icon icon-proband"></i>
-                            </p>
-                        </div>
-                    : null}
-
                     {_.range(this.state.variantCount).map(i => {
                         var variant;
 
@@ -1098,7 +1098,7 @@ var IndividualVariantInfo = function() {
                         );
                     })}
                 </div>
-            }            
+            }
         </div>
     );
 };

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -150,7 +150,7 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
                                         {gdm && annotation ?
                                             <div>
                                                 <a className="btn btn-default btn-individual-submit" href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}>Return to Record Curation page</a>
-                                                <div className="submit-results-note">Return to GDM record if you would like to add or add or edit a group, family, or individual.</div>
+                                                <div className="submit-results-note">Return to Record Curation page if you would like to add or add or edit a group, family, or individual.</div>
                                             </div>
                                         : null}
                                     </div>


### PR DESCRIPTION
### Related to #366:
#### Changes:
On both family_curation and experimental_curation, added GET for the object being curated on so the most updated version of the object is updated, and re-instantiated assessmentTracker after the fact. Also moved the first assessmentTracker instantiation out of render into componentWillReceiveProps so that it is not re-written with old data on re-render.

#### Testing:
1. Create GDM
2. Add PMID
3. Create experimental data and/or family item w/o assessment
4. Go to the item's View page
5. Assess and Update
6. Without refreshing the page, re-assess and update.
7. Confirm at `/assessments/` that only one assessment item exists for the parent experimental data/family item and that it has the correct value.
8. Refresh the View page, re-assess and update.
9. Confirm at `/assessments/` that only one assessment item exists for the parent experimental data/family item and that it has the correct value.

### Related to #367:
Text updated:
![image](https://cloud.githubusercontent.com/assets/4326866/10381774/70cf796a-6dd2-11e5-86cf-4e4928cadf7a.png)

### Related to #358:
The text 'GDM' is visible only at the one reported place, and has been changed.
![image](https://cloud.githubusercontent.com/assets/4326866/10381593/dacda190-6dd0-11e5-8e3a-aff1619dd85a.png)

### Related to #320:
Form location changed:
![image](https://cloud.githubusercontent.com/assets/4326866/10292750/df9a249a-6b65-11e5-933e-97e4cff901b4.png)
