### PR TITLE
Connects to #333. Swap citation info box and title positions on submit pages.

### DIFF
--- a/src/clincoded/static/components/experimental_submit.js
+++ b/src/clincoded/static/components/experimental_submit.js
@@ -107,13 +107,13 @@ var ExperimentalSubmit = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} />
                 <div className="container">
-                    {experimental ?
-                        <h1>{experimental.evidenceType}<br />Experimental Data Information: {experimental.label} <a href={experimental['@id'] + '?gdm=' + gdm.uuid} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editExperimentalLink} className="btn btn-info">Edit</a></h1>
-                    : null}
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">
                             <PmidSummary article={annotation.article} displayJournal />
                         </div>
+                    : null}
+                    {experimental ?
+                        <h1>{experimental.evidenceType}<br />Experimental Data Information: {experimental.label} <a href={experimental['@id'] + '?gdm=' + gdm.uuid} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editExperimentalLink} className="btn btn-info">Edit</a></h1>
                     : null}
                     <div className="row">
                         <div className="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">

--- a/src/clincoded/static/components/family_submit.js
+++ b/src/clincoded/static/components/family_submit.js
@@ -127,17 +127,17 @@ var FamilySubmit = module.exports.FamilySubmit = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} />
                 <div className="container">
+                    {annotation && annotation.article ?
+                        <div className="curation-pmid-summary">
+                            <PmidSummary article={annotation.article} displayJournal />
+                        </div>
+                    : null}
                     {family ?
                         <div className="viewer-titles">
                             <h1>Family Information: {family.label} <a href={family['@id'] + '?gdm=' + gdm.uuid} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editFamilyLink} className="btn btn-info">Edit</a></h1>
                             {group ?
                                 <h2>{'Group association: ' + group.label}</h2>
                             : null}
-                        </div>
-                    : null}
-                    {annotation && annotation.article ?
-                        <div className="curation-pmid-summary">
-                            <PmidSummary article={annotation.article} displayJournal />
                         </div>
                     : null}
                     <div className="row">

--- a/src/clincoded/static/components/group_submit.js
+++ b/src/clincoded/static/components/group_submit.js
@@ -115,13 +115,13 @@ var GroupSubmit = module.exports.GroupSubmit = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} />
                 <div className="container">
-                    {group ?
-                        <h1>Group Information: {group.label} <a href={group['@id']} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editGroupLink} className="btn btn-info">Edit</a></h1>
-                    : null}
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">
                             <PmidSummary article={annotation.article} displayJournal />
                         </div>
+                    : null}
+                    {group ?
+                        <h1>Group Information: {group.label} <a href={group['@id']} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editGroupLink} className="btn btn-info">Edit</a></h1>
                     : null}
                     <div className="row">
                         <div className="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -130,13 +130,13 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
             <div>
                 <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} />
                 <div className="container">
-                    {individual ?
-                        <h1>Individual Information: {individual.label} <a href={individual['@id']} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editIndividualLink} className="btn btn-info">Edit</a></h1>
-                    : null}
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">
                             <PmidSummary article={annotation.article} displayJournal />
                         </div>
+                    : null}
+                    {individual ?
+                        <h1>Individual Information: {individual.label} <a href={individual['@id']} className="btn btn-info" target="_blank">View</a>&nbsp;<a href={editIndividualLink} className="btn btn-info">Edit</a></h1>
                     : null}
                     <div className="row">
                         <div className="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">


### PR DESCRIPTION
This PR is for moving the citation info boxes to be above titles on evidence submission pages.

Testing for #333:

1. Create a new Gene-Disease record.
2. On the new GDM page, add a PMID to enable the display of the Evidence column on the far right.
3. Click on any of evidence options (e.g. "Family").
4. On the subsequent curation information page, fill out the required fields and save the submission form.
5. The expected result should be that the citation info box is displayed above the title (see screenshot below).

![screen shot 2016-01-20 at 5 30 24 pm](https://cloud.githubusercontent.com/assets/6956310/12498476/b8d7d216-c057-11e5-8336-e94f6a626a89.png)
