### PR TITLE
Connects to #500 Copy Orphanet ID from Group bug fix

### DIFF
--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -247,8 +247,10 @@ var Input = module.exports.Input = React.createClass({
     setValue: function(val) {
         if (this.props.type === 'text' || this.props.type === 'email' || this.props.type === 'textarea') {
             React.findDOMNode(this.refs.input).value = val;
+            this.setState({value: val});
         } else if (this.props.type === 'checkbox') {
             React.findDOMNode(this.refs.input).checked = val;
+            this.setState({value: val});
         }
     },
 


### PR DESCRIPTION
### Testing

1. Create new GDM and add PMID.
2. Create and save a group with basic information, then create an associated family and fill in its name.
3. Click the Copy Orphanet IDs from Associated Group button to put the group's Orphanet ID into the field.
4. Remove that value from that field.
5. Click Copy Orphanet IDs from Associated Group again. Verity if repopulates the field properly. Previously, the field would stay blank, and no console errors would display.