### PR TITLE
Connects to #527. Form clears on Experimental Data curation type and subtype changes

### DIFF
--- a/src/clincoded/static/components/assessment.js
+++ b/src/clincoded/static/components/assessment.js
@@ -208,6 +208,12 @@ var AssessmentPanel = module.exports.AssessmentPanel = React.createClass({
         updateMsg: React.PropTypes.string // String to display by the Update button if desired
     },
 
+    componentWillReceiveProps: function(nextProps) {
+        if (nextProps.assessmentTracker.currentVal == DEFAULT_VALUE) {
+            this.refs['assessment'].resetValue();
+        }
+    },
+
     // Called when the dropdown value changes
     handleChange: function(assessmentTracker, e) {
         var value = this.refs['assessment'].getValue();

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -171,6 +171,36 @@ var ExperimentalCuration = React.createClass({
         } else if (ref === 'experimentalSubtype') {
             var tempExperimentalSubtype = this.refs[ref].getValue();
             this.setState({experimentalSubtype: tempExperimentalSubtype});
+            // Reset values when changing between Subtypes
+            if (this.refs['experimentalName']) {
+                this.refs['experimentalName'].resetValue();
+                this.setState({experimentalName: ''});
+            }
+            if (this.refs['identifiedFunction']) {
+                this.refs['identifiedFunction'].setValue('');
+            }
+            if (this.refs['evidenceForFunction']) {
+                this.refs['evidenceForFunction'].resetValue();
+            }
+            if (this.refs['evidenceForFunctionInPaper']) {
+                this.refs['evidenceForFunctionInPaper'].resetValue();
+            }
+            if (this.refs['geneWithSameFunctionSameDisease.geneImplicatedWithDisease']) {
+                this.refs['geneWithSameFunctionSameDisease.geneImplicatedWithDisease'].resetValue();
+                this.setState({geneImplicatedWithDisease: false});
+            }
+            if (this.refs['organOfTissue']) {
+                this.refs['organOfTissue'].setValue('');
+            }
+            if (this.refs['normalExpression.expressedInTissue']) {
+                this.refs['normalExpression.expressedInTissue'].resetValue();
+                this.setState({expressedInTissue: false});
+            }
+            if (this.refs['alteredExpression.expressedInPatients']) {
+                this.refs['alteredExpression.expressedInPatients'].resetValue();
+                this.setState({expressedInPatients: false});
+            }
+            // If a subtype is not selected, do not let the user  specify the experimental name
             if (tempExperimentalSubtype == 'none' || tempExperimentalSubtype === '') {
                 this.setState({
                     experimentalTypeDescription: this.getExperimentalTypeDescription(this.state.experimentalType),

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -131,19 +131,18 @@ var ExperimentalCuration = React.createClass({
 
     // Handle value changes in forms
     handleChange: function(ref, e) {
-        var clinvarid, othervariant;
+        var clinvarid, othervariant, user;
         if (ref === 'experimentalName' && this.refs[ref].getValue()) {
             this.setState({experimentalName: this.refs[ref].getValue()});
         } else if (ref === 'experimentalType') {
             var tempExperimentalType = this.refs[ref].getValue();
-            // set values for assessmentTracker
-            var user = this.props.session && this.props.session.user_properties;
-            var userAssessment;
-            if (this.state.experimental && this.state.experimental.assessments) {
-                userAssessment = Assessments.userAssessment(this.state.experimental.assessments, user && user.uuid);
+            // if assessmentTracker was set previously, reset its value
+            if (this.cv.assessmentTracker) {
+                // set values for assessmentTracker
+                user = this.props.session && this.props.session.user_properties;
+                this.cv.assessmentTracker.setCurrentVal(Assessments.DEFAULT_VALUE);
+                this.setAssessmentValue(this.cv.assessmentTracker, Assessments.DEFAULT_VALUE);
             }
-            // set assessmentTracker
-            this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, tempExperimentalType);
             this.setState({
                 experimentalName: '',
                 experimentalType: tempExperimentalType,
@@ -171,6 +170,13 @@ var ExperimentalCuration = React.createClass({
         } else if (ref === 'experimentalSubtype') {
             var tempExperimentalSubtype = this.refs[ref].getValue();
             this.setState({experimentalSubtype: tempExperimentalSubtype});
+            // if assessmentTracker was set previously, reset its value
+            if (this.cv.assessmentTracker) {
+                // set values for assessmentTracker
+                user = this.props.session && this.props.session.user_properties;
+                this.cv.assessmentTracker.setCurrentVal(Assessments.DEFAULT_VALUE);
+                this.setAssessmentValue(this.cv.assessmentTracker, Assessments.DEFAULT_VALUE);
+            }
             // Reset values when changing between Subtypes
             if (this.refs['experimentalName']) {
                 this.refs['experimentalName'].resetValue();


### PR DESCRIPTION
Testing:

1. Create GDM and add PMID
2. Navigate to add an Experimental Data object
3. Set Type to 'Biochemical Function' and subtype to 'A'.
4. Fill out the form, including Assessment, but DO NOT SUBMIT. Instead, change the subtype to 'B' and confirm that the entire form resets, including Assessment.
5. Repeat steps 3 and 4, but with Type 'Expression' and subtype 'A'.
6. Repeat steps 3 and 4, but with any other Type, to any other Type (note the Assessment value)