### PR TITLE
Connects to #604. Revise breadcrumb display on Variant curation form

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -92,7 +92,7 @@ var CurationCentral = React.createClass({
     componentDidMount: function() {
         var winWidth = window.innerWidth;
         this.setState({winWidth: winWidth});
-        
+
         var gdmUuid = queryKeyValue('gdm', this.props.href);
         var pmid = queryKeyValue('pmid', this.props.href);
         if (gdmUuid) {
@@ -280,7 +280,7 @@ var AddPmidModal = React.createClass({
     propTypes: {
         closeModal: React.PropTypes.func, // Function to call to close the modal
         protocol: React.PropTypes.string, // Protocol to use to access PubMed ('http:' or 'https:')
-        updateGdmArticles: React.PropTypes.func, // Function to call when we have an article to add to the GDM
+        updateGdmArticles: React.PropTypes.func // Function to call when we have an article to add to the GDM
     },
 
     contextTypes: {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -78,7 +78,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
         omimId: React.PropTypes.string, // OMIM ID to display
         updateOmimId: React.PropTypes.func, // Function to call when OMIM ID changes
         linkGdm: React.PropTypes.bool, // whether or not to link GDM text back to GDM
-        variant: React.PropTypes.object // Variant object, for the variant curation page
+        pmid: React.PropTypes.string
     },
 
     render: function() {
@@ -96,26 +96,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var gene = this.props.gdm.gene;
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
-            var pmid;
-            var pmidCount = 0;
-            if (gdm.annotations.length > 0) {
-                if (annotations && variant) {
-                    // Search all annotations in the GDM for all associations for the given variant
-                    annotations.forEach(function(annotation) {
-                        // Get all associations (families, individuals) for this annotation and variant
-                        var associations = collectVariantAssociations(annotation, variant);
-                        if (associations && associations.length == 1) {
-                            pmidCount++;
-                            pmid = annotation.article.pmid;
-                        }
-                    });
-                    if (pmidCount > 1) {
-                        this.props.linkGdm = false;
-                    }
-                } else {
-                    pmid = gdm.annotations[0].article.pmid;
-                }
-            }
+            var pmid = this.props.pmid;
             var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
             if (gdm.provisionalClassifications && gdm.provisionalClassifications.length > 0) {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -441,7 +441,7 @@ var VariantAssociationsHeader = module.exports.VariantAssociationsHeader = React
                     });
                     var render = (
                         <h2 key={annotation.uuid}>
-                            <span>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} // PMID: <a href={globals.external_url_map['PubMed'] + annotation.article.pmid} target="_blank" title="PubMed article in a new tab">{annotation.article.pmid}</a> → </span>
+                            <span>PMID: <a href={globals.external_url_map['PubMed'] + annotation.article.pmid} target="_blank" title="PubMed article in a new tab">{annotation.article.pmid}</a> → </span>
                             {sortedAssociations.map(function(association, i) {
                                 var associationType = association['@type'][0];
                                 var probandLabel = (associationType === 'individual' && association.proband) ? <i className="icon icon-proband"></i> : null;

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -77,7 +77,8 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
         gdm: React.PropTypes.object, // GDM data to display
         omimId: React.PropTypes.string, // OMIM ID to display
         updateOmimId: React.PropTypes.func, // Function to call when OMIM ID changes
-        linkGdm: React.PropTypes.bool // whether or not to link GDM text back to GDM
+        linkGdm: React.PropTypes.bool, // whether or not to link GDM text back to GDM
+        variant: React.PropTypes.object // Variant object, for the variant curation page
     },
 
     render: function() {
@@ -88,14 +89,32 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
         var provisional;
         var provisionalExist = false;
         var summaryButton = false;
+        var variant = this.props.variant;
+        var annotations = gdm && gdm.annotations;
 
         if (gdm && gdm['@type'][0] === 'gdm') {
             var gene = this.props.gdm.gene;
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
             var pmid;
+            var pmidCount = 0;
             if (gdm.annotations.length > 0) {
-                pmid = gdm.annotations[0].article.pmid;
+                if (annotations && variant) {
+                    // Search all annotations in the GDM for all associations for the given variant
+                    annotations.forEach(function(annotation) {
+                        // Get all associations (families, individuals) for this annotation and variant
+                        var associations = collectVariantAssociations(annotation, variant);
+                        if (associations && associations.length == 1) {
+                            pmidCount++;
+                            pmid = annotation.article.pmid;
+                        }
+                    });
+                    if (pmidCount > 1) {
+                        this.props.linkGdm = false;
+                    }
+                } else {
+                    pmid = gdm.annotations[0].article.pmid;
+                }
             }
             var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
@@ -273,6 +292,7 @@ var ViewRecordHeader = module.exports.ViewRecordHeader = React.createClass({
 
 var findGdmPmidFromObj = module.exports.findGdmPmidFromObj = function(obj) {
     var tempGdm, tempPmid;
+    console.log(obj);
     if (obj.associatedAnnotations && obj.associatedAnnotations.length > 0) {
         tempGdm = obj.associatedAnnotations[0].associatedGdm[0];
         tempPmid = obj.associatedAnnotations[0].article.pmid;
@@ -440,7 +460,7 @@ var VariantAssociationsHeader = module.exports.VariantAssociationsHeader = React
                     });
                     var render = (
                         <h2 key={annotation.uuid}>
-                            <span>PMID: <a href={globals.external_url_map['PubMed'] + annotation.article.pmid} target="_blank" title="PubMed article in a new tab">{annotation.article.pmid}</a> → </span>
+                            <span>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} // PMID: <a href={globals.external_url_map['PubMed'] + annotation.article.pmid} target="_blank" title="PubMed article in a new tab">{annotation.article.pmid}</a> → </span>
                             {sortedAssociations.map(function(association, i) {
                                 var associationType = association['@type'][0];
                                 var probandLabel = (associationType === 'individual' && association.proband) ? <i className="icon icon-proband"></i> : null;

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1264,7 +1264,7 @@ var ExperimentalCuration = React.createClass({
             <div>
                 {(!this.queryValues.experimentalUuid || this.state.experimental) ?
                     <div>
-                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} />
+                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} pmid={pmid} />
                         <div className="container">
                             {annotation && annotation.article ?
                                 <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1224,7 +1224,7 @@ var FamilyCuration = React.createClass({
             <div>
                 {(!this.queryValues.familyUuid || this.state.family) ?
                     <div>
-                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} />
+                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} pmid={pmid} />
                         <div className="container">
                             {annotation && annotation.article ?
                                 <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -507,7 +507,7 @@ var GroupCuration = React.createClass({
             <div>
                 {(!this.queryValues.groupUuid || this.state.group) ?
                     <div>
-                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} />
+                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} pmid={pmid} />
                         <div className="container">
                             {annotation && annotation.article ?
                                 <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -896,7 +896,7 @@ var IndividualCuration = React.createClass({
             <div>
                 {(!this.queryValues.individualUuid || individual) ?
                     <div>
-                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} />
+                        <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} pmid={pmid} />
                         <div className="container">
                             {annotation && annotation.article ?
                                 <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -379,7 +379,7 @@ var VariantCuration = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} />
+                <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} variant={variant} />
                 <div className="container">
                     {!this.queryValues.all && annotation && annotation.article ?
                         <div className="curation-pmid-summary">
@@ -393,9 +393,6 @@ var VariantCuration = React.createClass({
                         {variant ?
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row" style={{'padding-left':'15px'}}>
-                                    <span>
-                                        {gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}&nbsp;
-                                    </span>
                                     <dl className="dl-horizontal">
                                         <dt style={{'font-weight':'normal'}}>VariationId</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,7 +394,7 @@ var VariantCuration = React.createClass({
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row" style={{'padding-left':'15px'}}>
                                     <dl className="dl-horizontal">
-                                        <dt style={{'font-weight':'normal'}}>VariationId</dt>
+                                        <dt style={{'font-weight':'normal'}}>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} // VariationId</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                     </dl>
                                     <dl className="dl-horizontal">

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -379,7 +379,7 @@ var VariantCuration = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} variant={variant} />
+                <RecordHeader gdm={gdm} omimId={this.state.currOmimId} updateOmimId={this.updateOmimId} session={session} linkGdm={true} pmid={this.queryValues.pmid} />
                 <div className="container">
                     {!this.queryValues.all && annotation && annotation.article ?
                         <div className="curation-pmid-summary">


### PR DESCRIPTION
* GDM breadcrumb displays properly on Variant Curation page
* GDM icon in Record Header points to proper PMID in GDM

![image](https://cloud.githubusercontent.com/assets/4326866/12968228/e7fc3088-d023-11e5-8533-305e6150732d.png)

Testing:
1. Create GDM, add multiple PMID
2. On non-first-created PMID, add Individual/Experiment/Family with Variant
3. Check Variant Curation page to make sure that the GDM links and display are correct
4. Check created Individual/Experiment/Family to ensure that the GDM link in Record Header points to correct PMID