### PR TITLE
Connects to #564. Clear error state when either experimentalType or experimentalSubtype selection is changed.

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -540,6 +540,15 @@ var ExperimentalCuration = React.createClass({
         this.cv.othersAssessed = false;
     },
 
+    // Clear error state when either experimentalType or experimentalSubtype selection is changed
+    componentDidUpdate: function(prevProps, prevState) {
+        if (typeof prevState.experimentalType !== undefined && prevState.experimentalType !== this.state.experimentalType) {
+            this.setState({formErrors: []});
+        } else if (typeof prevState.experimentalSubtype !== undefined && prevState.experimentalSubtype !== this.state.experimentalSubtype) {
+            this.setState({formErrors: []});
+        }
+    },
+
     // When the user changes the assessment value, this gets called
     updateAssessment: function(value) {
         var assessment = this.state.assessment;


### PR DESCRIPTION
This PR is to address the persistent form submission error message next to the **Cancel** button at the bottom of the experimental curation page.

**Testing steps for #564:**
1. Go to the Curation Central page and add a new PMID.
2. Proceed to the Experimental Curation page by clicking on the blue **Experimental Data** bar on the far-right column.
3. On the subsequent form, select **Biochemical Function** from the **Experiment type** dropdown menu.
4. Then select option **A** from the **Please select which one (A or B) you would like to curate** dropdown menu.
5. Without filling out any other fields, click the **Save** button. You should expect to see the red **Please fix errors on the form and resubmit.** error message at the bottom of the form.
6. Scroll back up on the same form. Select either **Expression** from the **Experiment type** dropdown menu, or option **B** from the **Please select which one (A or B) you would like to curate** dropdown menu. You should now expect the red "Please fix errors on the form and resubmit." error message is no longer visible at the bottom of the form.