### PR TITLE
Connects to #372. Disable submit buttons on click

### DIFF
--- a/src/clincoded/static/components/assessment.js
+++ b/src/clincoded/static/components/assessment.js
@@ -143,6 +143,7 @@ var AssessmentPanel = module.exports.AssessmentPanel = React.createClass({
         updateValue: React.PropTypes.func.isRequired, // Parent function to call when dropdown changes
         assessmentSubmit: React.PropTypes.func, // Function to call when Save button is clicked; This prop's existence makes the Save button exist
         disableDefault: React.PropTypes.bool, // TRUE to disable the Default (Not Assessed) item
+        submitBusy: React.PropTypes.bool, // TRUE while the form submit is running
         accordion: React.PropTypes.bool, // True if the panel should part of an openable accordion
         open: React.PropTypes.bool, // True if the panel should be an openable panel
         updateMsg: React.PropTypes.string // String to display by the Update button if desired
@@ -180,7 +181,7 @@ var AssessmentPanel = module.exports.AssessmentPanel = React.createClass({
                         </div>
                         {this.props.assessmentSubmit ?
                             <div className="curation-submit clearfix">
-                                <Input type="button" inputClassName="btn-primary pull-right" clickHandler={this.props.assessmentSubmit} title="Update" />
+                                <Input type="button" inputClassName="btn-primary pull-right" clickHandler={this.props.assessmentSubmit} title="Update" submitBusy={this.props.submitBusy} />
                                 {this.props.updateMsg ?
                                     <div className="submit-info pull-right">{this.props.updateMsg}</div>
                                 : null}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -929,10 +929,10 @@ var ExperimentalCuration = React.createClass({
                             } else {
                                 var missingGenes = _.difference(geneSymbols, genes['@graph'].map(function(gene) { return gene.symbol; }));
                                 if (newExperimental.evidenceType == 'Biochemical Function') {
-                                    this.setState({submitBusy: false});
+                                    this.setState({submitBusy: false}); // submit error; re-enable submit button
                                     this.setFormErrors('geneWithSameFunctionSameDisease.genes', missingGenes.join(', ') + ' not found');
                                 } else if (newExperimental.evidenceType == 'Protein Interactions') {
-                                    this.setState({submitBusy: false});
+                                    this.setState({submitBusy: false}); // submit error; re-enable submit button
                                     this.setFormErrors('interactingGenes', missingGenes.join(', ') + ' not found');
                                 }
 
@@ -1096,6 +1096,7 @@ var ExperimentalCuration = React.createClass({
                     // Next step relies on the pathogenicity, not the updated assessment
                     return Promise.resolve(savedExperimental);
                 }).then(data => {
+                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);
@@ -2067,7 +2068,6 @@ var ExperimentalViewer = React.createClass({
             if (updatedExperimental && updatedExperimental.assessments && updatedExperimental.assessments.length) {
                 this.setState({assessments: updatedExperimental.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
-            this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('EXPERIMENTAL DATA VIEW UPDATE ERROR: %s', e);

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1096,7 +1096,7 @@ var ExperimentalCuration = React.createClass({
                     // Next step relies on the pathogenicity, not the updated assessment
                     return Promise.resolve(savedExperimental);
                 }).then(data => {
-                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
+                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on, just in case
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -97,6 +97,7 @@ var ExperimentalCuration = React.createClass({
             variantCount: 0, // Number of variants to display
             variantOption: [], // One variant panel, and nothing entered
             addVariantDisabled: false, // True if Add Another Variant button enabled
+            submitBusy: false // True while form is submitting
         };
     },
 
@@ -913,6 +914,7 @@ var ExperimentalCuration = React.createClass({
                 }
 
                 var searchStr = '';
+                this.setState({submitBusy: true});
                 // Begin with empty promise
                 new Promise(function(resolve, reject) {
                     resolve(1);
@@ -927,8 +929,10 @@ var ExperimentalCuration = React.createClass({
                             } else {
                                 var missingGenes = _.difference(geneSymbols, genes['@graph'].map(function(gene) { return gene.symbol; }));
                                 if (newExperimental.evidenceType == 'Biochemical Function') {
+                                    this.setState({submitBusy: false});
                                     this.setFormErrors('geneWithSameFunctionSameDisease.genes', missingGenes.join(', ') + ' not found');
                                 } else if (newExperimental.evidenceType == 'Protein Interactions') {
+                                    this.setState({submitBusy: false});
                                     this.setFormErrors('interactingGenes', missingGenes.join(', ') + ' not found');
                                 }
 
@@ -1208,7 +1212,7 @@ var ExperimentalCuration = React.createClass({
                                         : null}
                                         {this.state.experimentalType != '' && this.state.experimentalType != 'none' && this.state.experimentalNameVisible ?
                                             <div className="curation-submit clearfix">
-                                                <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" />
+                                                <Input type="submit" inputClassName="btn-primary pull-right" submitBusy={this.state.submitBusy} id="submit" title="Save" />
                                                 <div className={submitErrClass}>Please fix errors on the form and resubmit.</div>
                                             </div>
                                         : null}
@@ -2008,7 +2012,8 @@ var ExperimentalViewer = React.createClass({
     getInitialState: function() {
         return {
             assessments: null, // Array of assessments for the experimental data
-            updatedAssessment: '' // Updated assessment value
+            updatedAssessment: '', // Updated assessment value
+            submitBusy: false // True while form is submitting
         };
     },
 
@@ -2018,6 +2023,7 @@ var ExperimentalViewer = React.createClass({
 
         // GET the experimental object to have the most up-to-date version
         this.getRestData('/experimental/' + this.props.context.uuid).then(data => {
+            this.setState({submitBusy: true});
             var experimental = data;
 
             // Write the assessment to the DB, if there was one.
@@ -2061,6 +2067,7 @@ var ExperimentalViewer = React.createClass({
             if (updatedExperimental && updatedExperimental.assessments && updatedExperimental.assessments.length) {
                 this.setState({assessments: updatedExperimental.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
+            this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('EXPERIMENTAL DATA VIEW UPDATE ERROR: %s', e);
@@ -2486,7 +2493,7 @@ var ExperimentalViewer = React.createClass({
                     : null}
                     {this.cv.gdmUuid && (experimentalUserAssessed || userExperimental) ?
                         <AssessmentPanel panelTitle="Experimental Data Assessment" assessmentTracker={this.cv.assessmentTracker} updateValue={this.updateAssessmentValue}
-                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} updateMsg={updateMsg} />
+                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} submitBusy={this.state.submitBusy} updateMsg={updateMsg} />
                     : null}
                 </div>
             </div>

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1213,7 +1213,7 @@ var ExperimentalCuration = React.createClass({
                                         : null}
                                         {this.state.experimentalType != '' && this.state.experimentalType != 'none' && this.state.experimentalNameVisible ?
                                             <div className="curation-submit clearfix">
-                                                <Input type="submit" inputClassName="btn-primary pull-right" submitBusy={this.state.submitBusy} id="submit" title="Save" />
+                                                <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" submitBusy={this.state.submitBusy} />
                                                 <div className={submitErrClass}>Please fix errors on the form and resubmit.</div>
                                             </div>
                                         : null}
@@ -2068,6 +2068,8 @@ var ExperimentalViewer = React.createClass({
             if (updatedExperimental && updatedExperimental.assessments && updatedExperimental.assessments.length) {
                 this.setState({assessments: updatedExperimental.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
+
+            this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('EXPERIMENTAL DATA VIEW UPDATE ERROR: %s', e);

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -710,6 +710,7 @@ var FamilyCuration = React.createClass({
                 }).then(newFamily => {
                     // Navigate back to Curation Central page.
                     // FUTURE: Need to navigate to Family Submit page.
+                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on, just in case
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut && !initvar) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -981,7 +981,7 @@ var FamilyCuration = React.createClass({
                                             </Panel>
                                         </PanelGroup>
                                         <div className="curation-submit clearfix">
-                                            <Input type="submit" inputClassName="btn-primary pull-right" submitBusy={this.state.submitBusy} id="submit" title="Save" />
+                                            <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" submitBusy={this.state.submitBusy} />
                                             <div className={submitErrClass}>Please fix errors on the form and resubmit.</div>
                                         </div>
                                     </Form>
@@ -1444,6 +1444,7 @@ var FamilyViewer = React.createClass({
             if (updatedFamily && updatedFamily.segregation && updatedFamily.segregation.assessments && updatedFamily.segregation.assessments.length) {
                 this.setState({assessments: updatedFamily.segregation.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
+
             this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
             return Promise.resolve(null);
         }).catch(function(e) {
@@ -1657,7 +1658,7 @@ var FamilyViewer = React.createClass({
 
                     {this.cv.gdmUuid && (familyUserAssessed || userFamily) ?
                         <AssessmentPanel panelTitle="Segregation Assessment" assessmentTracker={this.cv.assessmentTracker} updateValue={this.updateAssessmentValue}
-                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} submitDisable={this.state.submitBusy} updateMsg={updateMsg} />
+                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} submitBusy={this.state.submitBusy} updateMsg={updateMsg} />
                     : null}
 
                     <Panel title="Family - Variant(s) Segregating with Proband" panelClassName="panel-data">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1384,7 +1384,8 @@ var FamilyViewer = React.createClass({
     getInitialState: function() {
         return {
             assessments: null, // Array of assessments for the family's segregation
-            updatedAssessment: '' // Updated assessment value
+            updatedAssessment: '', // Updated assessment value
+            submitBusy: false // True while form is submitting
         };
     },
 
@@ -1394,6 +1395,7 @@ var FamilyViewer = React.createClass({
 
         // GET the family object to have the most up-to-date version
         this.getRestData('/families/' + this.props.context.uuid).then(data => {
+            this.setState({submitBusy: true});
             var family = data;
 
             // Write the assessment to the DB, if there was one.
@@ -1437,6 +1439,7 @@ var FamilyViewer = React.createClass({
             if (updatedFamily && updatedFamily.segregation && updatedFamily.segregation.assessments && updatedFamily.segregation.assessments.length) {
                 this.setState({assessments: updatedFamily.segregation.assessments, updatedAssessment: this.cv.assessmentTracker.getCurrentVal()});
             }
+            this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
             return Promise.resolve(null);
         }).catch(function(e) {
             console.log('FAMILY VIEW UPDATE ERROR=: %o', e);
@@ -1649,7 +1652,7 @@ var FamilyViewer = React.createClass({
 
                     {this.cv.gdmUuid && (familyUserAssessed || userFamily) ?
                         <AssessmentPanel panelTitle="Segregation Assessment" assessmentTracker={this.cv.assessmentTracker} updateValue={this.updateAssessmentValue}
-                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} updateMsg={updateMsg} />
+                            assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} submitDisable={this.state.submitBusy} updateMsg={updateMsg} />
                     : null}
 
                     <Panel title="Family - Variant(s) Segregating with Proband" panelClassName="panel-data">

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -439,7 +439,7 @@ var GroupCuration = React.createClass({
                                             </Panel>
                                         </PanelGroup>
                                         <div className="curation-submit clearfix">
-                                            <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" />
+                                            <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" submitBusy={this.state.submitBusy} />
                                             <div className={submitErrClass}>Please fix errors on the form and resubmit.</div>
                                         </div>
                                     </Form>

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -365,7 +365,7 @@ var GroupCuration = React.createClass({
                 }).then(data => {
                     // Navigate back to Curation Central page.
                     // FUTURE: Need to navigate to Group Submit page.
-                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
+                    this.setState({submitBusy: false}); // done / form submission; turn the submit button back on, just in case
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -767,7 +767,7 @@ var IndividualCuration = React.createClass({
                                             </Panel>
                                         </PanelGroup>
                                         <div className="curation-submit clearfix">
-                                            <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" />
+                                            <Input type="submit" inputClassName="btn-primary pull-right" id="submit" title="Save" submitBusy={this.state.submitBusy} />
                                             <div className={submitErrClass}>Please fix errors on the form and resubmit.</div>
                                         </div>
                                     </Form>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -542,7 +542,7 @@ var IndividualCuration = React.createClass({
                 }).then(data => {
                     // Navigate back to Curation Central page.
                     // FUTURE: Need to navigate to Family Submit page.
-                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on
+                    this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on, just in case
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -56,7 +56,8 @@ var VariantCuration = React.createClass({
             gdm: null, // GDM object given in UUID
             variant: null, // Variant object given in UUID
             pathogenicity: null, // If editing curation, pathogenicity we're editing
-            assessment: null // Assessment of pathogenicity
+            assessment: null, // Assessment of pathogenicity
+            submitBusy: false // True while form is submitting
         };
     },
 
@@ -227,6 +228,8 @@ var VariantCuration = React.createClass({
 
         // Start with default validation; indicate errors on form if not, then bail
         if (this.validateDefault()) {
+            this.setState({submitBusy: true});
+
             var pathogenicityUuid = this.state.pathogenicity ? this.state.pathogenicity.uuid : '';
 
             // If pathogenicity object has no assessment object found with currently logged-in user
@@ -302,6 +305,7 @@ var VariantCuration = React.createClass({
                 return Promise.resolve(null);
             }).then(data => {
                 // Now go back to Record Curation
+                this.setState({submitBusy: false}); // done w/ form submission; turn the submit button back on, just in case
                 var gdmQs = this.state.gdm ? '?gdm=' + this.state.gdm.uuid : '';
                 var pmidQs = this.queryValues.pmid ? '&pmid=' + this.queryValues.pmid : '';
                 this.context.navigate('/curation-central/' + gdmQs + pmidQs);
@@ -434,7 +438,7 @@ var VariantCuration = React.createClass({
                                         : (pathogenicity ? <VariantCurationView key={pathogenicity.uuid} pathogenicity={pathogenicity} note="Note: To Edit the pathogenicity evaluation, first change your assessment to “Not assessed” and click Save, then Edit the Variant again."/> : null) }
                                         <AssessmentPanel panelTitle="Variant Assessment" assessmentTracker={this.cv.assessmentTracker} updateValue={this.updateAssessmentValue} accordion open />
                                         <div className="curation-submit clearfix">
-                                            <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save" />
+                                            <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save" submitBusy={this.state.submitBusy} />
                                             {gdm ?
                                                 <a href={'/curation-central/?gdm=' + gdm.uuid + (this.queryValues.pmid ? '&pmid=' + this.queryValues.pmid : '')} className="btn btn-default btn-inline-spacer pull-right">Cancel</a>
                                             : null}

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -396,7 +396,7 @@ var Input = module.exports.Input = React.createClass({
                 input = (
                     <span className={this.props.wrapperClassName}>
                         <button className={inputClasses} onClick={this.props.submitHandler} disabled={this.props.inputDisabled || this.props.submitBusy}>
-                        <span className="submit-spinner"><i className="icon icon-spin icon-cog"></i></span> {title}</button>
+                        {this.props.submitBusy ? <span className="submit-spinner"><i className="icon icon-spin icon-cog"></i></span> : null}{title}</button>
                     </span>
                 );
                 break;

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -208,6 +208,7 @@ var Input = module.exports.Input = React.createClass({
         clickHandler: React.PropTypes.func, // Called to handle button click
         submitHandler: React.PropTypes.func, // Called to handle submit button click
         cancelHandler: React.PropTypes.func, // Called to handle cancel button click
+        submitBusy: React.PropTypes.bool, //
         minVal: React.PropTypes.number, // Minimum value for a number formatted input
         maxVal: React.PropTypes.number // Maximum value for a number formatted input
     },
@@ -365,10 +366,10 @@ var Input = module.exports.Input = React.createClass({
                 // Requires properties:
                 //   title: Label to put into button
                 //   clickHandler: Method to call when button is clicked
-                inputClasses = 'btn' + (this.props.inputClassName ? ' ' + this.props.inputClassName : '');
+                inputClasses = 'btn' + (this.props.inputClassName ? ' ' + this.props.inputClassName : '') + (this.props.submitBusy ? ' submit-busy' : '');
                 input = (
                     <span className={this.props.wrapperClassName}>
-                        <input className={inputClasses} type={this.props.type} value={this.props.title} onClick={this.props.clickHandler} disabled={this.props.inputDisabled} />
+                        <input className={inputClasses} type={this.props.type} value={this.props.title} onClick={this.props.clickHandler} disabled={this.props.inputDisabled || this.props.submitBusy} />
                     </span>
                 );
                 break;
@@ -391,10 +392,11 @@ var Input = module.exports.Input = React.createClass({
 
             case 'submit':
                 title = this.props.title ? this.props.title : 'Submit';
-                inputClasses = 'btn' + (this.props.inputClassName ? ' ' + this.props.inputClassName : '');
+                inputClasses = 'btn' + (this.props.inputClassName ? ' ' + this.props.inputClassName : '') + (this.props.submitBusy ? ' submit-busy' : '');
                 input = (
                     <span className={this.props.wrapperClassName}>
-                        <button className={inputClasses} onClick={this.props.submitHandler} disabled={this.props.inputDisabled}>{title}</button>
+                        <button className={inputClasses} onClick={this.props.submitHandler} disabled={this.props.inputDisabled || this.props.submitBusy}>
+                        <span className="submit-spinner"><i className="icon icon-spin icon-cog"></i></span> {title}</button>
                     </span>
                 );
                 break;

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -218,11 +218,6 @@ input[type=search] {
     display: inline-block;
     opacity: 0;
     width: 0;
-
-    -webkit-transition: opacity 0.2s, width 0.2s;
-    -moz-transition: opacity 0.2s, width 0.2s;
-    -o-transition: opacity 0.2s, width 0.2s;
-    transition: opacity 0.2s, width 0.2s;
 }
 
 .btn.submit-busy .submit-spinner {

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -213,3 +213,23 @@ input[type=search] {
         margin: 20px 0;
     }
 }
+
+.submit-spinner {
+    display: inline-block;
+    opacity: 0;
+    width: 0;
+
+    -webkit-transition: opacity 0.2s, width 0.2s;
+    -moz-transition: opacity 0.2s, width 0.2s;
+    -o-transition: opacity 0.2s, width 0.2s;
+    transition: opacity 0.2s, width 0.2s;
+}
+
+.submit-spinner i {
+    font-size: 15px;
+}
+
+.btn.submit-busy .submit-spinner {
+    opacity: 1;
+    width: auto;
+}

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -225,11 +225,12 @@ input[type=search] {
     transition: opacity 0.2s, width 0.2s;
 }
 
-.submit-spinner i {
-    font-size: 15px;
-}
-
 .btn.submit-busy .submit-spinner {
     opacity: 1;
     width: auto;
+    padding-right: 5px;
+}
+
+.submit-spinner i {
+    font-size: 15px;
 }


### PR DESCRIPTION
The fix pursued for #372 was to disable the button on form submit.

For Assessments from the View pages, the button will be disabled while the REST calls are happening in the background:
![image](https://cloud.githubusercontent.com/assets/4326866/10407170/24b26a0e-6e9c-11e5-8e37-0c9f0b43b394.png)

For the Groups, Family, Individual, Experimental Data creation and edit forms, as well as the Variants assessment form, the button will be disabled and display an animated cog while the REST calls are happening in the background, before the user is forwarded to the next page on a successful submit: 
![image](https://cloud.githubusercontent.com/assets/4326866/10407192/62cee0d8-6e9c-11e5-949b-ee9b1deb6e74.png)

Testing:

1. Create GDM
2. Add PMID
3. Create Group/Family/Individual/Experimental Data item(s), and confirm that the cogs show up on Submit button and that the button is disabled before taking you to next page.
  * Bonus step: Attempt to submit a form that is rejected (mainly via input of not-found Orphanet and Gene symbols), and make sure that the cog disappears on error
4. Assess on View page(s) of Family/Experimental Data, and confirm that the button is disabled for a split second (very fast transaction)
5. Assess a Variant and confirm that the cogs show up on Submit button and that the button is disabled before taking you to next page.