### PR TITLE
Connects to #645. Edit form of Group/Family Method missing pre-existing data.

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2582,15 +2582,17 @@ var ExperimentalViewer = React.createClass({
                                     <dd>{experimental.functionalAlteration.cellMutationOrEngineeredEquivalent}</dd>
                                 </div>
 
-                                <div>
-                                    <dt>Patient cell type</dt>
-                                    <dd>{experimental.functionalAlteration.patientCellType ? <a href={external_url_map['CLSearch'] + experimental.functionalAlteration.patientCellType} title={"CL entry for " + experimental.functionalAlteration.patientCellType + " in new tab"} target="_blank">{experimental.functionalAlteration.patientCellType}</a> : null}</dd>
-                                </div>
-
-                                <div>
-                                    <dt>Engineered cell type</dt>
-                                    <dd>{experimental.functionalAlteration.engineeredEquivalentCellType ? <a href={external_url_map['EFO'] + experimental.functionalAlteration.engineeredEquivalentCellType} title={"EFO entry for " + experimental.functionalAlteration.engineeredEquivalentCellType + " in new tab"} target="_blank">{experimental.functionalAlteration.engineeredEquivalentCellType}</a> : null}</dd>
-                                </div>
+                                {experimental.functionalAlteration.cellMutationOrEngineeredEquivalent === 'Patient cells' ?
+                                    <div>
+                                        <dt>Patient cell type</dt>
+                                        <dd>{experimental.functionalAlteration.patientCellType ? <a href={external_url_map['CLSearch'] + experimental.functionalAlteration.patientCellType} title={"CL entry for " + experimental.functionalAlteration.patientCellType + " in new tab"} target="_blank">{experimental.functionalAlteration.patientCellType}</a> : null}</dd>
+                                    </div>
+                                :
+                                    <div>
+                                        <dt>Engineered cell type</dt>
+                                        <dd>{experimental.functionalAlteration.engineeredEquivalentCellType ? <a href={external_url_map['EFO'] + experimental.functionalAlteration.engineeredEquivalentCellType} title={"EFO entry for " + experimental.functionalAlteration.engineeredEquivalentCellType + " in new tab"} target="_blank">{experimental.functionalAlteration.engineeredEquivalentCellType}</a> : null}</dd>
+                                    </div>
+                                }
 
                                 <div>
                                     <dt>Description of gene alteration</dt>
@@ -2622,15 +2624,17 @@ var ExperimentalViewer = React.createClass({
                                     <dd>{experimental.modelSystems.animalOrCellCulture}</dd>
                                 </div>
 
-                                <div>
-                                    <dt>Animal model</dt>
-                                    <dd>{experimental.modelSystems.animalModel}</dd>
-                                </div>
-
-                                <div>
-                                    <dt>Cell-culture type/line</dt>
-                                    <dd>{experimental.modelSystems.cellCulture ? <a href={external_url_map['EFO'] + experimental.modelSystems.cellCulture} title={"EFO entry for " + experimental.modelSystems.cellCulture + " in new tab"} target="_blank">{experimental.modelSystems.cellCulture}</a> : null}</dd>
-                                </div>
+                                {experimental.modelSystems.animalOrCellCulture === 'Animal model' ?
+                                    <div>
+                                        <dt>Animal model</dt>
+                                        <dd>{experimental.modelSystems.animalModel}</dd>
+                                    </div>
+                                :
+                                    <div>
+                                        <dt>Cell-culture type/line</dt>
+                                        <dd>{experimental.modelSystems.cellCulture ? <a href={external_url_map['EFO'] + experimental.modelSystems.cellCulture} title={"EFO entry for " + experimental.modelSystems.cellCulture + " in new tab"} target="_blank">{experimental.modelSystems.cellCulture}</a> : null}</dd>
+                                    </div>
+                                }
 
                                 <div>
                                     <dt>Description of gene alteration</dt>
@@ -2677,15 +2681,17 @@ var ExperimentalViewer = React.createClass({
                                     <dd>{experimental.rescue.patientCellOrEngineeredEquivalent}</dd>
                                 </div>
 
-                                <div>
-                                    <dt>Patient cell type</dt>
-                                    <dd>{experimental.rescue.patientCellType ? <a href={external_url_map['CLSearch'] + experimental.rescue.patientCellType} title={"CL entry for " + experimental.rescue.patientCellType + " in new tab"} target="_blank">{experimental.rescue.patientCellType}</a> : null}</dd>
-                                </div>
-
-                                <div>
-                                    <dt>Engineered equivalent cell type</dt>
-                                    <dd>{experimental.rescue.engineeredEquivalentCellType ? <a href={external_url_map['EFO'] + experimental.rescue.engineeredEquivalentCellType} title={"EFO entry for " + experimental.rescue.engineeredEquivalentCellType + " in new tab"} target="_blank">{experimental.rescue.engineeredEquivalentCellType}</a> : null}</dd>
-                                </div>
+                                {experimental.rescue.patientCellOrEngineeredEquivalent === 'Patient cells' ?
+                                    <div>
+                                        <dt>Patient cell type</dt>
+                                        <dd>{experimental.rescue.patientCellType ? <a href={external_url_map['CLSearch'] + experimental.rescue.patientCellType} title={"CL entry for " + experimental.rescue.patientCellType + " in new tab"} target="_blank">{experimental.rescue.patientCellType}</a> : null}</dd>
+                                    </div>
+                                :
+                                    <div>
+                                        <dt>Engineered equivalent cell type</dt>
+                                        <dd>{experimental.rescue.engineeredEquivalentCellType ? <a href={external_url_map['EFO'] + experimental.rescue.engineeredEquivalentCellType} title={"EFO entry for " + experimental.rescue.engineeredEquivalentCellType + " in new tab"} target="_blank">{experimental.rescue.engineeredEquivalentCellType}</a> : null}</dd>
+                                    </div>
+                                }
 
                                 <div>
                                     <dt>Description of gene alteration</dt>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1539,7 +1539,7 @@ var FamilyDemographics = function() {
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
                 {country_codes.map(function(country_code) {
-                    return <option key={country_code.code}>{country_code.name}</option>;
+                    return <option key={country_code.code} value={country_code.name}>{country_code.name}</option>;
                 })}
             </Input>
             <Input type="select" ref="ethnicity" label="Ethnicity:" defaultValue="none" value={family && family.ethnicity}

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -684,7 +684,7 @@ var GroupDemographics = function() {
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
                 {country_codes.map(function(country_code) {
-                    return <option key={country_code.code}>{country_code.name}</option>;
+                    return <option key={country_code.code} value={country_code.name}>{country_code.name}</option>;
                 })}
             </Input>
             <Input type="select" ref="ethnicity" label="Ethnicity:" defaultValue="none" value={group && group.ethnicity}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1226,7 +1226,7 @@ var IndividualDemographics = function() {
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
                 {country_codes.map(function(country_code) {
-                    return <option key={country_code.code}>{country_code.name}</option>;
+                    return <option key={country_code.code} value={country_code.name}>{country_code.name}</option>;
                 })}
             </Input>
             <Input type="select" ref="ethnicity" label="Ethnicity:" defaultValue="none" value={individual && individual.ethnicity}

--- a/src/clincoded/static/components/methods.js
+++ b/src/clincoded/static/components/methods.js
@@ -22,8 +22,8 @@ module.exports = {
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Yes</option>
-                    <option>No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
                 </Input>
                 <Input type="textarea" ref="prevtestingdesc" label="Description of Previous Testing:" rows="5" value={method.previousTestingDescription}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
@@ -32,52 +32,52 @@ module.exports = {
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7 label-box-match-middle" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Yes</option>
-                    <option>No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
                 </Input>
                 <h4 className="col-sm-7 col-sm-offset-5">Genotyping Method</h4>
                 <Input type="select" ref="genotypingmethod1" label="Method 1:" handleChange={this.handleChange} defaultValue="none" value={method.genotypingMethods && method.genotypingMethods[0] ? method.genotypingMethods[0] : null}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Exome sequencing</option>
-                    <option>Genotyping</option>
-                    <option>High resolution melting</option>
-                    <option>PCR</option>
-                    <option>Sanger sequencing</option>
-                    <option>Whole genome shotgun sequencing</option>
+                    <option value="Exome sequencing">Exome sequencing</option>
+                    <option value="Genotyping">Genotyping</option>
+                    <option value="High resolution melting">High resolution melting</option>
+                    <option value="PCR">PCR</option>
+                    <option value="Sanger sequencing">Sanger sequencing</option>
+                    <option value="Whole genome shotgun sequencing">Whole genome shotgun sequencing</option>
                 </Input>
                 <Input type="select" ref="genotypingmethod2" label="Method 2:" defaultValue="none" value={method.genotypingMethods && method.genotypingMethods[1] ? method.genotypingMethods[1] : null}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputDisabled={this.state.genotyping2Disabled}>
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Exome sequencing</option>
-                    <option>Genotyping</option>
-                    <option>High resolution melting</option>
-                    <option>PCR</option>
-                    <option>Sanger sequencing</option>
-                    <option>Whole genome shotgun sequencing</option>
+                    <option value="Exome sequencing">Exome sequencing</option>
+                    <option value="Genotyping">Genotyping</option>
+                    <option value="High resolution melting">High resolution melting</option>
+                    <option value="PCR">PCR</option>
+                    <option value="Sanger sequencing">Sanger sequencing</option>
+                    <option value="Whole genome shotgun sequencing">Whole genome shotgun sequencing</option>
                 </Input>
                 <Input type="select" ref="entiregene" label="Entire gene sequenced?:" defaultValue="none" value={curator.booleanToDropdown(method.entireGeneSequenced)}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Yes</option>
-                    <option>No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
                 </Input>
                 <Input type="select" ref="copyassessed" label="Copy number assessed?:" defaultValue="none" value={curator.booleanToDropdown(method.copyNumberAssessed)}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Yes</option>
-                    <option>No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
                 </Input>
                 <Input type="select" ref="mutationsgenotyped" label="Specific mutations genotyped?:" defaultValue="none" value={curator.booleanToDropdown(method.specificMutationsGenotyped)}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     <option value="none">No Selection</option>
                     <option disabled="disabled"></option>
-                    <option>Yes</option>
-                    <option>No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
                 </Input>
                 <Input type="textarea" ref="specificmutation" label="Description of genotyping method:" rows="5" value={method.specificMutationsGenotypedMethod}
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />


### PR DESCRIPTION
**This PR is to address 2 issues:**
1. The edit form of Group/Family Method does not retain pre-existing data.
2. Suppressed form field labels/values in the viewer that have dependency on user's selection in experimental curation.

**Testing steps for #645:**

_Issue 1_
1. Go to Curation Central page and add a new PMID.
2. From the Evidence column on the far-right, click on the blue **Group** bar to proceed to the curation form.
3. Fill out the required fields, and particularly the entire section of **Group - Methods**. Submit the form and proceed with adding the associated family and individual curation. Please be sure to fill out the **Family - Methods** section for the family curation, and the **Country of Origin** in the **Individual - Demographics** section for the individual curation.
4. Submit the form(s) and return to the Curation Central page. Click on the **Edit** links individually for the Group/Family/Individual Evidence to proceed to the Edit forms.
5. Expect to see the pre-existing data being present in the **Group - Methods**, **Family - Methods** and **Individual - Demographics** sections respectively.

_Issue 2_
1. While on the Curation Central page, click on the blue **Experimental Data** bar to proceed to the curation form.
2. From the **Experiment type** dropdown menu, select from one of the last 3 options: **Functional Alteration**, **Model Systems**, **Rescue**.
3. In their respective **Functional Alteration**, **Model Systems** and **Rescue** sections, select either one of the 2 options (e.g. _Patient cells_ or _Engineered equivalent_ in **Functional Alteration**). Submit the form and return to the Curation Central page.
4. Click on the **View/Assess** link for the Experimental Data evidence to proceed to the view page.
5. Expect the **Engineered equivalent cell type/line** label to be absent if the option **Patient cells** was previously selected. Or if the option **Engineered equivalent** was previously selected, the **Patient cell type** label will be absent.