### PR TITLE
Connects to #575 kl display variant preferred name

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -91,29 +91,29 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
 
-
+            var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
             if (gdm.provisionalClassifications && gdm.provisionalClassifications.length > 0) {
-                for (var i in gdm.provisionalClassifications) {
-                    if (userMatch(gdm.provisionalClassifications[i].submitted_by, session)) {
+                gdm.provisionalClassifications.forEach(this_provisional => {
+                    if (userMatch(this_provisional.submitted_by, session)) {
                         provisionalExist = true;
-                        provisional = gdm.provisionalClassifications[i];
-                        break;
+                        provisional = this_provisional;
+                        //break;
                     }
-                }
+                });
             }
 
             // go through all annotations, groups, families and individuals to find one proband individual with all variant assessed.
             var supportedVariants = getUserPathogenicity(gdm, session);
             if (!summaryButton && gdm.annotations && gdm.annotations.length > 0 && supportedVariants && supportedVariants.length > 0) {
-                for (var i in gdm.annotations) {
+                for (i in gdm.annotations) {
                     var annotation = gdm.annotations[i];
                     if (annotation.individuals && annotation.individuals.length > 0 && searchProbandIndividual(annotation.individuals, supportedVariants)) {
                         summaryButton = true;
                         break;
                     }
                     if (!summaryButton && annotation.families && annotation.families.length > 0) {
-                        for (var j in annotation.families) {
+                        for (j in annotation.families) {
                             if (annotation.families[j].individualIncluded && annotation.families[j].individualIncluded.length > 0 &&
                                 searchProbandIndividual(annotation.families[j].individualIncluded, supportedVariants)) {
                                 summaryButton = true;
@@ -125,9 +125,9 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                         break;
                     }
                     else if (annotation.groups && annotation.groups.length > 0) {
-                        for (var j in annotation.groups) {
+                        for (j in annotation.groups) {
                             if (annotation.groups[j].familyIncluded && annotation.groups[j].familyIncluded.length > 0) {
-                                for (var k in annotation.groups[j].familyIncluded) {
+                                for (k in annotation.groups[j].familyIncluded) {
                                     if (annotation.groups[j].familyIncluded[k].individualIncluded && annotation.groups[j].familyIncluded[k].individualIncluded.length > 0 &&
                                         searchProbandIndividual(annotation.groups[j].familyIncluded[k].individualIncluded, supportedVariants)) {
                                         summaryButton = true;
@@ -258,11 +258,14 @@ var all_in = function(individualVariantList, allSupportedlist) {
 
 // function to find one proband individual with all variants assessed.
 var searchProbandIndividual = function(individualList, variantList) {
-    for (var i in individualList) {
-        if (individualList[i].proband && individualList[i].variants && individualList[i].variants.length > 0 && all_in(individualList[i].variants, variantList)) {
+    individualList.forEach(individual => {
+        if (individual.proband && individual.variants && individual.variants.length > 0 && all_in(individual.variants, variantList)) {
             return true;
         }
-    }
+    });
+    //for (var i in individualList) {
+
+    //}
     return false;
 };
 
@@ -289,7 +292,16 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                         <p>Click a variant to View, Curate, or Edit/Assess it. The icon indicates curation by one or more curators.</p>
                         {Object.keys(collectedVariants).map(variantId => {
                             var variant = collectedVariants[variantId];
-                            var variantName = variant.clinvarVariantId ? variant.clinvarVariantId : truncateString(variant.otherDescription, 20);
+                            var variantName = variant.clinvarVariantTitle ? variant.clinvarVariantTitle :
+                                (variant.clinvarVariantId ? variant.clinvarVariantId : variant.otherDescription);
+                            var blueBarStyle = null;
+                            if (variantName.length > 50) {
+                                //variantName = variantName.substring(0, variantName.length/2) + ' ' + variantName.substring(variantName.length/2, variantName.length);
+                                //_.range(row_num).map(i => {
+
+                                //});
+                            }
+                            //var variantName = variant.clinvarVariantId ? variant.clinvarVariantId : truncateString(variant.otherDescription, 20);
                             var userPathogenicity = null;
 
                             // See if the variant has a pathogenicity curated in the current GDM
@@ -311,11 +323,14 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                             inCurrentGdm = userPathogenicity ? true : false;
 
                             return (
-                                <div className="col-sm-6 col-md-3 col-lg-2" key={variant.uuid}>
-                                    <a className="btn btn-primary btn-xs" href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}>
-                                        {inCurrentGdm ? <i className="icon icon-sticky-note"></i> : null}
-                                        {variantName}
-                                    </a>
+                                <div className="col-sm-4" key={variant.uuid}>
+                                        <div className="btn btn-primary btn-xs" style={{'color':'#fff', 'word-wrap':'normal'}}>
+                                            <span>{inCurrentGdm ? <i className="icon icon-sticky-note"></i> : null}</span>
+                                            <a style={{'color':'#fff', 'word-wrap':'normal'}}
+                                                href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}>
+                                                {variantName.length <= 50 ? variantName : <span>{variantName.substring(0, variantName.length/2)}<br />{variantName.substring(variantName.length/2, variantName.length)}</span>}
+                                            </a>
+                                        </div>
                                 </div>
                             );
                         })}
@@ -1178,15 +1193,17 @@ var collectAnnotationVariants = function(annotation) {
     if (annotation && Object.keys(annotation).length) {
         // Search unassociated individuals
         annotation.individuals.forEach(function(individual) {
-            individual.variants.forEach(function(variant) {
-                allVariants[variant['@id']] = variant;
-            });
+            if (individual.variants && individual.variants.length) {
+                individual.variants.forEach(function(variant) {
+                    allVariants[variant['@id']] = variant;
+                });
+            }
         });
 
         // Search unassociated families
         annotation.families.forEach(function(family) {
             // Collect variants in the family's segregation
-            if (family.segregation && family.segregation.variants) {
+            if (family.segregation && family.segregation.variants && family.segregation.variants.length) {
                 family.segregation.variants.forEach(function(variant) {
                     allVariants[variant['@id']] = variant;
                 });

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -301,7 +301,7 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                             var char_in_line = 46;
                             var nameDisplay;
                             //var blueBarStyle = null;
-                            if (variant.clinvarVariantTitle && variantName.length <= char_in_line) {
+                            if (variantName.length <= char_in_line) {
                                 nameDisplay = variantName;
                             } else {
                                 nameDisplay = variantName.substr(0, char_in_line-4) + ' ...';

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -91,10 +91,10 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
 
-            //var i, j, k;
+            var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
             if (gdm.provisionalClassifications && gdm.provisionalClassifications.length > 0) {
-                for (var i in gdm.provisionalClassifications) {
+                for (i in gdm.provisionalClassifications) {
                     if (userMatch(gdm.provisionalClassifications[i].submitted_by, session)) {
                         provisionalExist = true;
                         provisional = gdm.provisionalClassifications[i];
@@ -106,14 +106,14 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             // go through all annotations, groups, families and individuals to find one proband individual with all variant assessed.
             var supportedVariants = getUserPathogenicity(gdm, session);
             if (!summaryButton && gdm.annotations && gdm.annotations.length > 0 && supportedVariants && supportedVariants.length > 0) {
-                for (var i in gdm.annotations) {
+                for (i in gdm.annotations) {
                     var annotation = gdm.annotations[i];
                     if (annotation.individuals && annotation.individuals.length > 0 && searchProbandIndividual(annotation.individuals, supportedVariants)) {
                         summaryButton = true;
                         break;
                     }
                     if (!summaryButton && annotation.families && annotation.families.length > 0) {
-                        for (var j in annotation.families) {
+                        for (j in annotation.families) {
                             if (annotation.families[j].individualIncluded && annotation.families[j].individualIncluded.length > 0 &&
                                 searchProbandIndividual(annotation.families[j].individualIncluded, supportedVariants)) {
                                 summaryButton = true;
@@ -125,9 +125,9 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                         break;
                     }
                     else if (annotation.groups && annotation.groups.length > 0) {
-                        for (var j in annotation.groups) {
+                        for (j in annotation.groups) {
                             if (annotation.groups[j].familyIncluded && annotation.groups[j].familyIncluded.length > 0) {
-                                for (var k in annotation.groups[j].familyIncluded) {
+                                for (k in annotation.groups[j].familyIncluded) {
                                     if (annotation.groups[j].familyIncluded[k].individualIncluded && annotation.groups[j].familyIncluded[k].individualIncluded.length > 0 &&
                                         searchProbandIndividual(annotation.groups[j].familyIncluded[k].individualIncluded, supportedVariants)) {
                                         summaryButton = true;
@@ -328,7 +328,7 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                             inCurrentGdm = userPathogenicity ? true : false;
 
                             return (
-                                <div className="col-sm-4" key={variant.uuid}>
+                                <div className="col-sm-4 col-md-4 col-lg-4" key={variant.uuid}>
                                     <a className="btn btn-primary btn-xs"
                                         href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}
                                         title={variantName}>

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -91,29 +91,29 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
 
-            var i, j, k;
+            //var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
             if (gdm.provisionalClassifications && gdm.provisionalClassifications.length > 0) {
-                gdm.provisionalClassifications.forEach(this_provisional => {
-                    if (userMatch(this_provisional.submitted_by, session)) {
+                for (var i in gdm.provisionalClassifications) {
+                    if (userMatch(gdm.provisionalClassifications[i].submitted_by, session)) {
                         provisionalExist = true;
-                        provisional = this_provisional;
-                        //break;
+                        provisional = gdm.provisionalClassifications[i];
+                        break;
                     }
-                });
+                }
             }
 
             // go through all annotations, groups, families and individuals to find one proband individual with all variant assessed.
             var supportedVariants = getUserPathogenicity(gdm, session);
             if (!summaryButton && gdm.annotations && gdm.annotations.length > 0 && supportedVariants && supportedVariants.length > 0) {
-                for (i in gdm.annotations) {
+                for (var i in gdm.annotations) {
                     var annotation = gdm.annotations[i];
                     if (annotation.individuals && annotation.individuals.length > 0 && searchProbandIndividual(annotation.individuals, supportedVariants)) {
                         summaryButton = true;
                         break;
                     }
                     if (!summaryButton && annotation.families && annotation.families.length > 0) {
-                        for (j in annotation.families) {
+                        for (var j in annotation.families) {
                             if (annotation.families[j].individualIncluded && annotation.families[j].individualIncluded.length > 0 &&
                                 searchProbandIndividual(annotation.families[j].individualIncluded, supportedVariants)) {
                                 summaryButton = true;
@@ -125,9 +125,9 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                         break;
                     }
                     else if (annotation.groups && annotation.groups.length > 0) {
-                        for (j in annotation.groups) {
+                        for (var j in annotation.groups) {
                             if (annotation.groups[j].familyIncluded && annotation.groups[j].familyIncluded.length > 0) {
-                                for (k in annotation.groups[j].familyIncluded) {
+                                for (var k in annotation.groups[j].familyIncluded) {
                                     if (annotation.groups[j].familyIncluded[k].individualIncluded && annotation.groups[j].familyIncluded[k].individualIncluded.length > 0 &&
                                         searchProbandIndividual(annotation.groups[j].familyIncluded[k].individualIncluded, supportedVariants)) {
                                         summaryButton = true;
@@ -258,14 +258,16 @@ var all_in = function(individualVariantList, allSupportedlist) {
 
 // function to find one proband individual with all variants assessed.
 var searchProbandIndividual = function(individualList, variantList) {
-    individualList.forEach(individual => {
-        if (individual.proband && individual.variants && individual.variants.length > 0 && all_in(individual.variants, variantList)) {
+    //individualList.forEach(individual => {
+    //    if (individual.proband && individual.variants && individual.variants.length > 0 && all_in(individual.variants, variantList)) {
+    //        return true;
+    //    }
+    //});
+    for (var i in individualList) {
+        if (individualList[i].proband && individualList[i].variants && individualList[i].variants.length > 0 && all_in(individualList[i].variants, variantList)) {
             return true;
         }
-    });
-    //for (var i in individualList) {
-
-    //}
+    }
     return false;
 };
 
@@ -294,14 +296,17 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                             var variant = collectedVariants[variantId];
                             var variantName = variant.clinvarVariantTitle ? variant.clinvarVariantTitle :
                                 (variant.clinvarVariantId ? variant.clinvarVariantId : variant.otherDescription);
-                            var blueBarStyle = null;
-                            if (variantName.length > 50) {
-                                //variantName = variantName.substring(0, variantName.length/2) + ' ' + variantName.substring(variantName.length/2, variantName.length);
-                                //_.range(row_num).map(i => {
-
-                                //});
+                            // shorten long title
+                            // 46 char max
+                            var char_in_line = 46;
+                            var nameDisplay;
+                            //var blueBarStyle = null;
+                            if (variant.clinvarVariantTitle && variantName.length <= char_in_line) {
+                                nameDisplay = variantName;
+                            } else {
+                                nameDisplay = variantName.substr(0, char_in_line-4) + ' ...';
                             }
-                            //var variantName = variant.clinvarVariantId ? variant.clinvarVariantId : truncateString(variant.otherDescription, 20);
+
                             var userPathogenicity = null;
 
                             // See if the variant has a pathogenicity curated in the current GDM
@@ -324,13 +329,12 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
 
                             return (
                                 <div className="col-sm-4" key={variant.uuid}>
-                                        <div className="btn btn-primary btn-xs" style={{'color':'#fff', 'word-wrap':'normal'}}>
-                                            <span>{inCurrentGdm ? <i className="icon icon-sticky-note"></i> : null}</span>
-                                            <a style={{'color':'#fff', 'word-wrap':'normal'}}
-                                                href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}>
-                                                {variantName.length <= 50 ? variantName : <span>{variantName.substring(0, variantName.length/2)}<br />{variantName.substring(variantName.length/2, variantName.length)}</span>}
-                                            </a>
-                                        </div>
+                                    <a className="btn btn-primary btn-xs"
+                                        href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}
+                                        title={variantName}>
+                                        {nameDisplay}
+                                        {inCurrentGdm ? <i className="icon icon-sticky-note"></i> : null}
+                                    </a>
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -388,7 +388,17 @@ var VariantCuration = React.createClass({
                     <div className="viewer-titles">
                         <h1>{(pathogenicity ? 'Edit' : 'Curate') + ' Variant Information'}</h1>
                         {variant ?
-                            <h2>{variant.clinvarVariantId ? <span>VariationId: <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></span> : <span>{'Description: ' + variant.otherDescription}</span>}</h2>
+                            <h2>{variant.clinvarVariantId ? (
+                                <div className="row" style={{'padding-left':'15px'}}>
+                                    <span>VariationId: <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></span>
+                                    <br />
+                                    <dl>
+                                        <dt style={{'width':'20%', 'font-weight':'normal', 'float':'left'}}>ClinVar Preferred Name:&nbsp;</dt>
+                                        <dd style={{'width':'75%', 'word-wrap':'break-word', 'float':'left'}}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
+                                    </dl>
+                                </div>
+                            )
+                            : <span>{'Description: ' + variant.otherDescription}</span>}</h2>
                         : null}
                         {curatorName ? <h2>{'Curator: ' + curatorName}</h2> : null}
                     </div>

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -192,7 +192,7 @@
         "last_modified": "2015-10-22T22:59:10.000000+00:00"
     },
     {
-        "uuid": "31353737-0973-41ec-8985-8f7eccaaf5da",
+        "uuid": "30f092b3-e87c-4d85-aa3f-10479644953c",
         "clinvarVariantId": "9492",
         "dbSNPId": "",
         "clinVarRCV": "RCV000010100",
@@ -204,7 +204,7 @@
         "last_modified": "2015-10-22T22:59:10.000000+00:00"
     },
     {
-        "uuid": "2bc9e95e-fba8-4b11-b16e-56514f5e6260",
+        "uuid": "e7c5ff6e-bc3a-4474-a07c-8538efe124e2",
         "clinvarVariantId": "90973",
         "dbSNPId": "",
         "clinVarRCV": "RCV000076475",

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -190,5 +190,17 @@
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-10-21T22:47:10.000000+00:00",
         "last_modified": "2015-10-22T22:59:10.000000+00:00"
+    },
+    {
+        "uuid": "31353737-0973-41ec-8985-8f7eccaaf5da",
+        "clinvarVariantId": "157591",
+        "dbSNPId": "",
+        "clinVarRCV": "RCV000144919",
+        "clinvarVariantTitle": "NC_000018.10:g.657646_657673CCGCGCCACTTGGCCTGCCTCCGTCCCG[2][3][4][7][8][9]",
+        "hgvsNames": [],
+        "otherDescription": "",
+        "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
+        "date_created": "2015-10-21T22:47:10.000000+00:00",
+        "last_modified": "2015-10-22T22:59:10.000000+00:00"
     }
 ]

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -193,14 +193,26 @@
     },
     {
         "uuid": "31353737-0973-41ec-8985-8f7eccaaf5da",
-        "clinvarVariantId": "157591",
+        "clinvarVariantId": "9492",
         "dbSNPId": "",
-        "clinVarRCV": "RCV000144919",
-        "clinvarVariantTitle": "NC_000018.10:g.657646_657673CCGCGCCACTTGGCCTGCCTCCGTCCCG[2][3][4][7][8][9]",
+        "clinVarRCV": "RCV000010100",
+        "clinvarVariantTitle": "NM_005502.3(ABCA1):c.1584_1597delTGAGAGGAAGTTCTinsCGGGCGTGGTGGCAGGAGCTGTAATCCCAGCTACTTGGGAGGCTGAGGCACGAGAATCACTTGAACTCAGGAGGCAGAGGTTGCAGTGAGCTGAGGTCACGCCACTGTAC (p.Glu529_Gly867delinsGlyArgGlyGlyArgSerCysAsnProSerTyrLeuGlyGlyTer)",
         "hgvsNames": [],
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-10-21T22:47:10.000000+00:00",
         "last_modified": "2015-10-22T22:59:10.000000+00:00"
+    },
+    {
+        "uuid": "2bc9e95e-fba8-4b11-b16e-56514f5e6260",
+        "clinvarVariantId": "90973",
+        "dbSNPId": "",
+        "clinVarRCV": "RCV000076475",
+        "clinvarVariantTitle": "NM_000251.2(MSH2):c.243_273del31insCTGACAAGCGCCTATAGCACTCGAATAATTCTTCTCACCCTAACAGGTCAGCCTCGCTTCCCAGCCCTCACTAACATTAACGAAAACAACCCACCCACTAAACCCCATTAAACGCCTAACAATCGGAAGCCTATTTTGCAGGGTTTCTCCATCACCAACAGCATTCTCCCCACATCCACCCCCCAAATGACAATCCCACTTTACTTAAAACTCACAG (p.Lys82_Glu425delinsTer)",
+        "hgvsNames": [],
+        "otherDescription": "",
+        "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
+        "date_created": "2016-02-02T22:47:10.000000+00:00",
+        "last_modified": "2015-02-02T22:59:10.000000+00:00"
     }
 ]


### PR DESCRIPTION
Following tickets #543 (Obtain preferred HGVS name) and #559 (Schema change), this one display ClinVar preferred  name in curation-central page and variant curation page.

**Changes**
- Add code in curator.js read variant properties, shorten preferred name if it's too long, and display the name, or variation id if no preferred name, or other description if no variation id in curation-central page.
![screen shot 2016-02-03 at 3 24 32 pm](https://cloud.githubusercontent.com/assets/9206696/12800533/a05f0136-ca8a-11e5-9ff5-a8a82d9132ca.png)

- Add code in variant-curation.js to display preferred name if existing in variant curation page.
![screen shot 2016-02-03 at 4 02 55 pm](https://cloud.githubusercontent.com/assets/9206696/12801211/a1a4bbd0-ca8f-11e5-936f-277c4897ec0a.png)