### PR TITLE
Connects to #419 kd add molecular interactions

### DIFF
--- a/src/clincoded/schemas/experimental.json
+++ b/src/clincoded/schemas/experimental.json
@@ -167,13 +167,15 @@
                     "description": "Experimental Interaction Detection",
                     "type": "string",
                     "enum": [
-                        "coimmunoprecipitation (M:0019)",
-                        "pull down (M:0096)",
-                        "affinity chromatography technology (M:0004)",
-                        "protein cross-linking with a bifunctional reagent (M0031)",
-                        "comigration in gel electrophoresis (M:0807)",
-                        "x-ray crystallography (MI:0114)",
-                        "electron microscopy (MI:0040)"
+                        "affinity chromatography technology (MI:0004)",
+                        "coimmunoprecipitation (MI:0019)",
+                        "comigration in gel electrophoresis (MI:0807)",
+                        "electron microscopy (MI:0040)",
+                        "protein cross-linking with a bifunctional reagent (MI:0031)",
+                        "pull down (MI:0096)",
+                        "synthetic genetic analysis (MI:0441)",
+                        "two hybrid (MI:0018)",
+                        "x-ray crystallography (MI:0114)"
                     ]
                 },
                 "geneImplicatedInDisease": {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1351,7 +1351,7 @@ var TypeBiochemicalFunction = function() {
             : null}
         </div>
     );
-}
+};
 
 // HTML labels for Biochemical Functions panel
 var LabelIdentifiedFunction = React.createClass({
@@ -1404,7 +1404,7 @@ var TypeBiochemicalFunctionA = function() {
                 inputDisabled={!this.state.geneImplicatedWithDisease || this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // HTML labels for Biochemical Functions panel A
 var LabelGenesWithSameFunction = React.createClass({
@@ -1455,17 +1455,17 @@ var TypeBiochemicalFunctionB = function() {
                 inputDisabled={!(this.state.biochemicalFunctionHPO || this.state.biochemicalFunctionFT) || this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // HTML labels for Biochemical Functions panel B
 var LabelHPOIDs = React.createClass({
     render: function() {
-        return <span>Phenotype(s) consistent with function <span style={{fontWeight: 'normal'}}>(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID)</span>:</span>
+        return <span>Phenotype(s) consistent with function <span style={{fontWeight: 'normal'}}>(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID)</span>:</span>;
     }
 });
 var LabelPhenotypesFT = React.createClass({
     render: function() {
-        return <span>Phenotype(s) consistent with function <span style={{fontWeight: 'normal'}}>(free text)</span>:</span>
+        return <span>Phenotype(s) consistent with function <span style={{fontWeight: 'normal'}}>(free text)</span>:</span>;
     }
 });
 
@@ -1531,7 +1531,7 @@ var TypeProteinInteractions = function() {
                 rows="5" value={proteinInteractions.evidenceInPaper}inputDisabled={!this.state.geneImplicatedInDisease || this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // HTML labels for Protein Interactions panel
 var LabelInteractingGenes = React.createClass({
@@ -1563,7 +1563,7 @@ var TypeExpression = function() {
             : null}
         </div>
     );
-}
+};
 
 // HTML labels for Expression panel.
 var LabelUberonId = React.createClass({
@@ -1599,7 +1599,7 @@ var TypeExpressionA = function() {
                 rows="5" value={expression.normalExpression.evidenceInPaper} inputDisabled={!this.state.expressedInTissue || this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 var TypeExpressionB = function() {
     var experimental = this.state.experimental ? this.state.experimental : {};
@@ -1628,7 +1628,7 @@ var TypeExpressionB = function() {
                 rows="5" value={expression.alteredExpression.evidenceInPaper} inputDisabled={!this.state.expressedInPatients || this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // Functional Alteration type curation panel. Call with .call(this) to run in the same context
 // as the calling component.
@@ -1695,7 +1695,7 @@ var TypeFunctionalAlteration = function() {
                 rows="5" value={functionalAlteration.evidenceInPaper} inputDisabled={this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // HTML labels for Functional Alterations panel.
 var LabelFAPatientCellType = React.createClass({
@@ -1816,7 +1816,7 @@ var TypeModelSystems = function() {
                 rows="5" value={modelSystems.evidenceInPaper} inputDisabled={this.cv.othersAssessed} />
         </div>
     );
-}
+};
 
 // HTML labels for Model Systems panel.
 var LabelCellCulture = React.createClass({
@@ -1928,7 +1928,7 @@ var TypeRescue = function() {
                 rows="5" inputDisabled={!this.state.wildTypeRescuePhenotype || this.cv.othersAssessed} value={rescue.evidenceInPaper} />
         </div>
     );
-}
+};
 
 // HTML labels for Rescue panel
 var LabelRPatientCellType = React.createClass({

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1505,15 +1505,15 @@ var TypeProteinInteractions = function() {
                 inputDisabled={this.cv.othersAssessed} required>
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
-                <option>coimmunoprecipitation (M:0019)</option>
-                <option>pull down (M:0096)</option>
-                <option>affinity chromatography technology (M:0004)</option>
-                <option>protein cross-linking with a bifunctional reagent (M0031)</option>
-                <option>comigration in gel electrophoresis (M:0807)</option>
+                <option>affinity chromatography technology (MI:0004)</option>,
+                <option>coimmunoprecipitation (MI:0019)</option>,
+                <option>comigration in gel electrophoresis (MI:0807)</option>,
+                <option>electron microscopy (MI:0040)</option>,
+                <option>protein cross-linking with a bifunctional reagent (MI:0031)</option>,
+                <option>pull down (MI:0096)</option>,
+                <option>synthetic genetic analysis (MI:0441)</option>,
+                <option>two hybrid (MI:0018)</option>,
                 <option>x-ray crystallography (MI:0114)</option>
-                <option>electron microscopy (MI:0040)</option>
-                <option>synthetic genetic analysis (MI:0441)</option>
-                <option>two hybrid (MI:0018)</option>
             </Input>
             <Input type="checkbox" ref="geneImplicatedInDisease" label="Has this gene or genes been implicated in the above disease?:"
                 error={this.getFormError('geneImplicatedInDisease')} clearError={this.clrFormErrors.bind(null, 'geneImplicatedInDisease')}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1512,6 +1512,8 @@ var TypeProteinInteractions = function() {
                 <option>comigration in gel electrophoresis (M:0807)</option>
                 <option>x-ray crystallography (MI:0114)</option>
                 <option>electron microscopy (MI:0040)</option>
+                <option>synthetic genetic analysis (MI:0441)</option>
+                <option>two hybrid (MI:0018)</option>
             </Input>
             <Input type="checkbox" ref="geneImplicatedInDisease" label="Has this gene or genes been implicated in the above disease?:"
                 error={this.getFormError('geneImplicatedInDisease')} clearError={this.clrFormErrors.bind(null, 'geneImplicatedInDisease')}


### PR DESCRIPTION
To test:

1. Start local instance
1. Create GDM-> Add PMID
1. Add Experimental->Experiment type = "Protein Interactions"
1. In the "Protein Interactions" section: review the selections in the dropdown for "Method by which interaction detected":

![image](https://cloud.githubusercontent.com/assets/1878194/11639176/08c3064c-9ce0-11e5-9ae0-9318c66bc50e.png)

Items corrected and display in the new alphabetical order:

New items + order:
"affinity chromatography technology (MI:0004)",
"coimmunoprecipitation (MI:0019)",
"comigration in gel electrophoresis (MI:0807)",
"electron microscopy (MI:0040)",
"protein cross-linking with a bifunctional reagent (MI:0031)",
"pull down (MI:0096)",
"synthetic genetic analysis (MI:0441)",
"two hybrid (MI:0018)",
"x-ray crystallography (MI:0114)"



**Note**: Also included in PR: fixed eslint errors about semicolons in experimental_curation.js

**Note2**: As indicated on ticket, at least one record will be need to updated in production, after R2. Tested on an instance using copy of production db, and works properly.




For reference, from ticket: 
Previously incorrect items:
>pull down (M:0096)
affinity chromatography technology (M:0004)
protein cross-linking with a bifunctional reagent (M0031)
comigration in gel electrophoresis (M:0807)

New items: 
>synthetic genetic analysis (MI:0441)
two hybrid (MI:0018)