### PR TITLE
Connects to #617. Save variant preferred title on main form.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2476,7 +2476,7 @@ function clinvarSubmitResource() {
                 });
             } else {
                 // variation is new to our db
-                this.putRestData('/variants/', this.state.tempResource).then(result => {
+                this.postRestData('/variants/', this.state.tempResource).then(result => {
                     // record the user adding a new variant entry
                     this.recordHistory('add', result['@graph'][0]).then(history => {
                         this.props.updateParentForm(result['@graph'][0], this.props.fieldNum);

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2465,13 +2465,18 @@ function clinvarSubmitResource() {
             if (check.total) {
                 // variation already exists in our db
                 this.getRestData(check['@graph'][0]['@id']).then(result => {
+                    if (result['clinvarVariantTitle'].length < 1) {
+                        this.postRestData('/variants/', this.state.tempResource);
+                    }
+                    return result;
+                }).then(result => {
                     this.props.updateParentForm(result, this.props.fieldNum);
                     this.setState({submitResourceBusy: false});
                     this.props.closeModal();
                 });
             } else {
                 // variation is new to our db
-                this.postRestData('/variants/', this.state.tempResource).then(result => {
+                this.putRestData('/variants/', this.state.tempResource).then(result => {
                     // record the user adding a new variant entry
                     this.recordHistory('add', result['@graph'][0]).then(history => {
                         this.props.updateParentForm(result['@graph'][0], this.props.fieldNum);

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2302,6 +2302,8 @@ var AddResourceIdModal = React.createClass({
                 var tempTxtLabel;
                 if (this.props.initialFormValue) {
                     tempTxtLabel = clinvarTxt('editLabel');
+                    this.setState({queryResourceDisabled: false});
+                    this.setState({inputValue: this.props.initialFormValue});
                 } else {
                     tempTxtLabel = clinvarTxt('inputLabel');
                 }

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2091,7 +2091,7 @@ var ExperimentalDataVariant = function() {
                                     <div>
                                         <dl className="dl-horizontal">
                                             <dt>ClinVar Preferred Title</dt>
-                                            <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                            <dd>{variant.clinvarVariantTitle}</dd>
                                         </dl>
                                     </div>
                                 : null }
@@ -2679,7 +2679,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd style={{'paddingLeft':'22px'}}><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2687,7 +2687,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
-                                                    <dd style={{'word-wrap':'break-word', 'word-break':'break-all'}}>{variant.clinvarVariantTitle}</dd>
+                                                    <dd>{variant.clinvarVariantTitle}</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -394,7 +394,7 @@ var VariantCuration = React.createClass({
                             <h2>{variant.clinvarVariantId ? (
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
-                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
+                                        <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
                                         <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
                                     </dl>
                                     <dl className="dl-horizontal">


### PR DESCRIPTION
This PR is to address the problem in which adding a ClinVar VariantID without a pre-existing preferred title in the DB does not save the title on the main form upon closing the modal. 

**Testing steps for #617:**
1. Go to the Curation Central page and add a new PMID.
2. Proceed to the Family Curation page by clicking on the blue **Family** bar on the far-right column.
3. On the subsequent form, scroll down toward the end of the page and click the **Add variant associated with Individual** button.
4. In the modal, enter "111" string value in the input field, assuming that this is the ClinVar VariantID without a pre-existing preferred title in the DB. Feel free to try other IDs that are appropriate for testing.
5. Clicking **Save** upon successfully retrieving the ClinVar name. You should expect to see the ClinVar Preferred Title being saved on the main form.
6. Now click on the **Edit ClinVar ID** button to invoke the modal again. You should expect to see the the **Retrieve from ClinVar** button to be active, and clicking it will retrieve the ClinVar name.