### PR TITLE
Connects to #587. Connects to #608. Display changes.

### DIFF
--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1351,20 +1351,24 @@ var IndividualVariantInfo = function() {
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}
-                                {(i === this.state.variantCount - 1 && this.state.variantCount < MAX_VARIANTS) ?
-                                    <div className="col-sm-7 col-sm-offset-5">
-                                        <p className="alert alert-warning">
-                                            For a recessive condition, you must enter both variants believed to be causative for the disease in order that
-                                            each may be associated with the Individual and assessed (except in the case of homozygous recessive, then the
-                                            variant need only be entered once). Additionally, each variant must be assessed as supports for the Individual to be counted.
-                                        </p>
-                                        <Input type="button" ref="addvariant" inputClassName="btn-default btn-last pull-right" title="Add another variant associated with Individual"
-                                            clickHandler={this.handleAddVariant} inputDisabled={this.state.addVariantDisabled} />
-                                    </div>
-                                : null}
                             </div>
                         );
                     })}
+                    {this.state.variantCount < MAX_VARIANTS ?
+                        <div className="row">
+                            <div className="col-sm-7 col-sm-offset-5 clearfix">
+                                {this.state.variantCount ?
+                                    <p className="alert alert-warning">
+                                        For a recessive condition, you must enter both variants believed to be causative for the disease in order that
+                                        each may be associated with the Individual and assessed (except in the case of homozygous recessive, then the
+                                        variant need only be entered once). Additionally, each variant must be assessed as supports for the Individual to be counted.
+                                    </p>
+                                : null}
+                                <Input type="button" ref="addvariant" inputClassName="btn-default btn-last pull-right" title="Add another variant associated with Individual"
+                                    clickHandler={this.handleAddVariant} inputDisabled={this.state.addVariantDisabled} />
+                            </div>
+                        </div>
+                    : null}
                 </div>
             }
         </div>

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -402,7 +402,7 @@ var VariantCuration = React.createClass({
                         {curatorName ? <h2>{'Curator: ' + curatorName}</h2> : null}
                         <VariantAssociationsHeader gdm={gdm} variant={variant} />
                         {variant ?
-                            <h2>{variant.clinvarVariantId ? (
+                            <h2>{variant.clinvarVariantId ?
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
                                         <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
@@ -413,8 +413,14 @@ var VariantCuration = React.createClass({
                                         <dd>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
                                     </dl>
                                 </div>
-                            )
-                            : <span>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}</span>}</h2>
+                            :
+                                <div className="row variant-association-header">
+                                    <dl className="dl-horizontal">
+                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; Variant Description</dt>
+                                        <dd>{variant.otherDescription ? variant.otherDescription : null}</dd>
+                                    </dl>
+                                </div>
+                            }</h2>
                         : null}
                     </div>
                     <div className="row group-curation-content">

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -416,7 +416,10 @@ var VariantCuration = React.createClass({
                             :
                                 <div className="row variant-association-header">
                                     <dl className="dl-horizontal">
-                                        <dt>{gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; Variant Description</dt>
+                                        {gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}
+                                    </dl>
+                                    <dl className="dl-horizontal">
+                                        <dt>Other Description</dt>
                                         <dd>{variant.otherDescription ? variant.otherDescription : null}</dd>
                                     </dl>
                                 </div>


### PR DESCRIPTION
#### Related to #587:
Fix display on Variant page for variants with Other Description specified

![image](https://cloud.githubusercontent.com/assets/4326866/13832007/29f5e10a-eb95-11e5-9796-0e0be7b1fb11.png)

#### Related to #608:
Add spacing between Mutalyzer text and orange box in Variant form

![image](https://cloud.githubusercontent.com/assets/4326866/13823392/9103b81a-eb66-11e5-8533-df72cb2d8280.png)