### PR TITLE
Connects to #660. Connects to #640. Variant list refresh and Label limit

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1730,7 +1730,7 @@ var FamilyVariant = function() {
             {this.state.variantCount && !this.state.probandIndividual && this.state.individualRequired ?
                 <div className="variant-panel">
                     <Input type="text" ref="individualname" label="Individual Label"
-                        error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')}
+                        error={this.getFormError('individualname')} clearError={this.clrFormErrors.bind(null, 'individualname')} maxLength="60"
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" required />
                     <p className="col-sm-7 col-sm-offset-5 input-note-below">Note: Do not enter real names in this field. {curator.renderLabelNote('Individual')}</p>
                     {this.state.orpha ?

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -527,9 +527,11 @@ var IndividualCuration = React.createClass({
                             });
                         }
                     } else if (currIndividual && currIndividual.proband && family) {
-                        // Editing a proband in a family. Just pass through existing variants
-                        newVariants = currIndividual.variants.map(function(variant) { return '/variants/' + variant.uuid + '/'; });
-                        Promise.resolve(newVariants);
+                        // Editing a proband in a family. Get updated variants list from the target individual since it is changed from the Family edit page
+                        return this.getRestData('/individuals/' + currIndividual.uuid).then(updatedIndiv => {
+                            newVariants = updatedIndiv.variants.map(function(variant) { return '/variants/' + variant.uuid + '/'; });
+                            return Promise.resolve(newVariants);
+                        });
                     }
 
                     // No variant search strings. Go to next THEN.
@@ -570,6 +572,8 @@ var IndividualCuration = React.createClass({
                                 return Promise.resolve(results);
                             });
                         }
+                    } else if (currIndividual && currIndividual.proband && family) {
+                        individualVariants = newVariants;
                     }
 
                     // No variant search strings. Go to next THEN indicating no new named variants
@@ -731,11 +735,8 @@ var IndividualCuration = React.createClass({
             newIndividual.otherPMIDs = individualArticles['@graph'].map(function(article) { return article['@id']; });
         }
 
-        // Assign the given variant array if we're not editing an individual proband in a family
-        if (!currIndividual || !(currIndividual.proband && family)) {
-            if (individualVariants) {
-                newIndividual.variants = individualVariants;
-            }
+        if (individualVariants) {
+            newIndividual.variants = individualVariants;
         }
 
         // Set the proband boolean


### PR DESCRIPTION
#### Connects to #660:

Editing an Individual now refreshes the Variants list from the Individual before saving.

Testing:

1. Create GDM, add PMID
2. Create Family + Variant + Proband via the Family curation page
3. Open Edit Proband/Individual page in new tab/window
4. Open Edit Family page in another tab/window
5. Make changes to Variant associated w/ Proband in Edit Family page
6. Make changes to Proband/Individual in its Edit page
7. Curation palette should display correct variants for both Family and Individual


#### Connects to #640:

Added label limit length to Individual Label field in the Family page when adding proband

Testing:

1. Create GDM, add PMID
2. Create Family + Variant + Proband, and specify a very long name for the Proband label
3. Confirm that the Proband label length is limited to 60 characters, and you can create a Proband individual w/ a label length of 60 characters