### PR TITLE
Connects to #577. Fix issues with assessment

### DIFF
--- a/src/clincoded/static/components/assessment.js
+++ b/src/clincoded/static/components/assessment.js
@@ -209,15 +209,17 @@ var AssessmentPanel = module.exports.AssessmentPanel = React.createClass({
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (nextProps.assessmentTracker.currentVal == DEFAULT_VALUE) {
-            this.refs['assessment'].resetValue();
+        if (this.refs.assessment && nextProps.assessmentTracker && nextProps.assessmentTracker.currentVal == DEFAULT_VALUE) {
+            this.refs.assessment.resetValue();
         }
     },
 
     // Called when the dropdown value changes
     handleChange: function(assessmentTracker, e) {
-        var value = this.refs['assessment'].getValue();
-        this.props.updateValue(assessmentTracker, value);
+        if (this.refs.assessment) {
+            var value = this.refs.assessment.getValue();
+            this.props.updateValue(assessmentTracker, value);
+        }
     },
 
     render: function() {


### PR DESCRIPTION
Previous changes to assessment module made it not work on Variant curation page (calling form functions before form is rendered)

Testing:

* Create GDM, add PMID, add item with Variant
* Check Variant's curation page and ensure that it works (display + assessment)
* Check other pages where assessment occurs (Experimental Data, Family, Individual)