### PR TITLE
Connects to #344 View Family assessment panel conditional display

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1379,6 +1379,30 @@ var FamilyAdditional = function() {
 };
 
 
+// Determine whether the given segregation contains any non-empty values.
+function segregationExists(segregation) {
+    var exists = false;
+
+    if (segregation) {
+        exists = (segregation.pedigreeDescription && segregation.pedigreeDescription.length > 0) ||
+                  segregation.pedigreeSize ||
+                  segregation.numberOfGenerationInPedigree ||
+                  segregation.consanguineousFamily ||
+                  segregation.numberOfCases ||
+                 (segregation.deNovoType && segregation.deNovoType.length > 0) ||
+                  segregation.numberOfParentsUnaffectedCarriers ||
+                  segregation.numberOfAffectedAlleles ||
+                  segregation.numberOfAffectedWithOneVariant ||
+                  segregation.numberOfAffectedWithTwoVariants ||
+                  segregation.numberOfUnaffectedCarriers ||
+                  segregation.numberOfUnaffectedIndividuals ||
+                  segregation.probandAssociatedWithBoth ||
+                 (segregation.additionalInformation && segregation.additionalInformation.length > 0);
+    }
+    return exists;
+};
+
+
 var FamilyViewer = React.createClass({
     mixins: [RestMixin, AssessmentMixin],
 
@@ -1509,6 +1533,9 @@ var FamilyViewer = React.createClass({
                 familyUserAssessed = true;
             }
         }
+
+        // See if the segregation contains anything.
+        var haveSegregation = segregationExists(segregation);
 
         return (
             <div className="container">
@@ -1657,7 +1684,7 @@ var FamilyViewer = React.createClass({
 
                     {FamilySegregationViewer(segregation, assessments, true)}
 
-                    {this.cv.gdmUuid && (familyUserAssessed || userFamily) ?
+                    {this.cv.gdmUuid && (familyUserAssessed || userFamily) && haveSegregation ?
                         <AssessmentPanel panelTitle="Segregation Assessment" assessmentTracker={this.cv.assessmentTracker} updateValue={this.updateAssessmentValue}
                             assessmentSubmit={this.assessmentSubmit} disableDefault={othersAssessed} submitBusy={this.state.submitBusy} updateMsg={updateMsg} />
                     : null}


### PR DESCRIPTION
The View Family assessment panel now only appears if something in the family’s segregation has been set. This lets it be more consistent with the Curate/Edit Family page’s assessment.

1. Create a GDM and add a PMID.
2. Click **Family +** to add a new unassociated family with any data, but with nothing set in the segregation panel — leave it empty.
3. Save the new family and return to Record Curation.
4. Click the **View** link for the new family. Verify no Segregation Assessment panel appears.
5. Close the View window and edit the family. Add anything to its segregation and save it.
6. View the family again. Verify the assessment panel appears and can be used.