### PR TITLE
Connects to #442. Fixed modal box Cancel button in IE.

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -340,7 +340,7 @@ var AddPmidModal = React.createClass({
         //only a mouse click on cancel button closes modal
         //(do not let the enter key [which evaluates to 0 mouse
         //clicks] be accepted to close modal)
-        if (e.detail >= 1){
+        if (e.type == 'click'){
             this.props.closeModal();
         }
     },

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -335,14 +335,10 @@ var AddPmidModal = React.createClass({
     // Called when the modal form's cancel button is clicked. Just closes the modal like
     // nothing happened.
     cancelForm: function(e) {
-        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-
-        //only a mouse click on cancel button closes modal
-        //(do not let the enter key [which evaluates to 0 mouse
-        //clicks] be accepted to close modal)
-        if (e.type == 'click'){
-            this.props.closeModal();
-        }
+        // Changed modal cancel button from a form input to a html button
+        // as to avoid accepting enter/return key as a click event.
+        // Removed hack in this method.
+        this.props.closeModal();
     },
 
     render: function() {
@@ -354,7 +350,7 @@ var AddPmidModal = React.createClass({
                         labelClassName="control-label" groupClassName="form-group" required />
                 </div>
                 <div className='modal-footer'>
-                    <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="submit" inputClassName={this.getFormError('pmid') === null || this.getFormError('pmid') === undefined || this.getFormError('pmid') === '' ?
                         "btn-primary btn-inline-spacer" : "btn-primary btn-inline-spacer disabled"} title="Add Article" />
                 </div>

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -912,14 +912,10 @@ var AddOmimIdModal = React.createClass({
     // Called when the modal form's cancel button is clicked. Just closes the modal like
     // nothing happened.
     cancelForm: function(e) {
-        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-
-        //only a mouse click on cancel button closes modal
-        //(do not let the enter key [which evaluates to 0 mouse
-        //clicks] be accepted to close modal)
-        if (e.type == 'click'){
-            this.props.closeModal();
-        }
+        // Changed modal cancel button from a form input to a html button
+        // as to avoid accepting enter/return key as a click event.
+        // Removed hack in this method.
+        this.props.closeModal();
     },
 
     render: function() {
@@ -931,7 +927,7 @@ var AddOmimIdModal = React.createClass({
                         labelClassName="control-label" groupClassName="form-group" required />
                 </div>
                 <div className='modal-footer'>
-                    <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="submit" inputClassName="btn-primary btn-inline-spacer" title="Add/Change OMIM ID" />
                 </div>
             </Form>
@@ -2064,14 +2060,10 @@ var DeleteButtonModal = React.createClass({
     // Called when the modal form's cancel button is clicked. Just closes the modal like
     // nothing happened.
     cancelForm: function(e) {
-        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-
-        //only a mouse click on cancel button closes modal
-        //(do not let the enter key [which evaluates to 0 mouse
-        //clicks] be accepted to close modal)
-        if (e.type == 'click'){
-            this.props.closeModal();
-        }
+        // Changed modal cancel button from a form input to a html button
+        // as to avoid accepting enter/return key as a click event.
+        // Removed hack in this method.
+        this.props.closeModal();
     },
 
     // Called when user clicks a link in the delete confirmation modal to view another object.
@@ -2106,7 +2098,7 @@ var DeleteButtonModal = React.createClass({
                     : null}
                     </div>
                 <div className="modal-footer">
-                    <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="button" inputClassName="btn-danger btn-inline-spacer" clickHandler={this.deleteItem} title="Confirm Delete" submitBusy={this.state.submitBusy} />
                 </div>
             </div>

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -917,7 +917,7 @@ var AddOmimIdModal = React.createClass({
         //only a mouse click on cancel button closes modal
         //(do not let the enter key [which evaluates to 0 mouse
         //clicks] be accepted to close modal)
-        if (e.detail >= 1){
+        if (e.type == 'click'){
             this.props.closeModal();
         }
     },
@@ -2049,7 +2049,7 @@ var DeleteButtonModal = React.createClass({
         //only a mouse click on cancel button closes modal
         //(do not let the enter key [which evaluates to 0 mouse
         //clicks] be accepted to close modal)
-        if (e.detail >= 1){
+        if (e.type == 'click'){
             this.props.closeModal();
         }
     },

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -178,14 +178,10 @@ var ProvisionalCuration = React.createClass({
     },
 
     cancelForm: function(e) {
-        // Don't run through HTML submit handler
-        e.preventDefault();
-        e.stopPropagation();
-
-        // click Cancel button will go back to view - current
-        if (e.type == 'click'){
-            window.history.go(-1);
-        }
+        // Changed modal cancel button from a form input to a html button
+        // as to avoid accepting enter/return key as a click event.
+        // Removed hack in this method.
+        window.history.go(-1);
     },
 
     render: function() {
@@ -533,7 +529,7 @@ var EditCurrent = function() {
                     </Panel>
                 </PanelGroup>
                 <div className='modal-footer'>
-                    <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="submit" inputClassName="btn-primary btn-inline-spacer pull-right" id="submit" title="Save" />
                 </div>
             </Form>
@@ -1199,7 +1195,7 @@ var NewCalculation = function() {
                     </Panel>
                 </PanelGroup>
                 <div className='modal-footer'>
-                    <Input type="cancel" inputClassName="btn-default btn-inline-spacer" cancelHandler={this.cancelForm} />
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="submit" inputClassName="btn-primary btn-inline-spacer pull-right" id="submit" title="Save" />
                 </div>
             </Form>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -183,7 +183,7 @@ var ProvisionalCuration = React.createClass({
         e.stopPropagation();
 
         // click Cancel button will go back to view - current
-        if (e.detail >= 1){
+        if (e.type == 'click'){
             window.history.go(-1);
         }
     },


### PR DESCRIPTION
This PR is for fixed the issue in which clicking "Cancel" button in the modal box fails to dismiss modal box in IE11/Win7.

Testing for #442:

1. Go to any existing GDM.
2. Click on "Add New PMID(s)" button or the "Add" (or "Edit") link next to the OMIM ID label.
3. Click on "Cancel" button in modal box.
4. The expected result is that the modal box will be dismissed.