### PR TITLE
Connects to #635. Backfill clinvarVariantTitle field in variants

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -150,7 +150,7 @@ runcmd:
 - echo "America/Los_Angeles" | sudo tee /etc/timezone
 - sudo dpkg-reconfigure --frontend noninteractive tzdata
 - sudo echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
-- wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - 
+- wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 - sudo apt-get update
 - sudo apt-get -y install postgresql-9.4
 - update-rc.d elasticsearch defaults
@@ -176,7 +176,7 @@ runcmd:
 # Restore DB
 # (load data from s3)
 - if test "%(BACKUPDB)s" = "s3_data"
-- then 
+- then
 -   echo "====== restoring data from backup"
 -   /etc/init.d/postgresql stop
 -   sudo -u postgres /opt/wal-e/bin/wal-e --aws-instance-profile --s3-prefix="$(cat /etc/postgresql/9.4/main/wale_s3_prefix | tr -d "\n")" backup-fetch /var/lib/postgresql/9.4/main LATEST
@@ -213,12 +213,12 @@ runcmd:
 - a2disconf localized-error-pages
 - a2disconf other-vhosts-access-log
 - a2disconf serve-cgi-bin
-#TEMP for inital tests --commented out
-# - if test "%(ROLE)s" = "demo"
-# - then
-# -   sudo -u clincoded bin/batchupgrade production.ini --app-name app
-# - fi
-#/TEMP
+
+- if test "%(ROLE)s" = "demo"
+- then
+-   sudo -u clincoded bin/batchupgrade production.ini --app-name app
+- fi
+
 # - sleep 10
 # - sudo -u postgres echo "include 'master.conf'" >> /etc/postgresql/9.4/main/postgresql.conf
 # - pg_ctlcluster 9.4 main reload

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -209,7 +209,7 @@ runcmd:
 - a2dissite 000-default
 - a2enconf logging
 - a2disconf charset
-- a2disconf javascript-common
+# - a2disconf javascript-common
 - a2disconf localized-error-pages
 - a2disconf other-vhosts-access-log
 - a2disconf serve-cgi-bin

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -213,12 +213,10 @@ runcmd:
 - a2disconf localized-error-pages
 - a2disconf other-vhosts-access-log
 - a2disconf serve-cgi-bin
-
 - if test "%(ROLE)s" = "demo"
 - then
 -   sudo -u clincoded bin/batchupgrade production.ini --app-name app
 - fi
-
 # - sleep 10
 # - sudo -u postgres echo "include 'master.conf'" >> /etc/postgresql/9.4/main/postgresql.conf
 # - pg_ctlcluster 9.4 main reload

--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "clinvarVariantId": {
             "title": "Variant ID",

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -7,9 +7,74 @@ def variant_1_2(value, system):
     # for adding optional field clinvarVariantTitle
     if 'clinvarVariantTitle' not in value:
         if 'clinvarVariantId' in value:
-            response = urllib.request.urlopen('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&id=%s&retmode=json' % value['clinvarVariantId'])
-            str_response = response.read().decode('utf-8')
-            data = json.loads(str_response)
-            value['clinvarVariantTitle'] = str(data['result'][value['clinvarVariantId']]['title'])
+            if value['clinvarVariantId'] == '4662':
+                value['clinvarVariantTitle'] = 'NM_015074.3(KIF1B):c.4442G&gt;A (p.Ser1481Asn)'
+            if value['clinvarVariantId'] == '466':
+                value['clinvarVariantTitle'] = 'NM_000035.3(ALDOB):c.865_867delCTT (p.Leu289del)'
+            if value['clinvarVariantId'] == '6822':
+                value['clinvarVariantTitle'] = 'NM_058216.2(RAD51C):c.773G&gt;A (p.Arg258His)'
+            if value['clinvarVariantId'] == '50962':
+                value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1201A&gt;T (p.Arg401Ter)'
+            if value['clinvarVariantId'] == '50961':
+                value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1891delC (p.Gln631Serfs)'
+            if value['clinvarVariantId'] == '126422':
+                value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1370dupG (p.Arg458Lysfs)'
+            if value['clinvarVariantId'] == '126424':
+                value['clinvarVariantTitle'] = 'NM_001145293.1(NGLY1):c.1570C&gt;T (p.Arg524Ter)'
+            if value['clinvarVariantId'] == '126423':
+                value['clinvarVariantTitle'] = 'NM_001145294.1(NGLY1):c.1079_1081delGAA (p.Arg360del)'
+            if value['clinvarVariantId'] == '11717':
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.402delT (p.Phe134Leufs)'
+            if value['clinvarVariantId'] == '11720':
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.157A&gt;T (p.Ile53Phe)'
+            if value['clinvarVariantId'] == '11718':
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.971G&gt;A (p.Arg324Gln)'
+            if value['clinvarVariantId'] == '11719':
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.1009A&gt;G (p.Ile337Val)'
+            if value['clinvarVariantId'] == '11716':
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.62G&gt;T (p.Gly21Val)'
+            if value['clinvarVariantId'] == '12744':
+                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.520+2T&gt;C'
+            if value['clinvarVariantId'] == '12745':
+                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.176G&gt;A (p.Trp59Ter)'
+            if value['clinvarVariantId'] == '12746':
+                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.128_129delCC (p.Thr43Asnfs)'
+            if value['clinvarVariantId'] == '126649':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.2386G&gt;T (p.Gly796Ter)'
+            if value['clinvarVariantId'] == '126697':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.2982dupT (p.Ala995Cysfs)'
+            if value['clinvarVariantId'] == '126711':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3113G&gt;A (p.Trp1038Ter)'
+            if value['clinvarVariantId'] == '126715':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3116delA (p.Asn1039Ilefs)'
+            if value['clinvarVariantId'] == '128144':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3549C&gt;A (p.Tyr1183Ter)'
+            if value['clinvarVariantId'] == '41251':
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1303G&gt;A (p.Gly435Arg)'
+            if value['clinvarVariantId'] == '41252':
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.492C&gt;A (p.Phe164Leu)'
+            if value['clinvarVariantId'] == '30975':
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1192C&gt;T (p.Arg398Trp)'
+            if value['clinvarVariantId'] == '30976':
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1126C&gt;T (p.His376Tyr)'
+            if value['clinvarVariantId'] == '17072':
+                value['clinvarVariantTitle'] = 'C1QB, 150G-A'
+            if value['clinvarVariantId'] == '12707':
+                value['clinvarVariantTitle'] = 'NM_003276.2(TMPO):c.2068C&gt;T (p.Arg690Cys)'
+            if value['clinvarVariantId'] == '126609':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.1592delT (p.Leu531Cysfs)'
+            if value['clinvarVariantId'] == '126644':
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.229delT (p.Cys77Valfs)'
+            if value['clinvarVariantId'] == '4280':
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.415T&gt;C (p.Tyr139His)'
+            if value['clinvarVariantId'] == '4282':
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.460T&gt;A (p.Ter154Arg)'
+            if value['clinvarVariantId'] == '4281':
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.376G&gt;A (p.Val126Met)'
+            if value['clinvarVariantId'] == '1000':
+                value['clinvarVariantTitle'] = 'NM_001172813.1(SLC30A8):c.826C&gt;T (p.Arg276Trp)'
+            if value['clinvarVariantId'] == '5883':
+                value['clinvarVariantTitle'] = 'NM_005751.4(AKAP9):c.4709C&gt;T (p.Ser1570Leu)'
+
         else:
             value['clinvarVariantTitle'] = ''

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -8,73 +8,73 @@ def variant_1_2(value, system):
     if 'clinvarVariantTitle' not in value:
         if 'clinvarVariantId' in value:
             if value['clinvarVariantId'] == '4662':
-                value['clinvarVariantTitle'] = 'NM_015074.3(KIF1B):c.4442G&gt;A (p.Ser1481Asn)'
+                value['clinvarVariantTitle'] = 'NM_015074.3(KIF1B):c.4442G>A (p.Ser1481Asn)'
             if value['clinvarVariantId'] == '466':
                 value['clinvarVariantTitle'] = 'NM_000035.3(ALDOB):c.865_867delCTT (p.Leu289del)'
             if value['clinvarVariantId'] == '6822':
-                value['clinvarVariantTitle'] = 'NM_058216.2(RAD51C):c.773G&gt;A (p.Arg258His)'
+                value['clinvarVariantTitle'] = 'NM_058216.2(RAD51C):c.773G>A (p.Arg258His)'
             if value['clinvarVariantId'] == '50962':
-                value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1201A&gt;T (p.Arg401Ter)'
+                value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1201A>T (p.Arg401Ter)'
             if value['clinvarVariantId'] == '50961':
                 value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1891delC (p.Gln631Serfs)'
             if value['clinvarVariantId'] == '126422':
                 value['clinvarVariantTitle'] = 'NM_018297.3(NGLY1):c.1370dupG (p.Arg458Lysfs)'
             if value['clinvarVariantId'] == '126424':
-                value['clinvarVariantTitle'] = 'NM_001145293.1(NGLY1):c.1570C&gt;T (p.Arg524Ter)'
+                value['clinvarVariantTitle'] = 'NM_001145293.1(NGLY1):c.1570C>T (p.Arg524Ter)'
             if value['clinvarVariantId'] == '126423':
                 value['clinvarVariantTitle'] = 'NM_001145294.1(NGLY1):c.1079_1081delGAA (p.Arg360del)'
             if value['clinvarVariantId'] == '11717':
                 value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.402delT (p.Phe134Leufs)'
             if value['clinvarVariantId'] == '11720':
-                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.157A&gt;T (p.Ile53Phe)'
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.157A>T (p.Ile53Phe)'
             if value['clinvarVariantId'] == '11718':
-                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.971G&gt;A (p.Arg324Gln)'
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.971G>A (p.Arg324Gln)'
             if value['clinvarVariantId'] == '11719':
-                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.1009A&gt;G (p.Ile337Val)'
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.1009A>G (p.Ile337Val)'
             if value['clinvarVariantId'] == '11716':
-                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.62G&gt;T (p.Gly21Val)'
+                value['clinvarVariantTitle'] = 'NM_000686.4(AGTR2):c.62G>T (p.Gly21Val)'
             if value['clinvarVariantId'] == '12744':
-                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.520+2T&gt;C'
+                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.520+2T>C'
             if value['clinvarVariantId'] == '12745':
-                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.176G&gt;A (p.Trp59Ter)'
+                value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.176G>A (p.Trp59Ter)'
             if value['clinvarVariantId'] == '12746':
                 value['clinvarVariantTitle'] = 'NM_000733.3(CD3E):c.128_129delCC (p.Thr43Asnfs)'
             if value['clinvarVariantId'] == '126649':
-                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.2386G&gt;T (p.Gly796Ter)'
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.2386G>T (p.Gly796Ter)'
             if value['clinvarVariantId'] == '126697':
                 value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.2982dupT (p.Ala995Cysfs)'
             if value['clinvarVariantId'] == '126711':
-                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3113G&gt;A (p.Trp1038Ter)'
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3113G>A (p.Trp1038Ter)'
             if value['clinvarVariantId'] == '126715':
                 value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3116delA (p.Asn1039Ilefs)'
             if value['clinvarVariantId'] == '128144':
-                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3549C&gt;A (p.Tyr1183Ter)'
+                value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.3549C>A (p.Tyr1183Ter)'
             if value['clinvarVariantId'] == '41251':
-                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1303G&gt;A (p.Gly435Arg)'
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1303G>A (p.Gly435Arg)'
             if value['clinvarVariantId'] == '41252':
-                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.492C&gt;A (p.Phe164Leu)'
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.492C>A (p.Phe164Leu)'
             if value['clinvarVariantId'] == '30975':
-                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1192C&gt;T (p.Arg398Trp)'
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1192C>T (p.Arg398Trp)'
             if value['clinvarVariantId'] == '30976':
-                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1126C&gt;T (p.His376Tyr)'
+                value['clinvarVariantTitle'] = 'NM_018081.2(WRAP53):c.1126C>T (p.His376Tyr)'
             if value['clinvarVariantId'] == '17072':
                 value['clinvarVariantTitle'] = 'C1QB, 150G-A'
             if value['clinvarVariantId'] == '12707':
-                value['clinvarVariantTitle'] = 'NM_003276.2(TMPO):c.2068C&gt;T (p.Arg690Cys)'
+                value['clinvarVariantTitle'] = 'NM_003276.2(TMPO):c.2068C>T (p.Arg690Cys)'
             if value['clinvarVariantId'] == '126609':
                 value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.1592delT (p.Leu531Cysfs)'
             if value['clinvarVariantId'] == '126644':
                 value['clinvarVariantTitle'] = 'NM_024675.3(PALB2):c.229delT (p.Cys77Valfs)'
             if value['clinvarVariantId'] == '4280':
-                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.415T&gt;C (p.Tyr139His)'
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.415T>C (p.Tyr139His)'
             if value['clinvarVariantId'] == '4282':
-                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.460T&gt;A (p.Ter154Arg)'
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.460T>A (p.Ter154Arg)'
             if value['clinvarVariantId'] == '4281':
-                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.376G&gt;A (p.Val126Met)'
+                value['clinvarVariantTitle'] = 'NM_017838.3(NHP2):c.376G>A (p.Val126Met)'
             if value['clinvarVariantId'] == '1000':
-                value['clinvarVariantTitle'] = 'NM_001172813.1(SLC30A8):c.826C&gt;T (p.Arg276Trp)'
+                value['clinvarVariantTitle'] = 'NM_001172813.1(SLC30A8):c.826C>T (p.Arg276Trp)'
             if value['clinvarVariantId'] == '5883':
-                value['clinvarVariantTitle'] = 'NM_005751.4(AKAP9):c.4709C&gt;T (p.Ser1570Leu)'
+                value['clinvarVariantTitle'] = 'NM_005751.4(AKAP9):c.4709C>T (p.Ser1570Leu)'
 
         else:
             value['clinvarVariantTitle'] = ''

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -8,7 +8,7 @@ def variant_1_2(value, system):
     if 'clinvarVariantTitle' not in value:
         if 'clinvarVariantId' in value:
             response = urllib.request.urlopen('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&id=%s&retmode=json' % value['clinvarVariantId'])
-            str_response = response.readall().decode('utf-8')
+            str_response = response.read().decode('utf-8')
             data = json.loads(str_response)
             value['clinvarVariantTitle'] = str(data['result'][value['clinvarVariantId']]['title'])
         else:

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -1,7 +1,14 @@
 from contentbase.upgrader import upgrade_step
+import urllib
+import json
 
 @upgrade_step('variant', '1', '2')
 def variant_1_2(value, system):
     # for adding optional field clinvarVariantTitle
     if 'clinvarVariantTitle' not in value:
-        value['clinvarVariantTitle'] = ''
+        if 'clinvarVariantId' in value:
+            response = urllib.urlopen('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&id=%s&retmode=json' % value['clinvarVariantId'])
+            data = json.loads(response.read())
+            value['clinvarVariantTitle'] = str(data['result'][value['clinvarVariantId']]['title'])
+        else:
+            value['clinvarVariantTitle'] = ''

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -1,5 +1,5 @@
 from contentbase.upgrader import upgrade_step
-import urllib
+import urllib.request
 import json
 
 @upgrade_step('variant', '1', '2')
@@ -7,8 +7,9 @@ def variant_1_2(value, system):
     # for adding optional field clinvarVariantTitle
     if 'clinvarVariantTitle' not in value:
         if 'clinvarVariantId' in value:
-            response = urllib.urlopen('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&id=%s&retmode=json' % value['clinvarVariantId'])
-            data = json.loads(response.read())
+            response = urllib.request.urlopen('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&id=%s&retmode=json' % value['clinvarVariantId'])
+            str_response = response.readall().decode('utf-8')
+            data = json.loads(str_response)
             value['clinvarVariantTitle'] = str(data['result'][value['clinvarVariantId']]['title'])
         else:
             value['clinvarVariantTitle'] = ''

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -1,0 +1,7 @@
+from contentbase.upgrader import upgrade_step
+
+@upgrade_step('variant', '1', '2')
+def variant_1_2(value, system):
+    # for adding optional field clinvarVariantTitle
+    if 'clinvarVariantTitle' not in value:
+        value['clinvarVariantTitle'] = ''


### PR DESCRIPTION
Testing:

1. Spin up AWS instance with production data
2. Confirm that variants have the `clinvarVariantTitle` field (filled in with a valid variant preferred title or empty string)