### PR TITLE
Connects to #634. Connects to #638. Label styling, PMID sorting

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -66,7 +66,7 @@ var CurationCentral = React.createClass({
             if (pmid == undefined && gdm.annotations && gdm.annotations.length > 0) {
                 var annotations = _(gdm.annotations).sortBy(function(annotation) {
                     // Sort list of articles by first author
-                    return annotation.article.authors[0];
+                    return annotation.article.authors[0].toLowerCase();
                 });
                 pmid = annotations[0].article.pmid;
             }
@@ -223,7 +223,7 @@ var PmidSelectionList = React.createClass({
     render: function() {
         var annotations = _(this.props.annotations).sortBy(function(annotation) {
             // Sort list of articles by first author
-            return annotation.article.authors[0].toLowerCase;
+            return annotation.article.authors[0].toLowerCase();
         });
 
         return (

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -223,7 +223,7 @@ var PmidSelectionList = React.createClass({
     render: function() {
         var annotations = _(this.props.annotations).sortBy(function(annotation) {
             // Sort list of articles by first author
-            return annotation.article.authors[0];
+            return annotation.article.authors[0].toLowerCase;
         });
 
         return (

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -386,7 +386,7 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
 
                             return (
                                 <div className="col-sm-6 col-md-6 col-lg-4" key={variant.uuid}>
-                                    <a className={"btn btn-primary btn-xs variant-title-ellipsis" + (inCurrentGdm ? ' assessed' : '')}
+                                    <a className={"btn btn-primary btn-xs title-ellipsis" + (inCurrentGdm ? ' assessed' : '')}
                                         href={'/variant-curation/?all&gdm=' + gdm.uuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid + (session ? '&user=' + session.user_properties.uuid : '') + (userPathogenicity ? '&pathogenicity=' + userPathogenicity.uuid : '')}
                                         title={variantName}>
                                         {variantName}
@@ -638,7 +638,7 @@ var renderGroup = function(group, gdm, annotation, curatorMatch) {
 
     return (
         <div className="panel-evidence-group">
-            <h5>{group.label}</h5>
+            <h5><span className="title-ellipsis dotted" title={group.label}>{group.label}</span></h5>
             <div className="evidence-curation-info">
                 {group.submitted_by ?
                     <p className="evidence-curation-info">{group.submitted_by.title}</p>
@@ -664,7 +664,7 @@ var renderFamily = function(family, gdm, annotation, curatorMatch) {
 
     return (
         <div className="panel-evidence-group">
-            <h5>{family.label}</h5>
+            <h5><span className="title-ellipsis dotted" title={family.label}>{family.label}</span></h5>
             <div className="evidence-curation-info">
                 {family.submitted_by ?
                     <p className="evidence-curation-info">{family.submitted_by.title}</p>
@@ -678,7 +678,7 @@ var renderFamily = function(family, gdm, annotation, curatorMatch) {
                         return (
                             <span key={i}>
                                 {i > 0 ? ', ' : ''}
-                                <a href={group['@id']} title="View group in a new tab">{group.label}</a>
+                                <a href={group['@id']} title="View group in a new tab" className="title-ellipsis title-ellipsis-short">{group.label}</a>
                             </span>
                         );
                     })}
@@ -708,7 +708,7 @@ var renderIndividual = function(individual, gdm, annotation, curatorMatch) {
 
     return (
         <div className="panel-evidence-group">
-            <h5>{individual.label}{individual.proband ? <i className="icon icon-proband"></i> : null}</h5>
+            <h5><span className="title-ellipsis title-ellipsis-short dotted" title={individual.label}>{individual.label}</span>{individual.proband ? <i className="icon icon-proband"></i> : null}</h5>
             <div className="evidence-curation-info">
                 {individual.submitted_by ?
                     <p className="evidence-curation-info">{individual.submitted_by.title}</p>
@@ -722,7 +722,7 @@ var renderIndividual = function(individual, gdm, annotation, curatorMatch) {
                         return (
                             <span key={group.uuid}>
                                 {i++ > 0 ? ', ' : ''}
-                                <a href={group['@id']} title="View group in a new tab">{group.label}</a>
+                                <a href={group['@id']} title="View group in a new tab" className="title-ellipsis title-ellipsis-short">{group.label}</a>
                             </span>
                         );
                     })}
@@ -733,13 +733,13 @@ var renderIndividual = function(individual, gdm, annotation, curatorMatch) {
                                     return (
                                         <span key={group.uuid}>
                                             {i++ > 0 ? ', ' : ''}
-                                            <a href={group['@id']} title="View group in a new tab">{group.label}</a>
+                                            <a href={group['@id']} title="View group in a new tab" className="title-ellipsis title-ellipsis-short">{group.label}</a>
                                         </span>
                                     );
                                 })}
                                 <span key={family.uuid}>
                                     {i++ > 0 ? ', ' : ''}
-                                    <a href={family['@id'] + '?gdm=' + gdm.uuid} title="View family in a new tab">{family.label}</a>
+                                    <a href={family['@id'] + '?gdm=' + gdm.uuid} title="View family in a new tab" className="title-ellipsis title-ellipsis-short">{family.label}</a>
                                 </span>
                             </span>
                         );
@@ -782,7 +782,7 @@ var renderExperimental = function(experimental, gdm, annotation, curatorMatch) {
 
     return (
         <div className="panel-evidence-group" key={experimental.uuid}>
-            <h5>{experimental.label}</h5>
+            <h5><span className="title-ellipsis dotted" title={experimental.label}>{experimental.label}</span></h5>
             {experimental.evidenceType}{subtype}
             <div className="evidence-curation-info">
                 {experimental.submitted_by ?
@@ -826,7 +826,7 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session) {
 
     return (
         <div className="panel-evidence-group">
-            <h5 className="variant-title-ellipsis"><a title={variantTitle}>{variantTitle}</a></h5>
+            <h5><span className="title-ellipsis dotted" title={variantTitle}>{variantTitle}</span></h5>
             <div className="evidence-curation-info">
                 {variant.submitted_by ?
                     <p className="evidence-curation-info">{variant.submitted_by.title}</p>
@@ -842,7 +842,7 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session) {
                         return (
                             <span key={i}>
                                 {i > 0 ? ', ' : ''}
-                                <a href={association['@id']} title={'View ' + associationType + ' in a new tab'}>{association.label}</a>
+                                <a href={association['@id']} title={'View ' + associationType + ' in a new tab'} className="title-ellipsis title-ellipsis-short">{association.label}</a>
                                 {probandIndividual ? <i className="icon icon-proband"></i> : null}
                             </span>
                         );

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -152,7 +152,7 @@ var ExperimentalCuration = React.createClass({
                 experimentalTypeDescription: this.getExperimentalTypeDescription(tempExperimentalType)
             });
             if (this.state.experimentalNameVisible) {
-                this.refs['experimentalName'].resetValue();
+                this.refs['experimentalName'].setValue('');
             }
             if (tempExperimentalType == 'none') {
                 // reset form
@@ -182,7 +182,7 @@ var ExperimentalCuration = React.createClass({
             }
             // Reset values when changing between Subtypes
             if (this.refs['experimentalName']) {
-                this.refs['experimentalName'].resetValue();
+                this.refs['experimentalName'].setValue('');
                 this.setState({experimentalName: ''});
             }
             if (this.refs['identifiedFunction']) {
@@ -1467,10 +1467,9 @@ var ExperimentalNameType = function() {
                 </Input>
             : null}
             {this.state.experimentalNameVisible ?
-                <Input type="textarea" ref="experimentalName" label="Experiment name:"
+                <Input type="text" ref="experimentalName" label="Experiment name:"
                     error={this.getFormError('experimentalName')} clearError={this.clrFormErrors.bind(null, 'experimentalName')}
-                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="no-resize"
-                    rows='1' value={experimental && experimental.label} handleChange={this.handleChange} inputDisabled={this.cv.othersAssessed} required />
+                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" value={experimental && experimental.label} handleChange={this.handleChange} inputDisabled={this.cv.othersAssessed} required />
             : null}
         </div>
     );

--- a/src/clincoded/static/scss/clincoded/_base.scss
+++ b/src/clincoded/static/scss/clincoded/_base.scss
@@ -23,6 +23,8 @@ h6, .h6 { font-size: $font-size-h6; }
 
 p {
     line-height: 1.6;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 input[type=text],

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -233,6 +233,10 @@
 .panel-evidence-group {
     margin: 5px 0;
 
+    h5 {
+        display: block;
+    }
+
     .variant-preferred-title {
         border-bottom: 1px dotted #337ab7;
         cursor: pointer;
@@ -417,12 +421,12 @@
     }
 }
 
-.variant-title-ellipsis {
+.title-ellipsis {
     overflow: hidden;
-    display: block;
+    display: inline-block;
     white-space: nowrap;
     text-overflow: ellipsis;
-    padding-bottom: 3px;
+    max-width: 100%;
 
     a {
         border-bottom: 1px dotted #337ab7;
@@ -432,6 +436,18 @@
             text-decoration: none;
         }
     }
+}
+
+.title-ellipsis-short {
+    max-width: 91%;
+
+    @media screen and (min-width: $screen-sm-min) {
+        max-width: 89%;
+    }
+}
+
+.dotted {
+    border-bottom: 1px dotted #000;
 }
 
 .curation-submit {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -304,6 +304,7 @@
             padding: 8px 20px 8px 25px;
             border-top: 1px solid #ddd;
             list-style: none;
+            word-wrap: break-word;
         }
 
         li:nth-last-child(1) {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -396,11 +396,16 @@
 .viewer-titles {
     h1 {
         margin-bottom: 10px;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     h2 {
         margin-top: 0;
         font-size: 1.3rem;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     .pmid-association-header {


### PR DESCRIPTION
#### Related to #634:

Testing:

1. Add PMID with lower-case first-letter of last name (21217753)
2. Add PMID with upper-case first-letter of last name (19711971)
3. Confirm that sorting in the PMID list is case-insensitive

![image](https://cloud.githubusercontent.com/assets/4326866/13864625/55374da6-ec60-11e5-9692-84eb5d04949a.png)

#### Related to #638:

Testing:

1. Add Group, Family, Individual, Experimental Data, and Variants with very very long names
2. Confirm that the labels cutoff properly in the Curation Palette (both labels and associations), Variation Header, and Dashboard

![image](https://cloud.githubusercontent.com/assets/4326866/13864208/e3302c80-ec5c-11e5-9e3e-93f38d798037.png)
![image](https://cloud.githubusercontent.com/assets/4326866/13864215/ec20dcb8-ec5c-11e5-83a8-da3d63a20e66.png)
![image](https://cloud.githubusercontent.com/assets/4326866/13864243/2360fd34-ec5d-11e5-9a26-7c4223b7851f.png)
![image](https://cloud.githubusercontent.com/assets/4326866/13864965/6e937754-ec63-11e5-9b70-55ce0c64689d.png)