### PR TITLE
Connects to #596. Fix variant fields for multiple variants and make variants un-editable after multiple assessment

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1215,7 +1215,7 @@ var ExperimentalCuration = React.createClass({
         var addVariantDisabled;
         if (data) {
             // Enable/Disable Add Variant button as needed
-            if (fieldNum == 0) {
+            if (fieldNum < MAX_VARIANTS - 1) {
                 addVariantDisabled = false;
             } else {
                 addVariantDisabled = true;
@@ -1225,7 +1225,7 @@ var ExperimentalCuration = React.createClass({
             newVariantInfo[fieldNum] = {'clinvarVariantId': data.clinvarVariantId, 'clinvarVariantTitle': data.clinvarVariantTitle};
             // Disable the 'Other description' textarea
             this.refs['VARothervariant' + fieldNum].resetValue();
-            currVariantOption[0] = VAR_SPEC;
+            currVariantOption[parseInt(fieldNum)] = VAR_SPEC;
         } else {
             // Reset the form and display values
             this.refs['VARclinvarid' + fieldNum].setValue('');

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2068,59 +2068,99 @@ var ExperimentalDataVariant = function() {
 
     return (
         <div className="row">
-            {!experimental || !experimental.variants || experimental.variants.length === 0 ?
-                <div className="row">
-                    <p className="col-sm-7 col-sm-offset-5">If your Experimental data is about one or more variants, please add these variant(s) below</p>
-                </div>
-            : null}
-            {_.range(this.state.variantCount).map(i => {
-                var variant;
-
-                if (variants && variants.length) {
-                    variant = variants[i];
-                }
-
-                return (
-                    <div key={'variant' + i} className="variant-panel">
-                        <div className="row">
-                            <div className="col-sm-7 col-sm-offset-5">
-                                <p className="alert alert-warning">
-                                    ClinVar VariationID should be provided in all instances it exists. This is the only way to associate probands from different studies with
-                                    the same variant, and ensures the accurate counting of probands.
-                                </p>
-                            </div>
+        {this.cv.othersAssessed ?
+            <div>
+                {variants.map(function(variant, i) {
+                    return (
+                        <div key={i} className="variant-view-panel variant-view-panel-edit">
+                            <h5>Variant {i + 1}</h5>
+                            <dl className="dl-horizontal">
+                                {variant.clinvarVariantId ?
+                                    <div>
+                                        <dl className="dl-horizontal">
+                                            <dt>ClinVar VariationID</dt>
+                                            <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                        </dl>
+                                    </div>
+                                : null }
+                                {variant.clinvarVariantTitle ?
+                                    <div>
+                                        <dl className="dl-horizontal">
+                                            <dt>ClinVar Preferred Title</dt>
+                                            <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                        </dl>
+                                    </div>
+                                : null }
+                                {variant.otherDescription ?
+                                    <div>
+                                        <dl className="dl-horizontal">
+                                            <dt>Other description</dt>
+                                            <dd>{variant.otherDescription}</dd>
+                                        </dl>
+                                    </div>
+                                : null }
+                            </dl>
                         </div>
-                        {this.state.variantInfo[i] ?
-                            <div>
-                                <div className="row">
-                                    <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
-                                    <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
-                                </div>
-                                <div className="row">
-                                   <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                    <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                    );
+                })}
+            </div>
+        :
+            <div>
+                {!experimental || !variants || variants.length === 0 ?
+                    <div className="row">
+                        <p className="col-sm-7 col-sm-offset-5">If your Experimental data is about one or more variants, please add these variant(s) below</p>
+                    </div>
+                : null}
+                {_.range(this.state.variantCount).map(i => {
+                    var variant;
+
+                    if (variants && variants.length) {
+                        variant = variants[i];
+                    }
+
+                    return (
+                        <div key={'variant' + i} className="variant-panel">
+                            <div className="row">
+                                <div className="col-sm-7 col-sm-offset-5">
+                                    <p className="alert alert-warning">
+                                        ClinVar VariationID should be provided in all instances it exists. This is the only way to associate probands from different studies with
+                                        the same variant, and ensures the accurate counting of probands.
+                                    </p>
                                 </div>
                             </div>
-                        : null}
-                        <Input type="text" ref={'VARclinvarid' + i} value={variant && variant.clinvarVariantId} handleChange={this.handleChange}
-                            error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
-                            labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
-                        <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]}
-                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" }
-                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                            updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
-                        <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC || this.cv.othersAssessed}
-                            labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-                        {curator.renderMutalyzerLink()}
+                            {this.state.variantInfo[i] ?
+                                <div>
+                                    <div className="row">
+                                        <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
+                                        <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
+                                    </div>
+                                    <div className="row">
+                                       <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
+                                        <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                    </div>
+                                </div>
+                            : null}
+                            <Input type="text" ref={'VARclinvarid' + i} value={variant && variant.clinvarVariantId} handleChange={this.handleChange}
+                                error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
+                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
+                            <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]}
+                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" }
+                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
+                            <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC || this.cv.othersAssessed}
+                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+                            {curator.renderMutalyzerLink()}
+                        </div>
+                    );
+                })}
+                {this.state.variantCount < MAX_VARIANTS ?
+                    <div>
+                        <Input type="button" ref="addvariant" inputClassName="btn-default btn-last pull-right" title={this.state.variantCount ? "Add another variant associated with Experimental data" : "Add variant associated with Experimental data"}
+                            clickHandler={this.handleAddVariant} inputDisabled={this.state.addVariantDisabled || this.cv.othersAssessed} />
                     </div>
-                );
-            })}
-            {this.state.variantCount < MAX_VARIANTS ?
-                <div>
-                    <Input type="button" ref="addvariant" inputClassName="btn-default btn-last pull-right" title={this.state.variantCount ? "Add another variant associated with Experimental data" : "Add variant associated with Experimental data"}
-                        clickHandler={this.handleAddVariant} inputDisabled={this.state.addVariantDisabled || this.cv.othersAssessed} />
-                </div>
-            : null}
+                : null}
+            </div>
+        }
         </div>
     );
 };


### PR DESCRIPTION
Five Variants added to an Experimental Data object successfully, with forms interacting properly:
![image](https://cloud.githubusercontent.com/assets/4326866/12937361/c73c1b28-cf5c-11e5-8648-d675b9a3d656.png)
![image](https://cloud.githubusercontent.com/assets/4326866/12937373/db7502f8-cf5c-11e5-856f-99361117e084.png)
![image](https://cloud.githubusercontent.com/assets/4326866/12937383/e5d22230-cf5c-11e5-8c3a-662d1482c0c9.png)
![image](https://cloud.githubusercontent.com/assets/4326866/12937388/eee40672-cf5c-11e5-84e0-48ee8c905dce.png)

Make Variants un-editable after others have assessed on the Experimental Data object:
![image](https://cloud.githubusercontent.com/assets/4326866/12937614/2915be88-cf5f-11e5-9bba-0cff689b0d8a.png)

Testing:

1. Create GDM, add PMID
2. Open up Add Experimental Data form
3. Add a bunch of variants and ensure that the fields interact properly, and a max of 5 variants can be added
4. Assess and Save Experimental Data object
5. Assess on same object w/ another user
6. Check the Edit page with original user, and ensure that the Variants cannot be changed as another user has assessed on the Experimental Data object