### PR TITLE
Connects to #497 Update upgrade scripts

### DIFF
--- a/src/clincoded/tests/test_upgrade_user.py
+++ b/src/clincoded/tests/test_upgrade_user.py
@@ -8,7 +8,6 @@ def user():
         'last_name': 'Liu',
         'email': 'kg.liu@stanford.edu',
         'groups': ['admin'],
-        'uuid': 'b99c5c3e-ff1e-408a-9806-8941cbfd21ae'
     }
 
 

--- a/src/clincoded/upgrade/experimental.py
+++ b/src/clincoded/upgrade/experimental.py
@@ -5,3 +5,17 @@ from contentbase.upgrader import upgrade_step
 def experimental_1_2(value, system):
     # https://github.com/ClinGen/clincoded/issues/453
     value['status'] = 'in progress'
+
+    # https://github.com/ClinGen/clincoded/issues/419
+    if value['proteinInteractions']:
+        if value['proteinInteractions']['experimentalInteractionDetection']:
+            if value['proteinInteractions']['experimentalInteractionDetection'] == 'coimmunoprecipitation (M:0019)':
+                value['proteinInteractions']['experimentalInteractionDetection'] = 'coimmunoprecipitation (MI:0019)'
+            if value['proteinInteractions']['experimentalInteractionDetection'] == 'pull down (M:0096)':
+                value['proteinInteractions']['experimentalInteractionDetection'] = 'pull down (MI:0096)'
+            if value['proteinInteractions']['experimentalInteractionDetection'] == 'affinity chromatography technology (M:0004)':
+                value['proteinInteractions']['experimentalInteractionDetection'] = 'affinity chromatography technology (MI:0004)'
+            if value['proteinInteractions']['experimentalInteractionDetection'] == 'protein cross-linking with a bifunctional reagent (M0031)':
+                value['proteinInteractions']['experimentalInteractionDetection'] = 'protein cross-linking with a bifunctional reagent (MI:0031)'
+            if value['proteinInteractions']['experimentalInteractionDetection'] == 'comigration in gel electrophoresis (M:0807)':
+                value['proteinInteractions']['experimentalInteractionDetection'] = 'comigration in gel electrophoresis (MI:0807)'

--- a/src/clincoded/upgrade/user.py
+++ b/src/clincoded/upgrade/user.py
@@ -11,14 +11,14 @@ def user_2_3(value, system):
 @upgrade_step('user', '3', '4')
 def user_3_4(value, system):
     # https://github.com/ClinGen/clincoded/issues/453
-    if value['uuid'] not in [
-        '627eedbc-7cb3-4de3-9743-a86266e435a6',  # Forest
-        '870b7c6d-76f2-4c19-8393-e2f1398cfd99',  # Karen
-        'e49d01a5-51f7-4a32-ba0e-b2a71684e4aa',  # Kang
-        '04442cec-6ab7-40d0-af26-1e5fefd535eb',  # Selina
-        '3a70a47f-711a-473f-93cd-0996421eeaf2',  # Minyoung
-        '748c68cb-b59e-48dd-88e9-1bcd8be199d6',  # Ben
-        '5a97bb8e-8b87-4863-91c1-98080d46d4be',  # Mike
-        'c0a70214-08a8-48a0-ba8d-521bed321d4a',  # Matt
+    if value['email'] not in [
+        'fytanaka@stanford.edu',  # Forest
+        'kdalton@stanford.edu',  # Karen
+        'kgliu@stanford.edu',  # Kang
+        'selinad@stanford.edu',  # Selina
+        'minchoi@stanford.edu',  # Minyoung
+        'hitz@stanford.edu',  # Ben
+        'cherry@stanford.edu',  # Mike
+        'wrightmw@stanford.edu',  # Matt
     ]:
         value['groups'] = ['curator']


### PR DESCRIPTION
* Fixes upgrade scripts associated with item delete function (#453) and experimental data dropdown changes (#419)

Testing (applicable on AWS instances):
* Confirm that users with emails not included in users upgrade script (non-Stanford staff) have user group value of `['curator']` (need to use `#!edit-json` URL to see)
![image](https://cloud.githubusercontent.com/assets/4326866/11674559/f5f2b6d2-9dd6-11e5-81a7-2c78a5ce11e7.png)

* If loading production data, confirm that previously-created Protein Interaction experimental data entries with old enum values pass validation and have the correct value under the `experimentalInteractionDetection` field
![image](https://cloud.githubusercontent.com/assets/4326866/11674552/dc0cc0a0-9dd6-11e5-9384-ea06b0411399.png)
