### PR TITLE
Connects to #612. Fixed text display in narrow viewport.

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2091,7 +2091,7 @@ var ExperimentalDataVariant = function() {
                                     <div>
                                         <dl className="dl-horizontal">
                                             <dt>ClinVar Preferred Title</dt>
-                                            <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            <dd>{variant.clinvarVariantTitle}</dd>
                                         </dl>
                                     </div>
                                 : null }
@@ -2679,7 +2679,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2687,7 +2687,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
-                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                    <dd>{variant.clinvarVariantTitle}</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1679,7 +1679,7 @@ var FamilyVariant = function() {
                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                             updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
-                            handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+                            handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group other-variant-desc" />
                         {curator.renderMutalyzerLink()}
                     </div>
                 );

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,7 +394,7 @@ var VariantCuration = React.createClass({
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
-                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
+                                        <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                     </dl>
                                     <dl className="dl-horizontal">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -344,15 +344,25 @@
 .variant-panel {
     padding-top: 40px;
     border-top: 1px solid #c0c0c0;
-    padding-bottom: 40px;
+    padding-bottom: 15px;
 
     .mutalyzer-link {
-        margin-top: -20px;
+        float: none;
+        margin-bottom: 0;
+    }
+
+    .other-variant-desc {
+        margin-bottom: 0;
     }
 
     .clinvar-preferred-title {
         word-break:break-all;
         word-wrap: break-word;
+    }
+
+    &:first-child {
+        padding-top: 0;
+        border-top: none;
     }
 }
 


### PR DESCRIPTION
This PR is to address the problem in which the **Mutalyzer** text is overlapping the line below it on the family curation page in narrow viewport.

**Testing steps for #612:**
1. Go to the Curation Central page and add a new PMID.
2. Proceed to the Family Curation page by clicking on the blue "Family" bar on the far-right column.
3. Scroll down toward the end of the form and click on the **Add variant associated with Individual** button to add a ClinVar VariantID.
4. Upon successfully adding a ClinVar VariantionID onto the form, reduce the browser window width to 1220px or less.
5. You should expect to see that the **Mutalyzer text** is no longer overlapping the line below it.