### PR TITLE
Connects to #409. Anchor added or selected PMID.

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -54,13 +54,6 @@ var CurationCentral = React.createClass({
             if (this.state.currGdm) {
                 window.history.replaceState(window.state, '', '/curation-central/?gdm=' + this.state.currGdm.uuid + '&pmid=' + pmid);
             }
-
-            // Focus the current PMID selection in left PMID column
-            var userPmidList = document.getElementById('user-pmid-list');
-            var selectedPmid = document.getElementById('selected-pmid');
-            if (selectedPmid && userPmidList.scrollHeight > userPmidList.clientHeight) {
-                userPmidList.scrollTop = userPmidList.scrollTop + selectedPmid.offsetTop - userPmidList.offsetTop - 10;
-            }
         }
     },
 
@@ -78,6 +71,15 @@ var CurationCentral = React.createClass({
                 pmid = annotations[0].article.pmid;
             }
             this.currPmidChange(pmid);
+
+            // Focus the current PMID selection in left PMID column
+            var userPmidList = document.getElementById('user-pmid-list');
+            var selectedPmid = document.getElementById('selected-pmid');
+            userPmidList.scrollTop = 0;
+            if (selectedPmid && userPmidList.scrollHeight > userPmidList.clientHeight) {
+                userPmidList.scrollTop += selectedPmid.offsetTop - 50;
+            }
+
             return gdm;
         }).catch(function(e) {
             console.log('GETGDM ERROR=: %o', e);

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -54,6 +54,13 @@ var CurationCentral = React.createClass({
             if (this.state.currGdm) {
                 window.history.replaceState(window.state, '', '/curation-central/?gdm=' + this.state.currGdm.uuid + '&pmid=' + pmid);
             }
+
+            // Focus the current PMID selection in left PMID column
+            var userPmidList = document.getElementById('user-pmid-list');
+            var selectedPmid = document.getElementById('selected-pmid');
+            if (selectedPmid && userPmidList.scrollHeight > userPmidList.clientHeight) {
+                userPmidList.scrollTop = userPmidList.scrollTop + selectedPmid.offsetTop - userPmidList.offsetTop - 10;
+            }
         }
     },
 
@@ -227,12 +234,13 @@ var PmidSelectionList = React.createClass({
                     </Modal>
                 </div>
                 {annotations ?
-                    <div className="pmid-selection-list">
+                    <div className="pmid-selection-list" id="user-pmid-list">
                         {annotations.map(annotation => {
                             var classList = 'pmid-selection-list-item' + (annotation.article.pmid === this.props.currPmid ? ' curr-pmid' : '');
+                            var elementId = (annotation.article.pmid === this.props.currPmid ? 'selected-pmid' : '');
 
                             return (
-                                <div key={annotation.article.pmid} className={classList} onClick={this.props.currPmidChange.bind(null, annotation.article.pmid)}>
+                                <div key={annotation.article.pmid} className={classList} id={elementId} onClick={this.props.currPmidChange.bind(null, annotation.article.pmid)}>
                                     <div className="pmid-selection-list-specs">
                                         <PmidSummary article={annotation.article} />
                                     </div>

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -139,6 +139,7 @@
 .pmid-selection-list {
     max-height: 250px;
     overflow-y: auto;
+    background-color: #f9f9f9;
     border: 1px solid #e0e0e0;
 
     @media screen and (min-width: $screen-md-min) {
@@ -147,17 +148,30 @@
 }
 
 .pmid-selection-list-item {
+    margin: 10px;
     padding: 10px;
-    border-top: 1px solid #e0e0e0;
+    border: 1px solid #e0e0e0;
     cursor: pointer;
-    background-color: #f0f0f0;
+    background-color: #ffffff;
+    @include border-radius(3px);
+    box-shadow: 0 2px #e6e6e6;
+    opacity: 0.6;
+    transition: opacity .25s ease-in-out;
+    -moz-transition: opacity .25s ease-in-out;
+    -webkit-transition: opacity .25s ease-in-out;
 
     &:hover {
-        background-color: $color-hover;
+        box-shadow: 0 0 6px lighten($color-trim, 15%);
+        opacity: 1;
     }
 
     &.curr-pmid {
-        background-color: #fff;
+        box-shadow: 0 2px 0 1px lighten($color-trim, 25%);
+        border: 1px solid $color-trim;
+        opacity: 1;
+        //background-image: linear-gradient(to bottom, #f5fcff 0, #e1eff5 100%);
+        //background-repeat: repeat-x;
+        //background-color: #f5fcff;
     }
 }
 
@@ -167,6 +181,18 @@
 
 .pmid-selection-help {
     margin-top: 20px;
+}
+
+.curation-content .curr-pmid-overview {
+    .pmid-overview-abstract {
+        h4 {
+            border-bottom: 1px solid $color-trim;
+            color: $color-btn;
+            font-weight: 600;
+            font-size: 150%;
+            padding-bottom: 6px;
+        }
+    }
 }
 
 .panel-curator {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -129,7 +129,7 @@
     border-top: 1px solid #e0e0e0;
     border-right: 1px solid #e0e0e0;
     border-left: 1px solid #e0e0e0;
-    background-color: $color-neutral-bg;
+    background-color: #e0e0e0;
 }
 
 .pmid-selection-add-btn {
@@ -139,8 +139,8 @@
 .pmid-selection-list {
     max-height: 250px;
     overflow-y: auto;
-    background-color: #f9f9f9;
-    border: 1px solid #e0e0e0;
+    background-color: #f0f0f0;
+    border: 1px solid #dddddd;
 
     @media screen and (min-width: $screen-md-min) {
         max-height: 500px;
@@ -150,28 +150,27 @@
 .pmid-selection-list-item {
     margin: 10px;
     padding: 10px;
-    border: 1px solid #e0e0e0;
+    border: 1px solid darken(#dddddd, 10%);
     cursor: pointer;
     background-color: #ffffff;
     @include border-radius(3px);
-    box-shadow: 0 2px #e6e6e6;
-    opacity: 0.6;
-    transition: opacity .25s ease-in-out;
-    -moz-transition: opacity .25s ease-in-out;
-    -webkit-transition: opacity .25s ease-in-out;
+    box-shadow: 0 2px #e0e0e0;
 
-    &:hover {
-        box-shadow: 0 0 6px lighten($color-trim, 15%);
-        opacity: 1;
+    div {
+        opacity: 0.5;
+        transition: opacity .25s ease-in-out;
+        -moz-transition: opacity .25s ease-in-out;
+        -webkit-transition: opacity .25s ease-in-out;
     }
 
     &.curr-pmid {
         box-shadow: 0 2px 0 1px lighten($color-trim, 25%);
         border: 1px solid $color-trim;
+    }
+
+    &:hover div,
+    &.curr-pmid div {
         opacity: 1;
-        //background-image: linear-gradient(to bottom, #f5fcff 0, #e1eff5 100%);
-        //background-repeat: repeat-x;
-        //background-color: #f5fcff;
     }
 }
 
@@ -183,15 +182,15 @@
     margin-top: 20px;
 }
 
-.curation-content .curr-pmid-overview {
-    .pmid-overview-abstract {
-        h4 {
-            border-bottom: 1px solid $color-trim;
-            color: $color-btn;
-            font-weight: 600;
-            font-size: 150%;
-            padding-bottom: 6px;
-        }
+.curation-content .col-md-6 {
+    padding: 0;
+
+    .curr-pmid-overview {
+        background-color: #ffffff;
+        border: 1px solid $color-trim;
+        box-shadow: 0 2px 0 1px lighten($color-trim, 25%);
+        @include border-radius(3px);
+        padding: 10px 15px;
     }
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -154,7 +154,6 @@
     cursor: pointer;
     background-color: #ffffff;
     @include border-radius(3px);
-    box-shadow: 0 2px #e0e0e0;
 
     div {
         opacity: 0.5;
@@ -164,8 +163,8 @@
     }
 
     &.curr-pmid {
-        box-shadow: 0 2px 0 1px lighten($color-trim, 25%);
-        border: 1px solid $color-trim;
+        border: 4px solid $color-trim;
+        @include border-radius(4px);
     }
 
     &:hover div,
@@ -187,9 +186,8 @@
 
     .curr-pmid-overview {
         background-color: #ffffff;
-        border: 1px solid $color-trim;
-        box-shadow: 0 2px 0 1px lighten($color-trim, 25%);
-        @include border-radius(3px);
+        border: 4px solid $color-trim;
+        @include border-radius(4px);
         padding: 10px 15px;
     }
 }


### PR DESCRIPTION
This PR is to address the need to differentiate the added/selected PMID on the GDM page requested in #409.

**Testing steps for #409:**
1. Go to any given GDM page and add a new PMID. Upon successfully adding the PMID and dismissing the modal box, the newly added PMID should be shown within the viewable area of the scrollable far-left column.
2. Refreshing the GDM page should show the selected PMID even after it was scrolled off the bounding viewable area.
3. From the Dashboard page, clicking on a given PMID from the "Your Recent History" list should show the selected PMID in the far-left column on the subsequent GDM page.
4. Lastly, the selected PMID is highlighted in thicker blue border to differentiate itself from the non-selected ones. To help the user to associate the selected PMID with the displayed citation and abstract in the center, the same thicker blue border is also applied to the center.

The above changes can be reviewed at:
https://409-jz-highlight-selected-pmid-363a23d-jzhen.demo.clinicalgenome.org