### PR TITLE
Connects to #593. Hidden assessment panel

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2236,41 +2236,32 @@ var ExperimentalViewer = React.createClass({
         }
 
         if (typeof this.props.session.user_properties !== undefined) {
-            var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
             var user = this.props.session && this.props.session.user_properties;
-
-            // Make an assessment tracker object once we get the logged in user info
-            if (!this.cv.assessmentTracker && user) {
-                var userAssessment;
-
-                // Find if any assessments for the segregation are owned by the currently logged-in user
-                if (assessments && assessments.length) {
-                    // Find the assessment belonging to the logged-in curator, if any.
-                    userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
-                }
-                this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
-            }
+            this.loadAssessmentTracker(user);
         }
-
     },
 
     componentWillReceiveProps: function(nextProps) {
         if (typeof nextProps.session.user_properties !== undefined && nextProps.session.user_properties != this.props.session.user_properties) {
-            var experimental = this.props.context;
-            var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
             var user = nextProps.session && nextProps.session.user_properties;
+            this.loadAssessmentTracker(user);
+        }
+    },
 
-            // Make an assessment tracker object once we get the logged in user info
-            if (!this.cv.assessmentTracker && user) {
-                var userAssessment;
+    loadAssessmentTracker: function(user) {
+        var experimental = this.props.context;
+        var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
 
-                // Find if any assessments for the segregation are owned by the currently logged-in user
-                if (assessments && assessments.length) {
-                    // Find the assessment belonging to the logged-in curator, if any.
-                    userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
-                }
-                this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
+        // Make an assessment tracker object once we get the logged in user info
+        if (!this.cv.assessmentTracker && user) {
+            var userAssessment;
+
+            // Find if any assessments for the segregation are owned by the currently logged-in user
+            if (assessments && assessments.length) {
+                // Find the assessment belonging to the logged-in curator, if any.
+                userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
             }
+            this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
         }
     },
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2234,6 +2234,24 @@ var ExperimentalViewer = React.createClass({
         if (experimental && experimental.assessments && experimental.assessments.length) {
             this.setState({assessments: experimental.assessments});
         }
+
+        if (typeof this.props.session.user_properties !== undefined) {
+            var assessments = this.state.assessments ? this.state.assessments : (experimental.assessments ? experimental.assessments : null);
+            var user = this.props.session && this.props.session.user_properties;
+
+            // Make an assessment tracker object once we get the logged in user info
+            if (!this.cv.assessmentTracker && user) {
+                var userAssessment;
+
+                // Find if any assessments for the segregation are owned by the currently logged-in user
+                if (assessments && assessments.length) {
+                    // Find the assessment belonging to the logged-in curator, if any.
+                    userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
+                }
+                this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, experimental.evidenceType);
+            }
+        }
+
     },
 
     componentWillReceiveProps: function(nextProps) {

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1864,26 +1864,35 @@ var FamilyViewer = React.createClass({
         if (family && family.segregation && family.segregation.assessments && family.segregation.assessments.length) {
             this.setState({assessments: family.segregation.assessments});
         }
+
+        if (typeof this.props.session.user_properties !== undefined) {
+            var user = this.props.session && this.props.session.user_properties;
+            this.loadAssessmentTracker(user);
+        }
     },
 
     componentWillReceiveProps: function(nextProps) {
         if (typeof nextProps.session.user_properties !== undefined && nextProps.session.user_properties != this.props.session.user_properties) {
-            var family = this.props.context;
-            var assessments = this.state.assessments ? this.state.assessments : (segregation ? segregation.assessments : null);
             var user = nextProps.session && nextProps.session.user_properties;
-            var segregation = family.segregation;
+            this.loadAssessmentTracker(user);
+        }
+    },
 
-            // Make an assessment tracker object once we get the logged in user info
-            if (!this.cv.assessmentTracker && user && segregation) {
-                var userAssessment;
+    loadAssessmentTracker: function(user) {
+        var family = this.props.context;
+        var segregation = family.segregation;
+        var assessments = this.state.assessments ? this.state.assessments : (segregation ? segregation.assessments : null);
 
-                // Find if any assessments for the segregation are owned by the currently logged-in user
-                if (assessments && assessments.length) {
-                    // Find the assessment belonging to the logged-in curator, if any.
-                    userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
-                }
-                this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, 'Segregation');
+        // Make an assessment tracker object once we get the logged in user info
+        if (!this.cv.assessmentTracker && user && segregation) {
+            var userAssessment;
+
+            // Find if any assessments for the segregation are owned by the currently logged-in user
+            if (assessments && assessments.length) {
+                // Find the assessment belonging to the logged-in curator, if any.
+                userAssessment = Assessments.userAssessment(assessments, user && user.uuid);
             }
+            this.cv.assessmentTracker = new AssessmentTracker(userAssessment, user, 'Segregation');
         }
     },
 


### PR DESCRIPTION
The Assessment panel on Family and Experimental Curation pages should show up now on first load

Testing:

1. Create GDM, add PMID
2. Create Experimental Data object
3. From Curation Central, click on View/Assess for the item, and ensure that the Assessment panel is visible on first load
4. Create Family object w/ Segregation data
4. From Curation Central, click on View/Assess for the item, and ensure that the Assessment panel is visible on first load