### PR TITLE
Connect to #442. Fix bug causes modals cannot be closed on IE11

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -315,10 +315,12 @@ var AddPmidModal = React.createClass({
     cancelForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
 
-        //only a mouse click on cancel button closes modal
-        //(do not let the enter key [which evaluates to 0 mouse
-        //clicks] be accepted to close modal)
-        if (e.detail >= 1){
+        // Only a mouse click on cancel button closes modal
+        // (do not let the enter key [which evaluates to 0 mouse
+        // clicks] be accepted to close modal)
+        // In most browsers can use event.detail to detect mouse clicks,
+        // but in IE there's no way you had to use the screenX trick
+        if (e.detail >= 1 || e.screenX > 0) {
             this.props.closeModal();
         }
     },

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -902,10 +902,12 @@ var AddOmimIdModal = React.createClass({
     cancelForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
 
-        //only a mouse click on cancel button closes modal
-        //(do not let the enter key [which evaluates to 0 mouse
-        //clicks] be accepted to close modal)
-        if (e.detail >= 1){
+        // Only a mouse click on cancel button closes modal
+        // (do not let the enter key [which evaluates to 0 mouse
+        // clicks] be accepted to close modal)
+        // In most browsers can use event.detail to detect mouse clicks,
+        // but in IE there's no way you had to use the screenX trick
+        if (e.detail >= 1 || e.screenX > 0) {
             this.props.closeModal();
         }
     },

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -178,7 +178,9 @@ var ProvisionalCuration = React.createClass({
         e.stopPropagation();
 
         // click Cancel button will go back to view - current
-        if (e.detail >= 1){
+        // In most browsers can use event.detail to detect mouse clicks,
+        // but in IE there's no way you had to use the screenX trick
+        if (e.detail >= 1 || e.screenX > 0) {
             window.history.go(-1);
             //var backUrl = '/curation-central/?gdm=' + this.state.gdm.uuid;
             //backUrl += this.queryValues.pmid ? '&pmid=' + this.queryValues.pmid : '';


### PR DESCRIPTION
IE doesn't count mouse click properly. Maybe related to https://connect.microsoft.com/IE/feedback/details/789773/ie-increments-event-detail-on-clicks-over-different-locations :)