### PR TITLE
Connects to #515. UI bug found while testing

### DIFF
--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -139,7 +139,7 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
                         </div>
                     : null}
                     <div className="row">
-                        <div className="col-md-9 col-md-offset-2 col-sm-10 col-sm-offset-1">
+                        <div className="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">
                             <Panel panelClassName="submit-results-panel" panelBodyClassName="bg-info">
                                 <div className="row">
                                     <div className="col-md-6">

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -139,7 +139,7 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
                         </div>
                     : null}
                     <div className="row">
-                        <div className="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
+                        <div className="col-md-9 col-md-offset-2 col-sm-10 col-sm-offset-1">
                             <Panel panelClassName="submit-results-panel" panelBodyClassName="bg-info">
                                 <div className="row">
                                     <div className="col-md-6">


### PR DESCRIPTION
* Fixes UI bug where the 'Add another individual' button in the Individual Submit page would have overflowing text at certain resolutions.

![image](https://cloud.githubusercontent.com/assets/4326866/12319201/6ee82776-ba55-11e5-8251-00150501b198.png)


Testing:

1. Add GDM
2. Add PMID, then individual
3. Resize browser in resulting Individual Submit page to make sure that the text does not overflow