### PR TITLE
Connects to #581. Variant preferred title.

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -33,6 +33,7 @@ var CurationCentral = React.createClass({
 
     getInitialState: function() {
         return {
+            winWidth: null, // window's width, used to ser # char of preferred tile shown in curator palette
             currPmid: queryKeyValue('pmid', this.props.href),
             currGdm: null
         };
@@ -89,6 +90,9 @@ var CurationCentral = React.createClass({
     // After the Curator Central page component mounts, grab the uuid from the query string and
     // retrieve the corresponding GDM from the DB.
     componentDidMount: function() {
+        var winWidth = window.innerWidth;
+        this.setState({winWidth: winWidth});
+        
         var gdmUuid = queryKeyValue('gdm', this.props.href);
         var pmid = queryKeyValue('pmid', this.props.href);
         if (gdmUuid) {
@@ -176,7 +180,7 @@ var CurationCentral = React.createClass({
                         </div>
                         {currArticle ?
                             <div className="col-md-3">
-                                <CurationPalette gdm={gdm} annotation={annotation} session={session} />
+                                <CurationPalette gdm={gdm} annotation={annotation} session={session} winWidth={this.state.winWidth} />
                             </div>
                         : null}
                     </div>

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -517,7 +517,7 @@ var CurationPalette = module.exports.CurationPalette = React.createClass({
     render: function() {
         var gdm = this.props.gdm;
         var annotation = this.props.annotation;
-        var session = this.props.session;
+        var session = this.props.session && Object.keys(this.props.session).length ? this.props.session : null;
         var winWidth = this.props.winWidth;
         var curatorMatch = annotation && userMatch(annotation.submitted_by, session);
         var groupUrl = curatorMatch ? ('/group-curation/?gdm=' + gdm.uuid + '&evidence=' + this.props.annotation.uuid) : null;
@@ -773,7 +773,7 @@ var renderIndividual = function(individual, gdm, annotation, curatorMatch) {
 };
 
 // Render an experimental data in the curator palette.
-var renderExperimental = function(experimental, gdm, annotation, curatorMatch, winWidth) {
+var renderExperimental = function(experimental, gdm, annotation, curatorMatch) {
     var i = 0;
     var subtype = '';
     // determine if the evidence type has a subtype, and determine the subtype
@@ -841,7 +841,7 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session, wi
     } else {
         variantDisplay = variantTitle;
     }
-    var vCurationURL = '/variant-curation/?all&gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid + '&variant=' + variant.uuid + '&user=' + session.user_properties.uuid;
+    var vCurationURL = '/variant-curation/?all&gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '');
 
     return (
         <div className="panel-evidence-group">

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2570,17 +2570,30 @@ var ExperimentalViewer = React.createClass({
                                 return (
                                     <div className="variant-view-panel">
                                         <h5>Variant {i + 1}</h5>
-                                        <dl className="dl-horizontal">
+                                        {variant.clinvarVariantId ?
                                             <div>
-                                                <dt>ClinVar VariationID</dt>
-                                                <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar VariationID</dt>
+                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                </dl>
                                             </div>
-
+                                        : null }
+                                        {variant.clinvarVariantTitle ?
                                             <div>
-                                                <dt>Other description</dt>
-                                                <dd>{variant.otherDescription}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar Preferred Title</dt>
+                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
                                             </div>
-                                        </dl>
+                                        : null }
+                                        {variant.otherDescription ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Other description</dt>
+                                                    <dd>{variant.otherDescription}</dd>
+                                                </dl>
+                                              </div>
+                                        : null }
                                     </div>
                                 );
                             })}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2098,7 +2098,7 @@ var ExperimentalDataVariant = function() {
                                 </div>
                                 <div className="row">
                                    <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                    <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                    <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
                                 </div>
                             </div>
                         : null}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2003,17 +2003,30 @@ var FamilyViewer = React.createClass({
                                 return (
                                     <div className="variant-view-panel" key={variant.uuid}>
                                         <h5>Variant {i + 1}</h5>
-                                        <dl className="dl-horizontal">
+                                        {variant.clinvarVariantId ?
                                             <div>
-                                                <dt>ClinVar VariationID</dt>
-                                                <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar VariationID</dt>
+                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                </dl>
                                             </div>
-
+                                        : null }
+                                        {variant.clinvarVariantTitle ?
                                             <div>
-                                                <dt>Other description</dt>
-                                                <dd>{variant.otherDescription}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar Preferred Title</dt>
+                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
                                             </div>
-                                        </dl>
+                                        : null }
+                                        {variant.otherDescription ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Other description</dt>
+                                                    <dd>{variant.otherDescription}</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
                                     </div>
                                 );
                             })}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1651,7 +1651,7 @@ var FamilyVariant = function() {
                                 </div>
                                 <div className="row">
                                     <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                    <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                    <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
                                 </div>
                             </div>
                         : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1338,7 +1338,7 @@ var IndividualVariantInfo = function() {
                                         </div>
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                            <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                            <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
                                         </div>
                                     </div>
                                 : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1562,17 +1562,30 @@ var IndividualViewer = React.createClass({
                                 return (
                                     <div key={i} className="variant-view-panel">
                                         <h5>Variant {i + 1}</h5>
-                                        <dl className="dl-horizontal">
+                                        {variant.clinvarVariantId ?
                                             <div>
-                                                <dt>ClinVar VariationID</dt>
-                                                <dd>{variant.clinvarVariantId ? <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a> : null}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar VariationID</dt>
+                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                </dl>
                                             </div>
-
+                                        : null }
+                                        {variant.clinvarVariantTitle ?
                                             <div>
-                                                <dt>Other description</dt>
-                                                <dd>{variant.otherDescription}</dd>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinVar Preferred Title</dt>
+                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
                                             </div>
-                                        </dl>
+                                        : null}
+                                        {variant.otherDescription ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Other description</dt>
+                                                    <dd>{variant.otherDescription}</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
                                     </div>
                                 );
                             })}

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,16 +394,18 @@ var VariantCuration = React.createClass({
                                 <div className="row" style={{'padding-left':'15px'}}>
                                     <span>
                                         {gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}&nbsp;
-                                        // Variation <a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a>
                                     </span>
-                                    <br />
-                                    <dl>
-                                        <dt style={{'width':'20%', 'font-weight':'normal', 'float':'left'}}>ClinVar Preferred Name:&nbsp;</dt>
-                                        <dd style={{'width':'75%', 'word-wrap':'break-word', 'float':'left'}}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
+                                    <dl className="dl-horizontal">
+                                        <dt style={{'font-weight':'normal'}}>VariationId</dt>
+                                        <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                    </dl>
+                                    <dl className="dl-horizontal">
+                                        <dt style={{'font-weight':'normal'}}>ClinVar Preferred Title</dt>
+                                        <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
                                     </dl>
                                 </div>
                             )
-                            : <span>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null} // {'Description: ' + variant.otherDescription}</span>}</h2>
+                            : <span>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}</span>}</h2>
                         : null}
                     </div>
                     <div className="row group-curation-content">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -232,6 +232,13 @@
 
 .panel-evidence-group {
     margin: 5px 0;
+
+    .variant-preferred-title {
+        border-bottom: 1px dotted #337ab7;
+        cursor: pointer;
+        font-weight: bold;
+        text-decoration: none;
+    }
 }
 
 .panel-evidence {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -349,6 +349,11 @@
     .mutalyzer-link {
         margin-top: -20px;
     }
+
+    .clinvar-preferred-title {
+        word-break:break-all;
+        word-wrap: break-word;
+    }
 }
 
 .variant-view-panel {


### PR DESCRIPTION
**(This PR is to replace the closed PR #584, in which the committed changes incurred browser test failure and merge conflicts.)**

Following ticket #575, this ticket display ClinVar preferred title in curator palette and view pages.

**Changes**
- Add handling code to display preferred title in curator palette in curation central page
- Add handling code to display preferred title in family/individual/experimental view pages.

**Test Steps**
- Create GDM, add a PMID, add a new family, name Family010, enter variation ids 90973 and 9492, name proband Ind011, enter a Orphanet id, click Save. Go to curation central page and expect to see "Variants: 2" under Family010 and Ind011 in curator palette. And 2 preferred titles are shown in a pop-out window when mouse cursor is hover blue colored and underlined "2". 
<img width="495" alt="screen shot 2016-02-06 at 12 37 51 am" src="https://cloud.githubusercontent.com/assets/9206696/12865739/e6050902-cc69-11e5-9c09-3928456759d6.png">
- In addition, 2 preferred titles (or its left part with ellipses if too long) are shown in Associated Variants.
<img width="276" alt="screen shot 2016-02-06 at 12 48 26 am" src="https://cloud.githubusercontent.com/assets/9206696/12865793/7131c0aa-cc6b-11e5-9363-84e167f3a508.png">
- Click the titles, expect to redirect to variant curation page.
- Go back to curaion central page by clicking Cancel in variant curation page. View Family010, expect to see preferred titles shown as
<img width="1241" alt="screen shot 2016-02-06 at 12 53 18 am" src="https://cloud.githubusercontent.com/assets/9206696/12865806/1a18f44a-cc6c-11e5-93a4-59ad3c1472c5.png">
- Go back to curation central page and View Ind011, expect to see the same titles.
- Go back to curation central page and add a new experimental, name ExpAAA, select Rescue/Patient, cell, enter data in every required field; add variation ids 55966, 55996, 55942. In the event where something is not in ClinVar, enter some description in the Other description field to describe the experimental variant (e.g. HGVS term). Then save. At curation central page, expect to see
<img width="308" alt="screen shot 2016-02-06 at 1 04 46 am" src="https://cloud.githubusercontent.com/assets/9206696/12865854/a5d43ebc-cc6d-11e5-8365-5b2f13ffa2a4.png">
- View ExpAAA, expect to see 4 associated variants
<img width="641" alt="screen shot 2016-02-06 at 1 06 07 am" src="https://cloud.githubusercontent.com/assets/9206696/12865860/e6ef0e68-cc6d-11e5-8959-d6ed14cb2335.png">
- Under the variant counts, the underline has been changed from solid to dotted.
![image](https://cloud.githubusercontent.com/assets/6956310/12935416/661f52fe-cf4a-11e5-84df-f0c5ed3b00d2.png)


**End of Test**