### PR TITLE
Connects to #659. Link text offset in curation palettes.

### DIFF
--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -460,6 +460,7 @@
 
 .title-ellipsis-short {
     max-width: 91%;
+    display: inline;
 
     @media screen and (min-width: $screen-sm-min) {
         max-width: 89%;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -447,6 +447,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     max-width: 100%;
+    vertical-align: bottom;
 
     a {
         border-bottom: 1px dotted #337ab7;
@@ -460,7 +461,6 @@
 
 .title-ellipsis-short {
     max-width: 91%;
-    display: inline;
 
     @media screen and (min-width: $screen-sm-min) {
         max-width: 89%;


### PR DESCRIPTION
This PR is to address the offset (or vertical alignment) of *Associations* link text in curation palettes.

Steps to test #659 
1. On the Curation Central page, create a new PMID.
2. Then proceed with creating a new Group evidence, along with associated Family and Individual evidences, as well as with associated variants.
3. Complete and submit all the forms to return to the Curation Central page.
4. In the curation palettes, expect to see the *Associations* link text are vertically aligned to the baseline of the word **Associations** in the various curation palettes.