### PR TITLE
Connects to #602. Fix Add Article button on Add PMID Modal

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -92,7 +92,7 @@ var CurationCentral = React.createClass({
     componentDidMount: function() {
         var winWidth = window.innerWidth;
         this.setState({winWidth: winWidth});
-        
+
         var gdmUuid = queryKeyValue('gdm', this.props.href);
         var pmid = queryKeyValue('pmid', this.props.href);
         if (gdmUuid) {
@@ -297,16 +297,19 @@ var AddPmidModal = React.createClass({
         if (valid && formInput.match(/^0+$/)) {
             valid = false;
             this.setFormErrors('pmid', 'This PMID does not exist');
+            this.setState({submitBusy: false});
         }
         // valid if input isn't zero-leading
         if (valid && formInput.match(/^0+/)) {
             valid = false;
             this.setFormErrors('pmid', 'Please re-enter PMID without any leading 0\'s');
+            this.setState({submitBusy: false});
         }
         // valid if the input only has numbers
         if (valid && !formInput.match(/^[0-9]*$/)) {
             valid = false;
             this.setFormErrors('pmid', 'Only numbers allowed');
+            this.setState({submitBusy: false});
         }
         // valid if input isn't already associated with GDM
         if (valid) {
@@ -314,6 +317,7 @@ var AddPmidModal = React.createClass({
                 if (this.props.currGdm.annotations[i].article.pmid == formInput) {
                     valid = false;
                     this.setFormErrors('pmid', 'This article has already been associated with this Gene-Disease Record');
+                    this.setState({submitBusy: false});
                 }
             }
         }
@@ -339,7 +343,10 @@ var AddPmidModal = React.createClass({
                 return this.getRestDataXml(external_url_map['PubMedSearch'] + enteredPmid).then(xml => {
                     var newArticle = parsePubmed(xml);
                     // if the PubMed article for this PMID doesn't exist, display an error
-                    if (!('pmid' in newArticle)) this.setFormErrors('pmid', 'This PMID does not exist');
+                    if (!('pmid' in newArticle)) {
+                        this.setFormErrors('pmid', 'This PMID does not exist');
+                        this.setState({submitBusy: false});
+                    }
                     return this.postRestData('/articles/', newArticle).then(data => {
                         return Promise.resolve(data['@graph'][0]);
                     });


### PR DESCRIPTION
Verified with @wrightmw in person the behavior of the button.

Post-error:
![image](https://cloud.githubusercontent.com/assets/4326866/12965051/585cf8a6-d008-11e5-9da1-62ab9a79c38d.png)

After changing value the button is re-enabled:
![image](https://cloud.githubusercontent.com/assets/4326866/12965084/7d3fde86-d008-11e5-84ca-d67d3b1ae59d.png)

Testing:

1. Create GDM
2. Open Add PMID modal
3. Test by attempting to add 0-filled PMID, non-numeric PMID, PMID w/ leading 0s, already-added PMID, and non-existent PMID (i.e. 999999999999999), and ensuring that the spinning cog disappears once the error appears. Changing the value in the form after the error should make the 'Add Article' button re-enabled