### PR TITLE
Connects to #552 allow login with alternative win-localhost

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -9,7 +9,7 @@ sqlalchemy.url = postgresql://postgres@:5432/postgres?host=/tmp/clincoded/pgdata
 load_test_only = true
 create_tables = true
 testing = true
-persona.audiences = localhost:6543 *.clinicalgenome.org:6543
+persona.audiences = localhost:6543 win-localhost:6543 *.clinicalgenome.org:6543
 postgresql.statement_timeout = 20
 
 pyramid.reload_templates = true


### PR DESCRIPTION

General setup: 
----------------------------------------------------------------------------------------

**Testing Windows versions + Browsers via VirtualHost on a Mac:​**
—Install VirtualBox via their website or `brew install Caskroom/cask/virtualbox`
—Install Windows on it  https://dev.windows.com/en-us/microsoft-edge/tools/vms/mac/
—When OS is running, IE/Edge is already installed…use this browser to  find and install Chrome and Firefox
—You should be able to access any clinicalgenome production and demo URLs

**​To access ​_localhost_​ (code running on Mac) from VM on win7:​**
-- Start Start button , click All Programs, click Accessories, right-click Notepad, and then click Run as administrator. 
— Edit file `C:\Windows\System32\drivers\etc\hosts`
— Add to file 
`10.0.2.2    localhost`
`10.0.2.2    win-localhost`
— Save file.
—Access code running on Mac on VM’s  IE via the usual URL: http://localhost:6543 
—Access code running on Mac on VM’s  Chrome via the URL: http://win-localhost:6543 
(​_technically win-localhost could be used for both_​)
—Allow copying from Mac-Win and Win-Mac (helpful for pasting URLs): When the OS is running, from the VirtualBox Menu: Device->Shared Clipboard->Bidrectional


----------------------------------------------------------------------------------------
**To test this change:**
----------------------------------------------------------------------------------------
--Start local code on Mac in 2 terminals as usual
--On VirtualBox VM with Win7, login using Chrome at http://win-localhost:6543/ 