### PR TITLE
Connects to #343 AWS cloud monitoring and package upgrade configs

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -224,6 +224,10 @@ runcmd:
 
 users:
 - default
+- name: build
+  gecos: Build user
+  inactive: true
+  system: true
 - name: clincoded
   gecos: ClinGen Gene Curation Database daemon user
   inactive: true

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -248,6 +248,7 @@ write_files:
         "${distro_id} ${distro_codename}-security";
     };
     Unattended-Upgrade::Automatic-Reboot "true";
+    Unattended-Upgrade::Automatic-Reboot-Time "01:00";
 
 - path: /etc/cron.d/cloudwatchmon
   content: |

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -169,6 +169,10 @@ runcmd:
 - cd /srv/clincoded
 - sudo -u clincoded git clone --no-checkout https://github.com/ClinGen/clincoded.git .
 - sudo -u clincoded git checkout %(COMMIT)s
+- mkdir /opt/cloudwatchmon
+- chown build:build /opt/cloudwatchmon
+- sudo -u build virtualenv --python=python2.7 /opt/cloudwatchmon
+- sudo -u build /opt/cloudwatchmon/bin/pip install -r cloudwatchmon-requirements.txt
 - mkdir /opt/wal-e
 - chown postgres:postgres /opt/wal-e
 - sudo -u postgres virtualenv --python=python2.7 /opt/wal-e
@@ -217,15 +221,6 @@ runcmd:
 - then
 -   sudo -u clincoded bin/batchupgrade production.ini --app-name app
 - fi
-# - sleep 10
-# - sudo -u postgres echo "include 'master.conf'" >> /etc/postgresql/9.4/main/postgresql.conf
-# - pg_ctlcluster 9.4 main reload
-# - pg_ctlcluster 9.4 main promote
-# - sudo -u clincoded bin/update-keys-links production.ini --app-name app
-# - sudo -u clincoded bin/upgrade production.ini --app-name app
-# - sudo -i -u postgres /opt/wal-e/bin/wal-e --aws-profile default --s3-prefix="$(cat /etc/postgresql/9.4/main/wale_s3_prefix | tr -d "\n")" backup-push /var/lib/postgresql/9.4/main
-# - sleep 60
-# - sudo -i -u clincoded PATH="/usr/share/elasticsearch/bin:/usr/lib/postgresql/9.4/bin:$PATH" bin/test -m "not bdd" > tests.out
 
 users:
 - default
@@ -249,6 +244,10 @@ write_files:
         "${distro_id} ${distro_codename}-security";
     };
     Unattended-Upgrade::Automatic-Reboot "true";
+
+- path: /etc/cron.d/cloudwatchmon
+  content: |
+    */5 * * * * nobody /opt/cloudwatchmon/bin/mon-put-instance-stats.py --mem-util --swap-util --disk-space-util --disk-path=/ --from-cron
 
 - path: /etc/default/elasticsearch
   content: |

--- a/cloudwatchmon-requirements.txt
+++ b/cloudwatchmon-requirements.txt
@@ -1,0 +1,4 @@
+argparse==1.2.1
+boto==2.38.0
+cloudwatchmon==2.0.4
+wsgiref==0.1.2


### PR DESCRIPTION
Included in PR:
--Set up AWS sns notifiers for different condition that might need attention (on AWS, not in code changes here). Current topics are: AWS-alert-Memory-usage, AWS-alert-CPU-usage, AWS-alert-Status-Check
--Add cloudwatchmon package to send stats to AWS
--Method for setting alerts from commandline for instances of interest (prod/test)
--Change reboot time to 01:00 for unattended upgrade reboots

To stress test a t2.medium instance that has the alarms set:

`sudo apt-get stress`

CPU OVERLOAD (t2.medium instance):
`stress -c 2 -i 1 -m 1 --vm-bytes 128M -t 600s`

MEMORY OVERLOAD (t2.medium instance):
`stress -m 2 --vm-bytes 3G -t 600s`


Setting alerts from the commandline (should be made into a script using boto in a subsequent ticket):

`aws cloudwatch put-metric-alarm --alarm-name AWS-alert-CPU-usage-80-percent --alarm-description "Alarm when CPU exceeds 80 percent" --metric-name CPUUtilization --namespace AWS/EC2 --statistic Average --period 300 --threshold 80 --comparison-operator GreaterThanThreshold  --dimensions "Name=InstanceId,Value=MY_INSTANCE_ID" --evaluation-periods 2 --alarm-actions MY_ARN_ID --unit Percent`


`aws cloudwatch put-metric-alarm --alarm-name AWS-alert-Memory-usage-80-percent --alarm-description "Alarm when Memory exceeds 80 percent" --metric-name MemoryUtilization --namespace System/Linux --statistic Average --period 60 --threshold 80 --comparison-operator GreaterThanThreshold  --dimensions "Name=InstanceId,Value=MY_INSTANCE_ID" --evaluation-periods 2 --alarm-actions MY_ARN_ID --unit Percent`




`aws cloudwatch put-metric-alarm --alarm-name AWS-alert-Status-Check-Instance --alarm-description "Status Check Failure -- Instance" --metric-name StatusCheckFailed_Instance --namespace AWS/EC2 --statistic Minimum --comparison-operator GreaterThanThreshold --threshold 0 --period 60 --evaluation-periods 2 --dimensions "Name=InstanceId,Value=MY_INSTANCE_ID" --evaluation-periods 2 --alarm-actions MY_ARN_ID`



`aws cloudwatch put-metric-alarm --alarm-name AWS-alert-Status-Check-System --alarm-description "Status Check Failure -- System" --metric-name StatusCheckFailed_System --namespace AWS/EC2 --statistic Average --comparison-operator GreaterThanThreshold --threshold 0 --period 60 --evaluation-periods 2 --dimensions "Name=InstanceId,Value=MY_INSTANCE_ID" --evaluation-periods 2 --alarm-actions MY_ARN_ID`



`aws cloudwatch put-metric-alarm --alarm-name AWS-alert-Status-Check --alarm-description "Status Check Failure" --metric-name StatusCheckFailed --namespace AWS/EC2 --statistic Maximum --comparison-operator GreaterThanThreshold --threshold 0 --period 60 --evaluation-periods 2 --dimensions "Name=InstanceId,Value=MY_INSTANCE_ID" --evaluation-periods 2 --alarm-actions MY_ARN_ID`

--MY_ARN_ID will be the ARN ID is AWS for the topic
--MY_INSTANCE_ID will of course be the instance id which should be monitored