### PR TITLE
Connects to #640. Connects to #647. Label length limit and briefcase fix

### DIFF
--- a/src/clincoded/schemas/experimental.json
+++ b/src/clincoded/schemas/experimental.json
@@ -19,7 +19,8 @@
         "label": {
             "title": "Label",
             "description": "A user entered label for the experiment",
-            "type": "string"
+            "type": "string",
+            "maxLength": 60
         },
         "active": {
             "title": "Active",

--- a/src/clincoded/schemas/family.json
+++ b/src/clincoded/schemas/family.json
@@ -20,7 +20,8 @@
         "label": {
             "title": "Label",
             "description": "An user entered label for the family",
-            "type": "string"
+            "type": "string",
+            "maxLength": 60
         },
         "commonDiagnosis": {
             "title": "Common Diagnosis",

--- a/src/clincoded/schemas/group.json
+++ b/src/clincoded/schemas/group.json
@@ -24,7 +24,8 @@
             "title": "Label",
             "description": "Label of group",
             "type": "string",
-            "default": ""
+            "default": "",
+            "maxLength": 60
         },
         "commonDiagnosis": {
             "title": "Common Diagnosis",

--- a/src/clincoded/schemas/individual.json
+++ b/src/clincoded/schemas/individual.json
@@ -20,7 +20,8 @@
         "label": {
             "title": "Label",
             "description": "An user entered label for individual",
-            "type": "string"
+            "type": "string",
+            "maxLength": 60
         },
         "diagnosis": {
             "title": "Diagnosis",

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1468,7 +1468,7 @@ var ExperimentalNameType = function() {
             : null}
             {this.state.experimentalNameVisible ?
                 <Input type="text" ref="experimentalName" label="Experiment name:"
-                    error={this.getFormError('experimentalName')} clearError={this.clrFormErrors.bind(null, 'experimentalName')}
+                    error={this.getFormError('experimentalName')} clearError={this.clrFormErrors.bind(null, 'experimentalName')} maxLength="60"
                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" value={experimental && experimental.label} handleChange={this.handleChange} inputDisabled={this.cv.othersAssessed} required />
             : null}
         </div>

--- a/src/clincoded/static/components/experimental_submit.js
+++ b/src/clincoded/static/components/experimental_submit.js
@@ -113,7 +113,7 @@ var ExperimentalSubmit = React.createClass({
                         </div>
                     : null}
                     {experimental ?
-                        <div className="viewer-titles">
+                        <div className="viewer-titles submit-titles">
                             <h1>{experimental.evidenceType}<br />Experimental Data Information: {experimental.label}</h1> <a href={editExperimentalLink} className="btn btn-info">Edit/Assess</a>
                         </div>
                     : null}

--- a/src/clincoded/static/components/experimental_submit.js
+++ b/src/clincoded/static/components/experimental_submit.js
@@ -113,7 +113,9 @@ var ExperimentalSubmit = React.createClass({
                         </div>
                     : null}
                     {experimental ?
-                        <h1>{experimental.evidenceType}<br />Experimental Data Information: {experimental.label} <a href={editExperimentalLink} className="btn btn-info">Edit/Assess</a></h1>
+                        <div className="viewer-titles">
+                            <h1>{experimental.evidenceType}<br />Experimental Data Information: {experimental.label}</h1> <a href={editExperimentalLink} className="btn btn-info">Edit/Assess</a>
+                        </div>
                     : null}
                     <div className="row">
                         <div className="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1382,7 +1382,7 @@ var FamilyName = function(displayNote) {
                 <div className="col-sm-7 col-sm-offset-5"><p className="alert alert-warning">If this Family is a member of a Group, please curate the Group first and then add the Family to that Group.</p></div>
             : null}
             <Input type="text" ref="familyname" label="Family Label:" value={family && family.label} handleChange={this.handleChange}
-                error={this.getFormError('familyname')} clearError={this.clrFormErrors.bind(null, 'familyname')}
+                error={this.getFormError('familyname')} clearError={this.clrFormErrors.bind(null, 'familyname')} maxLength="60"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
             <p className="col-sm-7 col-sm-offset-5 input-note-below">{curator.renderLabelNote('Family')}</p>
             {displayNote ?

--- a/src/clincoded/static/components/family_submit.js
+++ b/src/clincoded/static/components/family_submit.js
@@ -209,12 +209,12 @@ var FamilySubmit = module.exports.FamilySubmit = React.createClass({
                                                         </p>
                                                     </div>
                                                     <div className="submit-results-buttons">
-                                                        <div className="col-md-6">
+                                                        <div className="col-lg-6">
                                                             <span className="family-submit-results-btn">
                                                                 <a className="btn btn-default" href={'/individual-curation/?gdm=' + gdm.uuid + '&evidence=' + annotation.uuid + '&family=' + family.uuid}>Add non-proband Individual</a>
                                                             </span>
                                                         </div>
-                                                        <div className="col-md-6">
+                                                        <div className="col-lg-6">
                                                             <span className="family-submit-results-btn">
                                                                 <a className="btn btn-default" href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}>Return to Record Curation page <i className="icon icon-briefcase"></i></a>
                                                             </span>

--- a/src/clincoded/static/components/family_submit.js
+++ b/src/clincoded/static/components/family_submit.js
@@ -133,7 +133,7 @@ var FamilySubmit = module.exports.FamilySubmit = React.createClass({
                         </div>
                     : null}
                     {family ?
-                        <div className="viewer-titles">
+                        <div className="viewer-titles submit-titles">
                             <h1>Family Information: {family.label}</h1> <a href={editFamilyLink} className="btn btn-info">Edit/Assess</a>
                             {group ?
                                 <h2>{'Group association: ' + group.label}</h2>

--- a/src/clincoded/static/components/family_submit.js
+++ b/src/clincoded/static/components/family_submit.js
@@ -134,7 +134,7 @@ var FamilySubmit = module.exports.FamilySubmit = React.createClass({
                     : null}
                     {family ?
                         <div className="viewer-titles">
-                            <h1>Family Information: {family.label} <a href={editFamilyLink} className="btn btn-info">Edit/Assess</a></h1>
+                            <h1>Family Information: {family.label}</h1> <a href={editFamilyLink} className="btn btn-info">Edit/Assess</a>
                             {group ?
                                 <h2>{'Group association: ' + group.label}</h2>
                             : null}

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -581,7 +581,7 @@ var GroupName = function() {
 
     return (
         <div className="row">
-            <Input type="text" ref="groupname" label="Group Label:" value={group && group.label} handleChange={this.handleChange}
+            <Input type="text" ref="groupname" label="Group Label:" value={group && group.label} maxLength="60" handleChange={this.handleChange}
                 error={this.getFormError('groupname')} clearError={this.clrFormErrors.bind(null, 'groupname')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
             <p className="col-sm-7 col-sm-offset-5 input-note-below">{curator.renderLabelNote('Group')}</p>

--- a/src/clincoded/static/components/group_submit.js
+++ b/src/clincoded/static/components/group_submit.js
@@ -121,7 +121,7 @@ var GroupSubmit = module.exports.GroupSubmit = React.createClass({
                         </div>
                     : null}
                     {group ?
-                        <div className="viewer-titles">
+                        <div className="viewer-titles submit-titles">
                             <h1>Group Information: {group.label}</h1> <a href={editGroupLink} className="btn btn-info">Edit</a>
                         </div>
                     : null}

--- a/src/clincoded/static/components/group_submit.js
+++ b/src/clincoded/static/components/group_submit.js
@@ -121,7 +121,9 @@ var GroupSubmit = module.exports.GroupSubmit = React.createClass({
                         </div>
                     : null}
                     {group ?
-                        <h1>Group Information: {group.label} <a href={editGroupLink} className="btn btn-info">Edit</a></h1>
+                        <div className="viewer-titles">
+                            <h1>Group Information: {group.label}</h1> <a href={editGroupLink} className="btn btn-info">Edit</a>
+                        </div>
                     : null}
                     <div className="row">
                         <div className="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1005,7 +1005,7 @@ var IndividualName = function(displayNote) {
                 <div className="col-sm-7 col-sm-offset-5"><p className="alert alert-warning">If this Individual is part of a Family or a Group, please curate that Group or Family first and then add the Individual as a member.</p></div>
             : null}
             <Input type="text" ref="individualname" label={<LabelIndividualName probandLabel={probandLabel} />} value={individual && individual.label} handleChange={this.handleChange}
-                error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
+                error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')} maxLength="60"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
             <p className="col-sm-7 col-sm-offset-5 input-note-below">Note: Do not enter real names in this field. {curator.renderLabelNote('Individual')}</p>
             {displayNote ?

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -136,7 +136,7 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
                         </div>
                     : null}
                     {individual ?
-                        <div className="viewer-titles">
+                        <div className="viewer-titles submit-titles">
                             <h1>Individual Information: {individual.label}</h1> <a href={editIndividualLink} className="btn btn-info">Edit/Assess</a>
                         </div>
                     : null}

--- a/src/clincoded/static/components/individual_submit.js
+++ b/src/clincoded/static/components/individual_submit.js
@@ -136,7 +136,9 @@ var IndividualSubmit = module.exports.FamilySubmit = React.createClass({
                         </div>
                     : null}
                     {individual ?
-                        <h1>Individual Information: {individual.label} <a href={editIndividualLink} className="btn btn-info">Edit/Assess</a></h1>
+                        <div className="viewer-titles">
+                            <h1>Individual Information: {individual.label}</h1> <a href={editIndividualLink} className="btn btn-info">Edit/Assess</a>
+                        </div>
                     : null}
                     <div className="row">
                         <div className="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -204,6 +204,7 @@ var Input = module.exports.Input = React.createClass({
             React.PropTypes.object
         ]),
         placeholder: React.PropTypes.string, // <input> placeholder text
+        maxLength: React.PropTypes.string, // maxlength for labels
         error: React.PropTypes.string, // Error message to display below input
         labelClassName: React.PropTypes.string, // CSS classes to add to labels
         groupClassName: React.PropTypes.string, // CSS classes to add to control groups (label/input wrapper div)
@@ -330,7 +331,7 @@ var Input = module.exports.Input = React.createClass({
                 inputClasses = 'form-control' + (this.props.error ? ' error' : '') + (this.props.inputClassName ? ' ' + this.props.inputClassName : '');
                 var innerInput = (
                     <span>
-                        <input className={inputClasses} type={inputType} id={this.props.id} name={this.props.id} placeholder={this.props.placeholder} ref="input" value={this.state.value} onChange={this.handleChange.bind(null, this.props.id)} disabled={this.props.inputDisabled} />
+                        <input className={inputClasses} type={inputType} id={this.props.id} name={this.props.id} placeholder={this.props.placeholder} ref="input" value={this.state.value} onChange={this.handleChange.bind(null, this.props.id)} maxLength={this.props.maxLength} disabled={this.props.inputDisabled} />
                         <div className="form-error">{this.props.error ? <span>{this.props.error}</span> : <span>&nbsp;</span>}</div>
                     </span>
                 );

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -395,6 +395,7 @@
 
 .viewer-titles {
     margin-bottom: -40px;
+
     h1 {
         display: inline-block;
         margin-bottom: 10px;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -394,15 +394,13 @@
 }
 
 .viewer-titles {
-    margin-bottom: -40px;
-
     h1 {
         display: inline-block;
         margin-bottom: 10px;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
-        max-width: 90%;
+        max-width: 100%;
     }
 
     h2 {
@@ -410,10 +408,6 @@
         font-size: 1.3rem;
         text-overflow: ellipsis;
         overflow: hidden;
-    }
-
-    a {
-        margin: 0 0 55px 10px;
     }
 
     .pmid-association-header {
@@ -432,6 +426,18 @@
             word-break: break-all;
             word-wrap: break-word;
         }
+    }
+}
+
+.submit-titles {
+    margin-bottom: -40px;
+
+    h1 {
+        max-width: 90%;
+    }
+
+    a {
+        margin: 0 0 55px 10px;
     }
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -394,6 +394,7 @@
 }
 
 .viewer-titles {
+    margin-bottom: -40px;
     h1 {
         display: inline-block;
         margin-bottom: 10px;
@@ -411,10 +412,7 @@
     }
 
     a {
-        margin-top: -10px;
-        @media screen and (min-width: $screen-lg-min) {
-            margin-top: -55px;
-        }
+        margin: 0 0 55px 10px;
     }
 
     .pmid-association-header {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -395,10 +395,12 @@
 
 .viewer-titles {
     h1 {
+        display: inline-block;
         margin-bottom: 10px;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
+        max-width: 90%;
     }
 
     h2 {
@@ -406,6 +408,13 @@
         font-size: 1.3rem;
         text-overflow: ellipsis;
         overflow: hidden;
+    }
+
+    a {
+        margin-top: -10px;
+        @media screen and (min-width: $screen-lg-min) {
+            margin-top: -55px;
+        }
     }
 
     .pmid-association-header {


### PR DESCRIPTION
## Connects to #640:

* Add support for `maxLength` for text fields in `form.js`
* Implement `maxLength` into label fields on curation pages
* Fix/better CSS for long label names on curation, submit, and view pages
* Changes to schema to enforce max label length

Testing:

1. Create GDM, add PMID
2. Add Group, Family, Individual, and Experimental Data objects with various nesting, and verify that the maximum name for these is 60 characters at most
3. Check the edit, submit, and view pages, along with the curation palette, at very window widths, and ensure that the ellipsis and rendering of the rest of the page is correct

#### Group
![image](https://cloud.githubusercontent.com/assets/4326866/14505752/6300fd1e-016f-11e6-9ead-744e0b5567fc.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506186/6cb4e9ae-0171-11e6-835a-62208c54b320.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506211/7b0920a6-0171-11e6-9c07-a0a8698a8de8.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14570481/4f6808ca-02f9-11e6-87d4-e9bd077e8e27.png)

#### Family
![image](https://cloud.githubusercontent.com/assets/4326866/14506229/948bb5fc-0171-11e6-8fb1-86d7fb21d174.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506793/701805e2-0174-11e6-9578-ddcd03bdce71.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506801/7ad4a63e-0174-11e6-9701-610fdeffb21f.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14570487/548edd60-02f9-11e6-9a5a-636899d14738.png)

#### Individual
![image](https://cloud.githubusercontent.com/assets/4326866/14506814/8e2e0324-0174-11e6-95ff-133be6b0dcef.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506821/98c437a4-0174-11e6-9225-d0fbdf4b38ec.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506829/9fd33da6-0174-11e6-8613-f873c0aef2a1.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14570493/596ecd04-02f9-11e6-9774-cccd3ab068b3.png)

#### Experimental
![image](https://cloud.githubusercontent.com/assets/4326866/14506844/aeebf81e-0174-11e6-9591-0e30402b962e.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506852/bb9db390-0174-11e6-9a00-d290cf862f13.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14506856/c2369b40-0174-11e6-9f61-66476cf5cb4f.png)
![image](https://cloud.githubusercontent.com/assets/4326866/14570496/5ea31d5c-02f9-11e6-8553-e133047f9315.png)

## Connects to #646:

* CSS class changes to buttons

Testing:

1. Create GDM, add PMID, create family
2. Re-size resulting submit page to make sure that the buttons scale properly

![image](https://cloud.githubusercontent.com/assets/4326866/14507326/f33ef05a-0176-11e6-8c48-7f85572f76eb.png)