### PR TITLE
Connects to #616. Fixed "Cannot read property 'article' of null" error.

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2091,7 +2091,7 @@ var ExperimentalDataVariant = function() {
                                     <div>
                                         <dl className="dl-horizontal">
                                             <dt>ClinVar Preferred Title</dt>
-                                            <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            <dd>{variant.clinvarVariantTitle}</dd>
                                         </dl>
                                     </div>
                                 : null }
@@ -2679,7 +2679,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2687,7 +2687,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
-                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                    <dd>{variant.clinvarVariantTitle}</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,7 +394,7 @@ var VariantCuration = React.createClass({
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
-                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
+                                        <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                     </dl>
                                     <dl className="dl-horizontal">


### PR DESCRIPTION
This PR is to address the "Cannot read property 'article' of null" error upon an user clicking on any of the individual/family/group/experimental name links in the header of variant curation page. Furthermore, this PR also removed some inline styles on the experimental curation viewer page.

**Testing steps for #616:**
1. Go to the curation central page and add a new PMID.
2. Clicking on the blue **Family** bar from the far-right **Evidence** column to proceed to the curation page.
3. Fill out the form and add a ClinVar ID and an individual associated with it.
4. Upon submitting the form and returning to the curation central page, click on the title of the variant in the **Associated Variants** panel to proceed to the **Curate Variant Information** Edit/View page.
5. Click on either one of the individual/family name links in the header.
6. The reported **Cannot read property 'article' of null** error should no longer be present.