### PR TITLE
Connects to #589. Family curation patch

### DIFF
--- a/src/clincoded/static/components/experimental_submit.js
+++ b/src/clincoded/static/components/experimental_submit.js
@@ -105,7 +105,7 @@ var ExperimentalSubmit = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} />
+                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} pmid={annotation ? annotation.article.pmid : null} />
                 <div className="container">
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/experimental_submit.js
+++ b/src/clincoded/static/components/experimental_submit.js
@@ -26,7 +26,7 @@ var ExperimentalSubmit = React.createClass({
         return {
             gdm: null, // GDM object given in query string
             experimental: null, // Experimental object given in query string
-            annotation: null, // Annotation object given in query string
+            annotation: null // Annotation object given in query string
         };
     },
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1270,7 +1270,7 @@ var FamilyCuration = React.createClass({
                                             </PanelGroup>
                                         :
                                             <div>
-                                                {family.segregation ?
+                                                {family && family.segregation ?
                                                     <PanelGroup accordion>
                                                         {FamilySegregationViewer(family.segregation, null, true)}
                                                     </PanelGroup>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1670,7 +1670,7 @@ var FamilyVariant = function() {
                 );
             })}
             {this.state.variantCount && !this.state.probandIndividual && this.state.individualRequired ?
-                <div className="variant-panel clearfix">
+                <div className="variant-panel">
                     <Input type="text" ref="individualname" label="Individual Label"
                         error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />

--- a/src/clincoded/static/components/family_submit.js
+++ b/src/clincoded/static/components/family_submit.js
@@ -125,7 +125,7 @@ var FamilySubmit = module.exports.FamilySubmit = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} />
+                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} pmid={annotation ? annotation.article.pmid : null} />
                 <div className="container">
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/group_submit.js
+++ b/src/clincoded/static/components/group_submit.js
@@ -113,7 +113,7 @@ var GroupSubmit = module.exports.GroupSubmit = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} />
+                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} pmid={annotation ? annotation.article.pmid : null} />
                 <div className="container">
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -128,7 +128,7 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
 
         return (
             <div>
-                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} />
+                <RecordHeader gdm={gdm} omimId={gdm && gdm.omimId} session={session} linkGdm={true} pmid={annotation ? annotation.article.pmid : null} />
                 <div className="container">
                     {annotation && annotation.article ?
                         <div className="curation-pmid-summary">


### PR DESCRIPTION
Fix inability to load Family Curation form after accessing the Edit Page of a Family that was already assessed
Testing:

1. Create GDM, add PMID
2. Create Family w/ Segregation and Assess it
3. Assess it with another user
4. View Edit page for Family with original user
5. Go back to Curation Central
6. Click the 'Add Family' button and confirm that it takes you to the Family Curation page


Fix GDM Links in Record Header for Submit pages
Testing:

1. When creating items, make sure that the briefcase icon in the Record Header of the Submit pages are linked, and link to the correct record

Fix Individual information not showing up when adding variants on Family curation page
Testing:

1. Add Variants on Family Curation page. Confirm that the Individual information input fields show up.