### PR TITLE
Connects to #515. Get updated parent on edits

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -97,12 +97,12 @@ var CurationCentral = React.createClass({
         }).then(newAnnotation => {
             return this.getRestData('/gdm/' + currGdm.uuid, null, true).then(freshGdm => {
                 var gdmObj = curator.flatten(freshGdm);
-
                 // Add our new annotation reference to the array of annotations in the GDM.
                 if (!gdmObj.annotations) {
                     gdmObj.annotations = [];
                 }
                 gdmObj.annotations.push(newAnnotation['@id']);
+
                 return this.putRestData('/gdm/' + currGdm.uuid, gdmObj).then(data => {
                     return data['@graph'][0];
                 });

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -95,15 +95,17 @@ var CurationCentral = React.createClass({
             // objects; basically the object as it exists in the DB. We'll update that and write it back to the DB.
             return (data['@graph'][0]);
         }).then(newAnnotation => {
-            var gdmObj = curator.flatten(currGdm);
+            return this.getRestData('/gdm/' + currGdm.uuid, null, true).then(freshGdm => {
+                var gdmObj = curator.flatten(freshGdm);
 
-            // Add our new annotation reference to the array of annotations in the GDM.
-            if (!gdmObj.annotations) {
-                gdmObj.annotations = [];
-            }
-            gdmObj.annotations.push(newAnnotation['@id']);
-            return this.putRestData('/gdm/' + currGdm.uuid, gdmObj).then(data => {
-                return data['@graph'][0];
+                // Add our new annotation reference to the array of annotations in the GDM.
+                if (!gdmObj.annotations) {
+                    gdmObj.annotations = [];
+                }
+                gdmObj.annotations.push(newAnnotation['@id']);
+                return this.putRestData('/gdm/' + currGdm.uuid, gdmObj).then(data => {
+                    return data['@graph'][0];
+                });
             });
         }).then(gdm => {
             // Record history of adding a PMID to a GDM

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1032,7 +1032,7 @@ var PmidDoiButtons = module.exports.PmidDoiButtons = React.createClass({
 //    }
 //    return pathogenicity;
 //};
-var getPathogenicityFromVariant = function(gdm, curatorUuid, variantUuid) {
+var getPathogenicityFromVariant = module.exports.getPathogenicityFromVariant = function(gdm, curatorUuid, variantUuid) {
     var pathogenicity = null;
     if (gdm.variantPathogenicity && gdm.variantPathogenicity.length > 0) {
         for (var i in gdm.variantPathogenicity) {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1076,8 +1076,6 @@ var ExperimentalCuration = React.createClass({
                                     if (!annotation.experimentalData) {
                                         annotation.experimentalData = [];
                                     }
-
-                                    // merge in new experimental data with experimental data already in annotation
                                     annotation.experimentalData.push(newExperimental.data['@id']);
 
                                     // Post the modified annotation to the DB

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -783,7 +783,7 @@ var FamilyCuration = React.createClass({
                                 // Merge existing families in the annotation with the new set of families.
                                 group.familyIncluded.push(newFamily['@id']);
 
-                                // Post the modified annotation to the DB, then go back to Curation Central
+                                // Post the modified group to the DB
                                 return this.putRestData('/groups/' + this.state.group.uuid, group).then(groupGraph => {
                                     // The next step needs the family, not the group it was written to
                                     return Promise.resolve(_.extend(data, {group: groupGraph['@graph'][0]}));
@@ -802,7 +802,7 @@ var FamilyCuration = React.createClass({
                                 // Merge existing families in the annotation with the new set of families.
                                 annotation.families.push(newFamily['@id']);
 
-                                // Post the modified annotation to the DB, then go back to Curation Central
+                                // Post the modified annotation to the DB
                                 return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(annotation => {
                                     // The next step needs the family, not the group it was written to
                                     return Promise.resolve(_.extend(data, {annotation: annotation}));
@@ -859,8 +859,7 @@ var FamilyCuration = React.createClass({
                         return Promise.resolve(null);
                     });
 
-                    // Navigate back to Curation Central page.
-                    // FUTURE: Need to navigate to Family Submit page.
+                    // Navigate to Curation Central or Family Submit page, depending on previous page
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut && !initvar) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -779,8 +779,6 @@ var FamilyCuration = React.createClass({
                                 if (!group.familyIncluded) {
                                     group.familyIncluded = [];
                                 }
-
-                                // Merge existing families in the annotation with the new set of families.
                                 group.familyIncluded.push(newFamily['@id']);
 
                                 // Post the modified group to the DB
@@ -798,8 +796,6 @@ var FamilyCuration = React.createClass({
                                 if (!annotation.families) {
                                     annotation.families = [];
                                 }
-
-                                // Merge existing families in the annotation with the new set of families.
                                 annotation.families.push(newFamily['@id']);
 
                                 // Post the modified annotation to the DB

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -774,33 +774,39 @@ var FamilyCuration = React.createClass({
                         // Adding a new family
                         if (this.state.group) {
                             // Add the newly saved families to the group
-                            var group = curator.flatten(this.state.group);
-                            if (!group.familyIncluded) {
-                                group.familyIncluded = [];
-                            }
+                            promise = this.getRestData('/groups/' + this.state.group.uuid, null, true).then(freshGroup => {
+                                var group = curator.flatten(freshGroup);
+                                if (!group.familyIncluded) {
+                                    group.familyIncluded = [];
+                                }
 
-                            // Merge existing families in the annotation with the new set of families.
-                            group.familyIncluded.push(newFamily['@id']);
+                                // Merge existing families in the annotation with the new set of families.
+                                group.familyIncluded.push(newFamily['@id']);
 
-                            // Post the modified annotation to the DB, then go back to Curation Central
-                            promise = this.putRestData('/groups/' + this.state.group.uuid, group).then(groupGraph => {
-                                // The next step needs the family, not the group it was written to
-                                return Promise.resolve(_.extend(data, {group: groupGraph['@graph'][0]}));
+                                // Post the modified annotation to the DB, then go back to Curation Central
+                                return this.putRestData('/groups/' + this.state.group.uuid, group).then(groupGraph => {
+                                    // The next step needs the family, not the group it was written to
+                                    return Promise.resolve(_.extend(data, {group: groupGraph['@graph'][0]}));
+                                });
                             });
                         } else {
                             // Not part of a group, so add the family to the annotation instead.
-                            var annotation = curator.flatten(this.state.annotation);
-                            if (!annotation.families) {
-                                annotation.families = [];
-                            }
+                            promise = this.getRestData('/evidence/' + this.state.annotation.uuid, null, true).then(freshAnnotation => {
+                                // Get a flattened copy of the fresh annotation object and put our new family into it,
+                                // ready for writing.
+                                var annotation = curator.flatten(freshAnnotation);
+                                if (!annotation.families) {
+                                    annotation.families = [];
+                                }
 
-                            // Merge existing families in the annotation with the new set of families.
-                            annotation.families.push(newFamily['@id']);
+                                // Merge existing families in the annotation with the new set of families.
+                                annotation.families.push(newFamily['@id']);
 
-                            // Post the modified annotation to the DB, then go back to Curation Central
-                            promise = this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(annotation => {
-                                // The next step needs the family, not the group it was written to
-                                return Promise.resolve(_.extend(data, {annotation: annotation}));
+                                // Post the modified annotation to the DB, then go back to Curation Central
+                                return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(annotation => {
+                                    // The next step needs the family, not the group it was written to
+                                    return Promise.resolve(_.extend(data, {annotation: annotation}));
+                                });
                             });
                         }
                     } else {

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -396,10 +396,10 @@ var GroupCuration = React.createClass({
                                 annotation.groups = [];
                             }
 
-                            // merge in new group with new groups already in annotation
+                            // merge in new groups with new groups already in annotation
                             annotation.groups.push(newGroup['@id']);
 
-                            // Post the modified annotation to the DB, then go back to Curation Central
+                            // Post the modified annotation to the DB
                             return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(data => {
                                 return Promise.resolve({group: newGroup, annotation: data['@graph'][0]});
                             });
@@ -426,8 +426,7 @@ var GroupCuration = React.createClass({
                         this.recordHistory('modify', data.group);
                     }
 
-                    // Navigate back to Curation Central page.
-                    // FUTURE: Need to navigate to Group Submit page.
+                    // Navigate to Curation Central or Family Submit page, depending on previous page
                     this.resetAllFormValues();
                     if (this.queryValues.editShortcut) {
                         this.context.navigate('/curation-central/?gdm=' + this.state.gdm.uuid + '&pmid=' + this.state.annotation.article.pmid);

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -388,18 +388,20 @@ var GroupCuration = React.createClass({
                 }).then(newGroup => {
                     savedGroup = newGroup;
                     if (!this.state.group) {
-                        // Get a flattened copy of the annotation and put our new group into it,
-                        // ready for writing.
-                        var annotation = curator.flatten(this.state.annotation);
-                        if (annotation.groups) {
-                            annotation.groups.push(newGroup['@id']);
-                        } else {
-                            annotation.groups = [newGroup['@id']];
-                        }
+                        return this.getRestData('/evidence/' + this.state.annotation.uuid, null, true).then(freshAnnotation => {
+                            // Get a flattened copy of the fresh annotation object and put our new group into it,
+                            // ready for writing.
+                            var annotation = curator.flatten(freshAnnotation);
+                            if (annotation.groups) {
+                                annotation.groups.push(newGroup['@id']);
+                            } else {
+                                annotation.groups = [newGroup['@id']];
+                            }
 
-                        // Post the modified annotation to the DB, then go back to Curation Central
-                        return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(data => {
-                            return Promise.resolve({group: newGroup, annotation: data['@graph'][0]});
+                            // Post the modified annotation to the DB, then go back to Curation Central
+                            return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(data => {
+                                return Promise.resolve({group: newGroup, annotation: data['@graph'][0]});
+                            });
                         });
                     }
 

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -395,8 +395,6 @@ var GroupCuration = React.createClass({
                             if (!annotation.groups) {
                                 annotation.groups = [];
                             }
-
-                            // merge in new groups with groups already in annotation
                             annotation.groups.push(newGroup['@id']);
 
                             // Post the modified annotation to the DB

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -392,11 +392,12 @@ var GroupCuration = React.createClass({
                             // Get a flattened copy of the fresh annotation object and put our new group into it,
                             // ready for writing.
                             var annotation = curator.flatten(freshAnnotation);
-                            if (annotation.groups) {
-                                annotation.groups.push(newGroup['@id']);
-                            } else {
-                                annotation.groups = [newGroup['@id']];
+                            if (!annotation.groups) {
+                                annotation.groups = [];
                             }
+
+                            // merge in new group with new groups already in annotation
+                            annotation.groups.push(newGroup['@id']);
 
                             // Post the modified annotation to the DB, then go back to Curation Central
                             return this.putRestData('/evidence/' + this.state.annotation.uuid, annotation).then(data => {

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -396,7 +396,7 @@ var GroupCuration = React.createClass({
                                 annotation.groups = [];
                             }
 
-                            // merge in new groups with new groups already in annotation
+                            // merge in new groups with groups already in annotation
                             annotation.groups.push(newGroup['@id']);
 
                             // Post the modified annotation to the DB

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -573,8 +573,6 @@ var IndividualCuration = React.createClass({
                                 if (!group.individualIncluded) {
                                     group.individualIncluded = [];
                                 }
-
-                                // Merge existing individuals in the group with the new set of individuals
                                 group.individualIncluded.push(newIndividual['@id']);
 
                                 // Post the modified group to the DB
@@ -589,8 +587,6 @@ var IndividualCuration = React.createClass({
                                 if (!family.individualIncluded) {
                                     family.individualIncluded = [];
                                 }
-
-                                // Merge existing individuals in the family with the new set of individuals.
                                 family.individualIncluded.push(newIndividual['@id']);
 
                                 // Post the modified family to the DB
@@ -607,8 +603,6 @@ var IndividualCuration = React.createClass({
                                 if (!annotation.individuals) {
                                     annotation.individuals = [];
                                 }
-
-                                // Merge existing individuals in the annotation with the new set of individuals.
                                 annotation.individuals.push(newIndividual['@id']);
 
                                 // Post the modified annotation to the DB

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -284,17 +284,19 @@ var VariantCuration = React.createClass({
                 // Given pathogenicity has been saved (created or updated).
                 // Now update the GDM to include the pathogenicity if it's new
                 if (!this.state.pathogenicity && this.state.gdm && data.pathogenicity) {
-                    // New pathogenicity; add it to the GDM’s pathogenicity array.
-                    var newGdm = curator.flatten(this.state.gdm);
-                    if (newGdm.variantPathogenicity && newGdm.variantPathogenicity.length) {
-                        newGdm.variantPathogenicity.push(data.pathogenicity['@id']);
-                    } else {
-                        newGdm.variantPathogenicity = [data.pathogenicity['@id']];
-                    }
+                    return this.getRestData('/gdm/' + this.state.gdm.uuid, null, true).then(freshGdm => {
+                        // New pathogenicity; add it to the GDM’s pathogenicity array.
+                        var newGdm = curator.flatten(freshGdm);
+                        if (newGdm.variantPathogenicity && newGdm.variantPathogenicity.length) {
+                            newGdm.variantPathogenicity.push(data.pathogenicity['@id']);
+                        } else {
+                            newGdm.variantPathogenicity = [data.pathogenicity['@id']];
+                        }
 
-                    // Write the updated GDM
-                    return this.putRestData('/gdm/' + this.state.gdm.uuid, newGdm).then(() => {
-                        return Promise.resolve(_.extend(data, {modified: false}));
+                        // Write the updated GDM
+                        return this.putRestData('/gdm/' + this.state.gdm.uuid, newGdm).then(() => {
+                            return Promise.resolve(_.extend(data, {modified: false}));
+                        });
                     });
                 }
 


### PR DESCRIPTION
Testing:

1. Create GDM
2. Open GDM window in two separate tab/windows. Add a PMID in both w/o refreshing the pages, and confirm that both PMIDs are visible after the operations
3. Open two separate Add Group pages. Add a Group in both w/o refreshing the pages, and confirm that both Groups are visible after the operations
4. Open two separate Add Family pages. Add a Family in both w/o refreshing the pages, and confirm that both Families are visible after the operations
  * Repeat above, but with adding the Families under the same Group
5. Open two separate Add Individual pages. Add an Individual in both w/o refreshing the pages, and confirm that both Individuals are visible after the operations
  * Repeat above, but with adding the Individuals under the same Group
  * Repeat above, but with adding the Individuals under the same Family
6. Open two separate Experimental Data pages. Add an Experimental Data in both w/o refreshing the pages, and confirm that both Experimental Data objects are visible after the operations
7. Open two Edit Family and/or Edit Experimental Data pages and add Variants to them w/o refreshing the pages, and confirm that the Variants added are visible after the operations
8. Open two separate Variant Curation for two different Variants not previously assessed on, and then assess them w/o refreshing the pages, and confirm that the Variants have the little assessed flag in Curation Central after the operations
9. Open two separate Variant Curation for the same Variant not previously assessed on, and then assess them w/o refreshing the pages, and confirm that the correct (latest) assessment exists on the Variant after refreshing. Also check that the parent GDM object has the correct number of variantPathogenicity entries