### PR TITLE
Connects to #472. Added warning message on new family/individual curation pages.

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1093,6 +1093,42 @@ var FamilyCuration = React.createClass({
         this.setState({variantCount: this.state.variantCount + 1, addVariantDisabled: true});
     },
 
+    // Determine whether a Family is associated with a Group
+    // or
+    // whether an individual is associated with a Family or a Group
+    getAssociation: function(item) {
+        var associatedGroups, associatedFamilies;
+
+        if (this.state.group) {
+            associatedGroups = [this.state.group];
+        } else if (this.state.family && this.state.family.associatedGroups && this.state.family.associatedGroups.length) {
+            associatedGroups = this.state.family.associatedGroups;
+        }
+
+        if (this.state.family) {
+            associatedFamilies = [this.state.family];
+        } else if (this.state.individual && this.state.individual.associatedFamilies && this.state.individual.associatedFamilies.length) {
+            associatedFamilies = this.state.individual.associatedFamilies;
+        }
+
+        switch(item) {
+            case 'individual':
+                return this.state.individual;
+
+            case 'family':
+                return this.state.family;
+
+            case 'associatedFamilies':
+                return associatedFamilies;
+
+            case 'associatedGroups':
+                return associatedGroups;
+
+            default:
+                break;
+        }
+    },
+
     // After the Family Curation page component mounts, grab the GDM, group, family, and annotation UUIDs (as many as given)
     // from the query string and retrieve the corresponding objects from the DB, if they exist. Note, we have to do this after
     // the component mounts because AJAX DB queries can't be done from unmounted components.
@@ -1228,6 +1264,9 @@ var FamilyName = function(displayNote) {
 
     return (
         <div className="row">
+            {!this.getAssociation('family') && !this.getAssociation('associatedGroups') ?
+                <div className="col-sm-7 col-sm-offset-5"><p className="alert alert-warning">If this Family is a member of a Group, please curate the Group first and then add the Family to that Group.</p></div>
+            : null}
             <Input type="text" ref="familyname" label="Family Label:" value={family && family.label} handleChange={this.handleChange}
                 error={this.getFormError('familyname')} clearError={this.clrFormErrors.bind(null, 'familyname')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -746,6 +746,42 @@ var IndividualCuration = React.createClass({
         this.setState({variantCount: this.state.variantCount + 1, addVariantDisabled: true});
     },
 
+    // Determine whether a Family is associated with a Group
+    // or
+    // whether an individual is associated with a Family or a Group
+    getAssociation: function(item) {
+        var associatedGroups, associatedFamilies;
+
+        if (this.state.group) {
+            associatedGroups = [this.state.group];
+        } else if (this.state.family && this.state.family.associatedGroups && this.state.family.associatedGroups.length) {
+            associatedGroups = this.state.family.associatedGroups;
+        }
+
+        if (this.state.family) {
+            associatedFamilies = [this.state.family];
+        } else if (this.state.individual && this.state.individual.associatedFamilies && this.state.individual.associatedFamilies.length) {
+            associatedFamilies = this.state.individual.associatedFamilies;
+        }
+
+        switch(item) {
+            case 'individual':
+                return this.state.individual;
+
+            case 'family':
+                return this.state.family;
+
+            case 'associatedFamilies':
+                return associatedFamilies;
+
+            case 'associatedGroups':
+                return associatedGroups;
+
+            default:
+                break;
+        }
+    },
+
     // After the Family Curation page component mounts, grab the GDM, group, family, and annotation UUIDs (as many as given)
     // from the query string and retrieve the corresponding objects from the DB, if they exist. Note, we have to do this after
     // the component mounts because AJAX DB queries can't be done from unmounted components.
@@ -933,17 +969,18 @@ var IndividualName = function(displayNote) {
                 </p>
             </div>
             : null}
-            <div className="clearfix">
-                <Input type="text" ref="individualname" label={<LabelIndividualName probandLabel={probandLabel} />} value={individual && individual.label} handleChange={this.handleChange}
-                    error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
-                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
-                <p className="col-sm-7 col-sm-offset-5 input-note-below">Note: Do not enter real names in this field. {curator.renderLabelNote('Individual')}</p>
-            </div>
+            {!this.getAssociation('individual') && !this.getAssociation('associatedFamilies') && !this.getAssociation('associatedGroups') ?
+                <div className="col-sm-7 col-sm-offset-5"><p className="alert alert-warning">If this Individual is part of a Family or a Group, please curate that Group or Family first and then add the Individual as a member.</p></div>
+            : null}
+            <Input type="text" ref="individualname" label={<LabelIndividualName probandLabel={probandLabel} />} value={individual && individual.label} handleChange={this.handleChange}
+                error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
+            <p className="col-sm-7 col-sm-offset-5 input-note-below">Note: Do not enter real names in this field. {curator.renderLabelNote('Individual')}</p>
             {displayNote ?
                 <p className="col-sm-7 col-sm-offset-5">Note: If there is more than one individual with IDENTICAL information, you can indicate this at the bottom of this form.</p>
             : null}
             {!family ?
-                <div className="clearfix">
+                <div>
                     <Input type="select" ref="proband" label="Is this Individual a proband:" value={individual && individual.proband ? "Yes" : (individual ? "No" : "none")}
                         error={this.getFormError('proband')} clearError={this.clrFormErrors.bind(null, 'proband')} handleChange={this.handleChange}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required>


### PR DESCRIPTION
This PR is to add warning message on new family/individual curation pages, as well as to fix invisible individual label input field per Min's commit #3449215.

**Testing steps for #472**
1. Go to the GDM page and add a new PMID.
2. From the far-right column under "Evidence for PMID XXX", add a group curation by clicking on the blue Group bar.
3. Fill out the group curation form and add a family curation to the newly created group curation. And add an individual curation to the added family curation.
4. Upon completion, go back to the GDM page. Now click on the blue Family bar to add a new family curation, and on the curation page, you should expect to see a warning message above the "Family Label" input field stating "If this Family is a member of a Group, please curate the Group first and then add the Family to that Group."
5. Return to the GDM page and click on the blue Individual bar to add a new individual curation. On the curation page, you should expect to see a warning message above the "Individual Label" input field stating "If this Individual is part of a Family or a Group, please curate that Group or Family first and then add the Individual as a member."
6. Return to the GDM page, click on either the "Add new Family to this Group" or "Add new Individual to this Group" links under the Group curation panel, or the "Add new Individual to this Family" link under the Family curation panel. On the subsequent curation pages, you should NOT expect to see any of the warning messages above the input fields.
7. Add a family curation without associating any groups and without attaching any individuals. Upon completing the form, return to the GDM page and click on the "Add new Individual to this Family" link under the family with no associations under the Family curation panel. On the subsequent page, you should expect to see the "Individual Label" input field present below the warning message atop.