### PR TITLE
Connects to #539. Fixed button display in narrow viewport.

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2091,7 +2091,7 @@ var ExperimentalDataVariant = function() {
                                     <div>
                                         <dl className="dl-horizontal">
                                             <dt>ClinVar Preferred Title</dt>
-                                            <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            <dd>{variant.clinvarVariantTitle}</dd>
                                         </dl>
                                     </div>
                                 : null }
@@ -2679,7 +2679,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2687,7 +2687,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
-                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                    <dd>{variant.clinvarVariantTitle}</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1679,7 +1679,7 @@ var FamilyVariant = function() {
                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                             updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
-                            handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+                            handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group other-variant-desc" />
                         {curator.renderMutalyzerLink()}
                     </div>
                 );

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,7 +394,7 @@ var VariantCuration = React.createClass({
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
-                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
+                                        <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                     </dl>
                                     <dl className="dl-horizontal">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -344,15 +344,25 @@
 .variant-panel {
     padding-top: 40px;
     border-top: 1px solid #c0c0c0;
-    padding-bottom: 40px;
+    padding-bottom: 15px;
 
     .mutalyzer-link {
-        margin-top: -20px;
+        float: none;
+        margin-bottom: 0;
+    }
+
+    .other-variant-desc {
+        margin-bottom: 0;
     }
 
     .clinvar-preferred-title {
         word-break:break-all;
         word-wrap: break-word;
+    }
+
+    &:first-child {
+        padding-top: 0;
+        border-top: none;
     }
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -210,8 +210,17 @@ input[type=search] {
     margin-top: -40px;
     margin-bottom: 40px;
 
-    @media screen and (max-width: $screen-sm-min) {
+    @media screen and (max-width: 767px) {
         margin-top: 0;
+    }
+
+    @media screen and (max-width: 1199px) and (min-width: 992px) {
+        .row:last-child .col-md-6 {
+            float: none;
+            margin: 0 auto;
+            text-align: center;
+            width: 55%;
+        }
     }
 
     .row {

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -210,6 +210,10 @@ input[type=search] {
     margin-top: -40px;
     margin-bottom: 40px;
 
+    @media screen and (max-width: $screen-sm-min) {
+        margin-top: 0;
+    }
+
     .row {
         margin: 20px 0;
     }


### PR DESCRIPTION
This PR is to address the problem in which the buttons are overlapping the text on the form submission confirmation page in narrow viewport.

**Testing steps for #539:**
1. Go to the Curation Central page and add a new PMID.
2. Proceed to the Family Curation page by clicking on the blue "Family" bar on the far-right column.
3. Fill out the form and click "Save" to submit it.
4. On the subsequent confirmation page, on where there are 3 buttons (e.g. **Edit proband Individual**, **Add non-proband Individual**, and **Return to Record Curation page**), reduce the browser window width to less than 767px.
5. You should expect to see that the buttons are no longer overlapping the text above it.