### PR TITLE
COnnects to #581 kl preferred name each pmid

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -33,6 +33,7 @@ var CurationCentral = React.createClass({
 
     getInitialState: function() {
         return {
+            winWidth: null, // browser's width, used to set how many char to show variant perferred name in curator palette
             currPmid: queryKeyValue('pmid', this.props.href),
             currGdm: null
         };
@@ -77,9 +78,18 @@ var CurationCentral = React.createClass({
         });
     },
 
+    // check browser's width and save the value in state
+    componentWillMount: function() {
+        //var winWidth = window.innerWidth;
+        //this.setState({winWidth: winWidth});
+    },
+
     // After the Curator Central page component mounts, grab the uuid from the query string and
     // retrieve the corresponding GDM from the DB.
     componentDidMount: function() {
+        var winWidth = window.innerWidth;
+        this.setState({winWidth: winWidth});
+
         var gdmUuid = queryKeyValue('gdm', this.props.href);
         var pmid = queryKeyValue('pmid', this.props.href);
         if (gdmUuid) {
@@ -167,7 +177,7 @@ var CurationCentral = React.createClass({
                         </div>
                         {currArticle ?
                             <div className="col-md-3">
-                                <CurationPalette gdm={gdm} annotation={annotation} session={session} />
+                                <CurationPalette gdm={gdm} annotation={annotation} session={session} winWidth={this.state.winWidth} />
                             </div>
                         : null}
                     </div>

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -78,12 +78,6 @@ var CurationCentral = React.createClass({
         });
     },
 
-    // check browser's width and save the value in state
-    componentWillMount: function() {
-        //var winWidth = window.innerWidth;
-        //this.setState({winWidth: winWidth});
-    },
-
     // After the Curator Central page component mounts, grab the uuid from the query string and
     // retrieve the corresponding GDM from the DB.
     componentDidMount: function() {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -781,7 +781,6 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session, wi
 
     return (
         <div className="panel-evidence-group">
-            <span>{winWidth}</span>
             <h5><a href={vCurationURL} title={variantTitle}>{variantDisplay}</a></h5>
             <div className="evidence-curation-info">
                 {variant.submitted_by ?

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -560,24 +560,6 @@ var CurationPalette = module.exports.CurationPalette = React.createClass({
     }
 });
 
-// Display variant(s) either associated to a evidence (group/family/individual/experiemental) or in a pmid
-var displayAssociatedVariant = function(variants, winWidth) {
-    // set length based on window width
-    var adjWidth = winWidth >= 1200 ? [18, 2] : (winWidth >= 992 ? [12, 4] : [65, 2]);
-    var showItem = [];
-    if (variants && variants.length) {
-        variants.forEach(variant => {
-            // try use preferred title first, then variation id, then other description
-            var sItem = variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.clinvarVarVariantId ? variant.clinvarVarVariantId : variant.otherDescription);
-            if (sItem.length > adjWidth[0]) {
-                // shorten if too long
-                sItem = sItem.substr(0, adjWidth[0]-adjWidth[1]) + ' ...';
-            }
-            showItem.push(sItem);
-        });
-    }
-    return showItem;
-};
 
 // Render a family in the curator palette.
 var renderGroup = function(group, gdm, annotation, curatorMatch) {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2552,17 +2552,30 @@ var ExperimentalViewer = React.createClass({
                             return (
                                 <div className="variant-view-panel">
                                     <h5>Variant {i + 1}</h5>
-                                    <dl className="dl-horizontal">
+                                    {variant.clinvarVariantId ?
                                         <div>
-                                            <dt>ClinVar VariationID</dt>
-                                            <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
+                                            <dl className="dl-horizontal">
+                                                <dt>ClinVar VariationID</dt>
+                                                <dd style={{'padding-left':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                            </dl>
                                         </div>
-
+                                    : null }
+                                    {variant.clinvarVariantTitle ?
                                         <div>
-                                            <dt>Other description</dt>
-                                            <dd>{variant.otherDescription}</dd>
+                                            <dl className="dl-horizontal">
+                                                <dt>ClinVar Preferred Title</dt>
+                                                <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            </dl>
                                         </div>
-                                    </dl>
+                                    : null}
+                                    {variant.otherDescription ?
+                                        <div>
+                                            <dl className="dl-horizontal">
+                                                <dt>Other description</dt>
+                                                <dd>{variant.otherDescription}</dd>
+                                            </dl>
+                                        </div>
+                                    : null }
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1949,17 +1949,30 @@ var FamilyViewer = React.createClass({
                             return (
                                 <div className="variant-view-panel" key={variant.uuid}>
                                     <h5>Variant {i + 1}</h5>
-                                    <dl className="dl-horizontal">
+                                    {variant.clinvarVariantId ?
                                         <div>
-                                            <dt>ClinVar VariationID</dt>
-                                            <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
+                                            <dl className="dl-horizontal">
+                                                <dt>ClinVar VariationID</dt>
+                                                <dd style={{'padding-left':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                            </dl>
                                         </div>
-
+                                    : null }
+                                    {variant.clinvarVariantTitle ?
                                         <div>
-                                            <dt>Other description</dt>
-                                            <dd>{variant.otherDescription}</dd>
+                                            <dl className="dl-horizontal">
+                                                <dt>ClinVar Preferred Title</dt>
+                                                <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            </dl>
                                         </div>
-                                    </dl>
+                                    : null}
+                                    {variant.otherDescription ?
+                                        <div>
+                                            <dl className="dl-horizontal">
+                                                <dt>Other description</dt>
+                                                <dd>{variant.otherDescription}</dd>
+                                            </dl>
+                                        </div>
+                                    : null }
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1515,20 +1515,34 @@ var IndividualViewer = React.createClass({
 
                     <Panel title={<LabelPanelTitleView individual={individual} variant />} panelClassName="panel-data">
                         {variants.map(function(variant, i) {
+
                             return (
                                 <div key={i} className="variant-view-panel">
                                     <h5>Variant {i + 1}</h5>
-                                    <dl className="dl-horizontal">
-                                        <div>
-                                            <dt>ClinVar VariationID</dt>
-                                            <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
-                                        </div>
-
-                                        <div>
-                                            <dt>Other description</dt>
-                                            <dd>{variant.otherDescription}</dd>
-                                        </div>
-                                    </dl>
+                                        {variant.clinvarVariantId ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar VariationID</dt>
+                                                    <dd style={{'padding-left':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.clinvarVariantTitle ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar Preferred Title</dt>
+                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
+                                            </div>
+                                        : null}
+                                        {variant.otherDescription ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Other description</dt>
+                                                    <dd>{variant.otherDescription}</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -389,12 +389,14 @@ var VariantCuration = React.createClass({
                         <h1>{(pathogenicity ? 'Edit' : 'Curate') + ' Variant Information'}</h1>
                         {variant ?
                             <h2>{variant.clinvarVariantId ? (
-                                <div className="row" style={{'padding-left':'15px'}}>
-                                    <span>VariationId: <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></span>
-                                    <br />
-                                    <dl>
-                                        <dt style={{'width':'20%', 'font-weight':'normal', 'float':'left'}}>ClinVar Preferred Name:&nbsp;</dt>
-                                        <dd style={{'width':'75%', 'word-wrap':'break-word', 'float':'left'}}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
+                                <div>
+                                    <dl className="dl-horizontal">
+                                        <dt style={{'font-weight':'normal'}}>VariationId</dt>
+                                        <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                    </dl>
+                                    <dl className="dl-horizontal">
+                                        <dt style={{'font-weight':'normal'}}>ClinVar Preferred Title</dt>
+                                        <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
                                     </dl>
                                 </div>
                             )


### PR DESCRIPTION
Following change at tickets #575, this ticket functions to display ClinVar preferred title in curator palette for each family, individual or experimental if there is variant associated.

**Changes**
- Edit handling code in curator.js to display ClinVar preferred title in curator palette in curation central page.
 
**Test**
- Create a GDM and add PMID
- Add a family, named Family010, associate variant 90973 and 9492, name proband Ind011 and enter Orphanet id, click Save and go to curation central page. Expect to see "Variants: 2" under Family010 and Ind011in curator palette. When hover the number, 2 preferred titles are shown in a pop-out as below
![screen shot 2016-02-05 at 5 18 47 pm](https://cloud.githubusercontent.com/assets/9206696/12863577/c95e6e3e-cc2c-11e5-83c4-f02effb7dbc4.png)

**End of Test**