### PR TITLE
Connects to #542. Added warning note below Individual Label input field on family curation page.

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1674,6 +1674,7 @@ var FamilyVariant = function() {
                     <Input type="text" ref="individualname" label="Individual Label"
                         error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
+                    <p className="col-sm-7 col-sm-offset-5 input-note-below">Note: Do not enter real names in this field. {curator.renderLabelNote('Individual')}</p>
                     {this.state.orpha ?
                         <div className="form-group">
                             <div className="col-sm-5"><strong className="pull-right">Orphanet Disease(s) Associated with Family:</strong></div>


### PR DESCRIPTION
This PR is to add the warning note below the *Individual Label* input field on the family curation page.

**Testing steps for #542**
1. Go to a GDM page and add a new PMID.
2. From the far-right *Evidence* column, click on the blue *Family* bar to proceed to the family curation page.
3. Scroll down the page and find the *Add variant associated with Individual* button. Click and add a variant.
4. Upon successfully adding a valid ClinVar ID, the Individual Label input field becomes visible. The warning note is expected to be present below the input field.
5. And this warning note should be the same as seen on the individual curation page.