### PR TITLE
Connects to #334. Add any PMID in curation pages

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -294,7 +294,7 @@ var AddPmidModal = React.createClass({
                 var url = this.props.protocol + external_url_map['PubMedSearch'];
                 // PubMed article not in our DB; go out to PubMed itself to retrieve it as XML
                 return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
-                    var newArticle = parsePubmed(xml, enteredPmid);
+                    var newArticle = parsePubmed(xml);
                     // if the PubMed article for this PMID doesn't exist, display an error
                     if (!('pmid' in newArticle)) this.setFormErrors('pmid', 'This PMID does not exist');
                     return this.postRestData('/articles/', newArticle).then(data => {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1260,7 +1260,7 @@ module.exports.capture = {
 
     // Find all the comma-separated PMID occurrences. Return all valid PMIDs in an array.
     pmids: function(s) {
-        return captureBase(s, /^\s*(\d{1,10})\s*$/);
+        return captureBase(s, /^\s*([1-9]{1}\d*)\s*$/);
     },
 
     // Find all the comma-separated HPO ID occurrences. Return all valid HPO ID in an array.

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -9,6 +9,7 @@ var globals = require('./globals');
 var curator = require('./curator');
 var RestMixin = require('./rest').RestMixin;
 var methods = require('./methods');
+var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
 
 var CurationMixin = curator.CurationMixin;
 var RecordHeader = curator.RecordHeader;
@@ -228,14 +229,51 @@ var GroupCuration = React.createClass({
                         searchStr = '/search/?type=article&' + pmids.map(function(pmid) { return 'pmid=' + pmid; }).join('&');
                         return this.getRestData(searchStr).then(articles => {
                             if (articles['@graph'].length === pmids.length) {
-                                // Successfully retrieved all genes
+                                // Successfully retrieved all PMIDs, so just set groupArticles and return
                                 groupArticles = articles;
                                 return Promise.resolve(articles);
                             } else {
-                                this.setState({submitBusy: false}); // submit error; re-enable submit button
+                                // some PMIDs were not in our db already
+                                // generate list of PMIDs and pubmed URLs for those PMIDs
                                 var missingPmids = _.difference(pmids, articles['@graph'].map(function(article) { return article.pmid; }));
-                                this.setFormErrors('otherpmids', missingPmids.join(', ') + ' not found');
-                                throw articles;
+                                var missingPmidsUrls = [];
+                                for (var missingPmidsIndex = 0; missingPmidsIndex < missingPmids.length; missingPmidsIndex++) {
+                                    missingPmidsUrls.push(external_url_map['PubMedSearch']  + missingPmids[missingPmidsIndex]);
+                                }
+                                // get the XML for the missing PMIDs
+                                return this.getRestDatasXml(missingPmidsUrls).then(xml => {
+                                    var newArticles = [];
+                                    var invalidPmids = [];
+                                    var tempArticle;
+                                    // loop through the resulting XMLs and parsePubmed them
+                                    for (var xmlIndex = 0; xmlIndex < xml.length; xmlIndex++) {
+                                        tempArticle = parsePubmed(xml[xmlIndex]);
+                                        // check to see if Pubmed actually had an entry for the PMID
+                                        if ('pmid' in tempArticle) {
+                                            newArticles.push(tempArticle);
+                                        } else {
+                                            // PMID was not found at Pubmed
+                                            invalidPmids.push(missingPmids[xmlIndex]);
+                                        }
+                                    }
+                                    // if there were invalid PMIDs, throw an error with a list of them
+                                    if (invalidPmids.length > 0) {
+                                        this.setState({submitBusy: false}); // submit error; re-enable submit button
+                                        this.setFormErrors('otherpmids', 'PMID(s) ' + invalidPmids.join(', ') + ' not found');
+                                        throw invalidPmids;
+                                    }
+                                    // otherwise, post the valid PMIDs
+                                    if (newArticles.length > 0) {
+                                        return this.postRestDatas('/articles', newArticles).then(data => {
+                                            for (var dataIndex = 0; dataIndex < data.length; dataIndex++) {
+                                                articles['@graph'].push(data[dataIndex]['@graph'][0]);
+                                            }
+                                            groupArticles = articles;
+                                            return Promise.resolve(data);
+                                        });
+                                    }
+                                    return Promise(articles);
+                                });
                             }
                         });
                     } else {

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -528,9 +528,9 @@ var GroupCommonDiseases = function() {
     var orphanetidVal, hpoidVal, nothpoidVal;
 
     if (group) {
-        orphanetidVal = group.commonDiagnosis ? group.commonDiagnosis.map(function(disease) { return 'ORPHA' + disease.orphaNumber; }).join() : null;
-        hpoidVal = group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis.join() : null;
-        nothpoidVal = group.hpoIdInElimination ? group.hpoIdInElimination.join() : null;
+        orphanetidVal = group.commonDiagnosis ? group.commonDiagnosis.map(function(disease) { return 'ORPHA' + disease.orphaNumber; }).join(', ') : null;
+        hpoidVal = group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis.join(', ') : null;
+        nothpoidVal = group.hpoIdInElimination ? group.hpoIdInElimination.join(', ') : null;
     }
 
     return (
@@ -714,7 +714,7 @@ var GroupAdditional = function() {
     var otherpmidsVal;
     var group = this.state.group;
     if (group) {
-        otherpmidsVal = group.otherPMIDs ? group.otherPMIDs.map(function(article) { return article.pmid; }).join() : null;
+        otherpmidsVal = group.otherPMIDs ? group.otherPMIDs.map(function(article) { return article.pmid; }).join(', ') : null;
     }
 
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -9,6 +9,7 @@ var globals = require('./globals');
 var curator = require('./curator');
 var RestMixin = require('./rest').RestMixin;
 var methods = require('./methods');
+var parsePubmed = require('../libs/parse-pubmed').parsePubmed;
 
 var CurationMixin = curator.CurationMixin;
 var RecordHeader = curator.RecordHeader;
@@ -362,20 +363,57 @@ var IndividualCuration = React.createClass({
                     this.setFormErrors('orphanetid', 'The given diseases not found');
                     throw e;
                 }).then(diseases => {
-                    // Handle 'Add any other PMID(s) that have evidence about this same Individual' list of PMIDs
-                    if (pmids) {
+                    // Handle 'Add any other PMID(s) that have evidence about this same Group' list of PMIDs
+                    if (pmids && pmids.length) {
                         // User entered at least one PMID
                         searchStr = '/search/?type=article&' + pmids.map(function(pmid) { return 'pmid=' + pmid; }).join('&');
                         return this.getRestData(searchStr).then(articles => {
                             if (articles['@graph'].length === pmids.length) {
-                                // Successfully retrieved all genes
+                                // Successfully retrieved all PMIDs, so just set individualArticles and return
                                 individualArticles = articles;
                                 return Promise.resolve(articles);
                             } else {
-                                this.setState({submitBusy: false}); // submit error; re-enable submit button
+                                // some PMIDs were not in our db already
+                                // generate list of PMIDs and pubmed URLs for those PMIDs
                                 var missingPmids = _.difference(pmids, articles['@graph'].map(function(article) { return article.pmid; }));
-                                this.setFormErrors('otherpmids', missingPmids.join(', ') + ' not found');
-                                throw articles;
+                                var missingPmidsUrls = [];
+                                for (var missingPmidsIndex = 0; missingPmidsIndex < missingPmids.length; missingPmidsIndex++) {
+                                    missingPmidsUrls.push(external_url_map['PubMedSearch']  + missingPmids[missingPmidsIndex]);
+                                }
+                                // get the XML for the missing PMIDs
+                                return this.getRestDatasXml(missingPmidsUrls).then(xml => {
+                                    var newArticles = [];
+                                    var invalidPmids = [];
+                                    var tempArticle;
+                                    // loop through the resulting XMLs and parsePubmed them
+                                    for (var xmlIndex = 0; xmlIndex < xml.length; xmlIndex++) {
+                                        tempArticle = parsePubmed(xml[xmlIndex]);
+                                        // check to see if Pubmed actually had an entry for the PMID
+                                        if ('pmid' in tempArticle) {
+                                            newArticles.push(tempArticle);
+                                        } else {
+                                            // PMID was not found at Pubmed
+                                            invalidPmids.push(missingPmids[xmlIndex]);
+                                        }
+                                    }
+                                    // if there were invalid PMIDs, throw an error with a list of them
+                                    if (invalidPmids.length > 0) {
+                                        this.setState({submitBusy: false}); // submit error; re-enable submit button
+                                        this.setFormErrors('otherpmids', 'PMID(s) ' + invalidPmids.join(', ') + ' not found');
+                                        throw invalidPmids;
+                                    }
+                                    // otherwise, post the valid PMIDs
+                                    if (newArticles.length > 0) {
+                                        return this.postRestDatas('/articles', newArticles).then(data => {
+                                            for (var dataIndex = 0; dataIndex < data.length; dataIndex++) {
+                                                articles['@graph'].push(data[dataIndex]['@graph'][0]);
+                                            }
+                                            individualArticles = articles;
+                                            return Promise.resolve(data);
+                                        });
+                                    }
+                                    return Promise(articles);
+                                });
                             }
                         });
                     } else {
@@ -901,9 +939,9 @@ var IndividualCommonDiseases = function() {
 
     // If we're editing an individual, make editable values of the complex properties
     if (individual) {
-        orphanetidVal = individual.diagnosis ? individual.diagnosis.map(function(disease) { return 'ORPHA' + disease.orphaNumber; }).join() : null;
-        hpoidVal = individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis.join() : null;
-        nothpoidVal = individual.hpoIdInElimination ? individual.hpoIdInElimination.join() : null;
+        orphanetidVal = individual.diagnosis ? individual.diagnosis.map(function(disease) { return 'ORPHA' + disease.orphaNumber; }).join(', ') : null;
+        hpoidVal = individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis.join(', ') : null;
+        nothpoidVal = individual.hpoIdInElimination ? individual.hpoIdInElimination.join(', ') : null;
     }
 
     // Make a list of diseases from the group, either from the given group,
@@ -1165,7 +1203,7 @@ var IndividualAdditional = function() {
 
     // If editing an individual, get its existing articles
     if (individual) {
-        otherpmidsVal = individual.otherPMIDs ? individual.otherPMIDs.map(function(article) { return article.pmid; }).join() : null;
+        otherpmidsVal = individual.otherPMIDs ? individual.otherPMIDs.map(function(article) { return article.pmid; }).join(', ') : null;
     }
 
     return (

--- a/src/clincoded/static/components/rest.js
+++ b/src/clincoded/static/components/rest.js
@@ -40,6 +40,12 @@ var RestMixin = module.exports.RestMixin = {
         });
     },
 
+    getRestDatasXml: function(uris) {
+        return Promise.all(uris.map(function(uri, i) {
+            return this.getRestDataXml(uri, function() {});
+        }.bind(this)));
+    },
+
     // GET JSON data from the given URI. Returns data in the promise.
     // Non-OK error response calls the optional errorHandler function.
     getRestData: function(uri, errorHandler, dbSearch) {

--- a/src/clincoded/static/components/rest.js
+++ b/src/clincoded/static/components/rest.js
@@ -40,6 +40,7 @@ var RestMixin = module.exports.RestMixin = {
         });
     },
 
+    // use getRestDataXml to get an array of XML responses from an array of URIs
     getRestDatasXml: function(uris) {
         return Promise.all(uris.map(function(uri, i) {
             return this.getRestDataXml(uri, function() {});

--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -87,7 +87,7 @@ function pubmedAuthors($PubmedArticle){
                 var $Initials = $Authors[i].getElementsByTagName('Initials')[0];
                 if ($Initials){
                     author += (author ? ' ' : '') + $Initials.textContent;
-                }                
+                }
             }
             authors.push(author);
         }


### PR DESCRIPTION
Testing:
1. Create GDM and add PMID to it
2. Add Group/Family/Individual object w/ PMID not already in db
3. Confirm that the new PMID is associated with the object by View/Editing it
4. Confirm that the new PMID exists in the db by checking /articles/
5. Attempt to add/edit in an invalid PMID
6. Attempt to add/edit in multiple new PMIDs
7. Attempt to add/edit in mix of new PMIDs and PMIDs already in the db

Additional changes:
* Refined check for valid PMID entries in curation module
* Incorporate getRestDatasXml function