### PR TITLE
Connects to #676 kl edit variant schema

### DIFF
--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -20,35 +20,57 @@
         "clinvarVariantId": {
             "title": "Variant ID",
             "description": "ClinVar Variant ID",
-            "type": "string"
+            "type": "string",
+            "default": ""
+        },
+        "carId": {
+            "title": "CAR ID",
+            "description": "Canonical Allele Registration ID from Baylor's Allele Registration",
+            "type": "string",
+            "default": ""
         },
         "clinvarVariantTitle": {
             "title": "ClinVar Variant Title",
             "type": "string",
             "default": ""
         },
-        "dbSNPId": {
-            "title": "dbSNP ID",
-            "description": "dbSNP id of the variant",
-            "type": "string",
-            "default": ""
+        "clinVarRCVs": {
+            "title": "ClinVar RCV Accession",
+            "description": "List of ClinVar RCV ids associated to the variant",
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
         },
-        "clinVarRCV": {
-            "title": "ClinVar ID",
-            "description": "ClinVar id for the variant",
+        "clinVarSCVs": {
+            "title": "ClinVar SCV Accession",
+            "description": "List of ClinVar SCV ids associated to the variant",
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
+        "dbSNPIds": {
+            "title": "dbSNP ID",
+            "description": "List of dbSNP ids related of the variant",
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },        "hgvsGRCh37": {
+            "title": "HGVS GRCh37",
+            "description": "HGVS term referenced with GRCh37",
             "type": "string",
             "default": ""
         },
         "hgvsNames": {
-            "title": "HGVS Names",
-            "description": "List of HGVS names of the variant",
-            "type": "array",
-            "default": [],
-            "items": {
-                "title": "HGVS Name",
-                "type": "string",
-                "default": ""
-            }
+            "title": "Other HGVS Terms",
+            "description": "List of other HGVS terms",
+            "type": "object",
+            "default": {}
         },
         "otherDescription": {
             "title": "Other Description",
@@ -60,6 +82,18 @@
     "columns": {
         "uuid": {
             "title": "Variant",
+            "type": "string"
+        },
+        "clinvarVariantId": {
+            "title": "ClinVar Variation ID",
+            "type": "string"
+        },
+        "clinvarVariantTitle": {
+            "title": "ClinVar Prefered Name",
+            "type": "string"
+        },
+        "carId": {
+            "title": "CAR ID",
             "type": "string"
         },
         "otherDescription": {

--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "2"
+            "default": "3"
         },
         "clinvarVariantId": {
             "title": "Variant ID",
@@ -60,15 +60,10 @@
             "items": {
                 "type": "string"
             }
-        },        "hgvsGRCh37": {
-            "title": "HGVS GRCh37",
-            "description": "HGVS term referenced with GRCh37",
-            "type": "string",
-            "default": ""
         },
         "hgvsNames": {
-            "title": "Other HGVS Terms",
-            "description": "List of other HGVS terms",
+            "title": "HGVS Terms",
+            "description": "Object containing HGVS terms. Separated to GRCh37, GRCh38 and others",
             "type": "object",
             "default": {}
         },

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -13,11 +13,6 @@
                 "NM_000111.2:c.1306C>T",
                 "NG_008046.1:g.25432C>T",
                 "NP_000102.1:p.Gln436Ter"
-            ],
-            "mafs": [
-                {"source": "ExAC", "population": "European", "value": 0.003},
-                {"source": "1000Genomes", "population": "global", "value": 0.007},
-                {"sournce": "ESP", "population": "African", "value": 0.002}
             ]
         },
         "otherDescription": "",

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -1,179 +1,208 @@
 [
     {
         "uuid": "c71fc085-2683-11e5-b9fe-60f81dc5b05a",
-        "dbSNPId": "rs386833448",
+        "dbSNPIds": ["rs386833448"],
         "clinvarVariantId": "55966",
-        "clinVarRCV": "RCV000049375",
+        "clinVarRCVs": ["RCV000049375"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1306C>T (p.Gln436Ter)",
-        "hgvsNames": [
-            "NM_000111.2:c.1306C>T",
-            "NG_008046.1:g.25432C>T",
-            "NC_000007.14:g.107782802G>A",
-            "NC_000007.13:g.107423247G>A",
-            "NP_000102.1:p.Gln436Ter"
-        ],
+        "carId": "CA144043",
+        "hgvsNames": {
+            "grch37": "NC_000007.13:g.107423247G>A",
+            "grch38": "NC_000007.14:g.107782802G>A",
+            "others": [
+                "NM_000111.2:c.1306C>T",
+                "NG_008046.1:g.25432C>T",
+                "NP_000102.1:p.Gln436Ter"
+            ],
+            "mafs": [
+                {"source": "ExAC", "population": "European", "value": 0.003},
+                {"source": "1000Genomes", "population": "global", "value": 0.007},
+                {"sournce": "ESP", "population": "African", "value": 0.002}
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-07-10T22:47:10.000000+00:00"
     },
     {
         "uuid": "3080772e-2685-11e5-ad92-60f81dc5b05a",
-        "dbSNPId": "rs386833446",
+        "dbSNPIds": ["rs386833446"],
         "clinvarVariantId": "55964",
-        "clinVarRCV": "RCV000049373",
+        "clinVarRCVs": ["RCV000049373"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1136G>C (p.Gly379Ala)",
-        "hgvsNames": [
-            "NM_000111.2:c.1136G>C",
-            "NG_008046.1:g.25157G>C",
-            "NC_000007.14:g.107783077C>G",
-            "NC_000007.13:g.107423522C>G",
-            "NP_000102.1:p.Gly379Ala"
-        ],
+        "carId": "CA144040",
+        "hgvsNames": {
+            "gRCh37": "NC_000007.13:g.107423522C>G",
+            "gRCh38": "NC_000007.14:g.107783077C>G",
+            "others": [
+                "NM_000111.2:c.1136G>C",
+                "NG_008046.1:g.25157G>C",
+                "NP_000102.1:p.Gly379Ala"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-07-26T22:47:10.000000+00:00"
     },
     {
         "uuid": "35eedfdc-2685-11e5-b6a0-60f81dc5b05a",
-        "dbSNPId": "rs386833444",
+        "dbSNPIds": ["rs386833444"],
         "clinvarVariantId": "55962",
-        "clinVarRCV": "RCV000049371",
+        "clinVarRCVs": ["RCV000049371"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1028G>A (p.Cys343Tyr)",
-        "hgvsNames": [
-            "NM_000111.2:c.1028G>A",
-            "NG_008046.1:g.24938G>A",
-            "NC_000007.14:g.107783296C>T",
-            "NC_000007.13:g.107423741C>T",
-            "NP_000102.1:p.Cys343Tyr"
-        ],
+        "carId": "CA144035",
+        "hgvsNames": {
+            "gRCh37": "NC_000007.13:g.107423741C>T",
+            "gRCh38": "NC_000007.14:g.107783296C>T",
+            "others": [
+                "NM_000111.2:c.1028G>A",
+                "NG_008046.1:g.24938G>A",
+                "NP_000102.1:p.Cys343Tyr"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-07-23T22:47:10.000000+00:00"
     },
     {
         "uuid": "3b3af7f0-2685-11e5-bc56-60f81dc5b05a",
-        "dbSNPId": "rs387907373",
+        "dbSNPIds": ["rs387907373"],
         "clinvarVariantId": "55874",
-        "clinVarRCV": "RCV000049288",
+        "clinVarRCVs": ["RCV000049288"],
         "clinvarVariantTitle": "NM_000475.4(NR0B1):c.1274G>T (p.Arg425Ile)",
-        "hgvsNames": [
-            "NM_000475.4:c.1274G>T",
-            "NG_009814.1:g.9661G>T",
-            "NC_000023.11:g.30304718C>A",
-            "NC_000023.10:g.30322835C>A",
-            "NP_000466.2:p.Arg425Ile"
-        ],
+        "carId": "CA263240",
+        "hgvsNames": {
+            "gRCh37": "NC_000023.10:g.30322835C>A",
+            "gRCh38": "NC_000023.11:g.30304718C>A",
+            "others": [
+                "NM_000475.4:c.1274G>T",
+                "NG_009814.1:g.9661G>T",
+                "NP_000466.2:p.Arg425Ile"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-07-28T22:47:10.000000+00:00"
     },
     {
         "uuid": "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a",
-        "dbSNPId": "rs147674680",
+        "dbSNPIds": ["rs147674680"],
         "clinvarVariantId": "55847",
-        "clinVarRCV": "RCV000049262",
-        "hgvsNames": [
-            "NM_032682.5:c.1702C>T",
-            "NG_028243.1:g.618234C>T",
-            "NC_000003.12:g.70970756G>A",
-            "NC_000003.11:g.71019907G>A",
-            "NP_116071.2:p.Pro568Ser"
-        ],
+        "clinVarRCVs": ["RCV000049262"],
+        "hgvsNames": {
+            "gRCh37": "NC_000003.12:g.70970756G>A",
+            "gRCh38": "NC_000003.11:g.71019907G>A",
+            "others": [
+                "NM_032682.5:c.1702C>T",
+                "NG_028243.1:g.618234C>T",
+                "NP_116071.2:p.Pro568Ser"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "04442cec-6ab7-40d0-af26-1e5fefd535eb",
         "date_created": "2015-08-01T22:47:10.000000+00:00"
     },
     {
         "uuid": "e496545c-2685-11e5-a4b3-60f81dc5b05a",
-        "dbSNPId": "rs76262710",
+        "dbSNPIds": ["rs76262710"],
         "clinvarVariantId": "38601",
-        "clinVarRCV": "RCV000032040",
+        "clinVarRCVs": ["RCV000032040"],
         "clinvarVariantTitle": "NM_020975.4(RET):c.1852T>A (p.Cys618Ser)",
-        "hgvsNames": [
-            "NM_020975.4:c.1852T>A",
-            "NM_020630.4:c.1852T>A",
-            "NG_007489.1:g.41580T>A",
-            "NC_000010.11:g.43113648T>A",
-            "NC_000010.10:g.43609096T>A",
-            "NP_066124.1:p.Cys618Ser",
-            "NP_065681.1:p.Cys618Ser"
-        ],
+        "hgvsNames": {
+            "gRCh37": "NC_000010.10:g.43609096T>A",
+            "gRCh38": "NC_000010.11:g.43113648T>A",
+            "others": [
+                "NM_020975.4:c.1852T>A",
+                "NM_020630.4:c.1852T>A",
+                "NG_007489.1:g.41580T>A",
+                "NP_066124.1:p.Cys618Ser",
+                "NP_065681.1:p.Cys618Ser"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-01-14T22:47:10.000000+00:00"
     },
     {
         "uuid": "df8135d4-2685-11e5-af19-60f81dc5b05a",
-        "dbSNPId": "rs2298771",
+        "dbSNPIds": ["rs2298771"],
         "clinvarVariantId": "36753",
-        "clinVarRCV": "RCV000030432",
+        "clinVarRCVs": ["RCV000030432"],
         "clinvarVariantTitle": "NM_006920.4(SCN1A):c.3166G>A (p.Ala1056Thr)",
-        "hgvsNames": [
-            "LRG_8t1:c.3166G>A",
-            "NM_001165964.1:c.3115G>A",
-            "NM_006920.4:c.3166G>A",
-            "NM_001165963.1:c.3199G>A",
-            "LRG_8:g.42362G>A",
-            "NG_011906.1:g.42362G>A",
-            "NC_000002.12:g.166036278C>T",
-            "NC_000002.11:g.166892788C>T",
-            "p.A1067T:GCA>ACA",
-            "LRG_8p1:p.Ala1056Thr",
-            "NP_001159436.1:p.Ala1039Thr",
-            "NP_008851.3:p.Ala1056Thr",
-            "NP_001159435.1:p.Ala1067Thr"
-        ],
+        "hgvsNames": {
+            "gRCh37": "NC_000002.11:g.166892788C>T",
+            "gRCh38": "NC_000002.12:g.166036278C>T",
+            "others": [
+                "LRG_8t1:c.3166G>A",
+                "NM_001165964.1:c.3115G>A",
+                "NM_006920.4:c.3166G>A",
+                "NM_001165963.1:c.3199G>A",
+                "LRG_8:g.42362G>A",
+                "NG_011906.1:g.42362G>A",
+                "p.A1067T:GCA>ACA",
+                "LRG_8p1:p.Ala1056Thr",
+                "NP_001159436.1:p.Ala1039Thr",
+                "NP_008851.3:p.Ala1056Thr",
+                "NP_001159435.1:p.Ala1067Thr"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-06-14T22:47:10.000000+00:00"
     },
     {
         "uuid": "d9717187-2685-11e5-9eac-60f81dc5b05a",
-        "dbSNPId": "rs193922686",
+        "dbSNPIds": ["rs193922686"],
         "clinvarVariantId": "36485",
-        "clinVarRCV": "RCV000030157",
+        "clinVarRCVs": ["RCV000030157"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.677T>C (p.Ile226Thr)",
-        "hgvsNames": [
+        "hgvsNames": {
+            "gRCh37": "NC_000018.9:g.58038906A>G",
+            "gRCh38": "NC_000018.10:g.60371673A>G",
+            "others": [
             "NM_005912.2:c.677T>C",
             "NG_016441.1:g.6096T>C",
-            "NC_000018.10:g.60371673A>G",
-            "NC_000018.9:g.58038906A>G",
             "NP_005903.2:p.Ile226Thr"
-        ],
+        ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-03-14T22:47:10.000000+00:00"
     },
     {
         "uuid": "d439f000-2685-11e5-9792-60f81dc5b05a",
-        "dbSNPId": "rs138281308",
+        "dbSNPIds": ["rs138281308"],
         "clinvarVariantId": "36484",
-        "clinVarRCV": "RCV000030156",
+        "clinVarRCVs": ["RCV000030156"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.606C>A (p.Phe202Leu)",
-        "hgvsNames": [
+        "hgvsNames": {
+            "gRCh37": "NC_000018.9:g.58038977G>T",
+            "gRCh38": "NC_000018.10:g.60371744G>T",
+            "others": [
             "NM_005912.2:c.606C>A",
             "NG_016441.1:g.6025C>A",
-            "NC_000018.10:g.60371744G>T",
-            "NC_000018.9:g.58038977G>T",
             "NP_005903.2:p.Phe202Leu"
-        ],
+        ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-04-14T22:47:10.000000+00:00"
     },
     {
         "uuid": "95d62ca5-d344-4c0f-8509-488b2e043969",
-        "dbSNPId": "386833478",
+        "dbSNPIds": ["rs386833478"],
         "clinvarVariantId": "55996",
-        "clinVarRCV": "RCV000049405",
+        "clinVarRCVs": ["RCV000049405"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.344delT (p.Ile115Thrfs)",
-        "hgvsNames": [
-            "NM_000111.2:c.344delT",
-            "NG_008046.1:g.16366delT",
-            "NC_000007.14:g.107791868delA",
-            "NC_000007.13:g.107432313delA",
-            "NP_000102.1:p.Ile115Thrfs"
-        ],
+        "hgvsNames": {
+            "gRCh37": "NC_000007.13:g.107432313delA",
+            "gRCh38": "NC_000007.14:g.107791868delA",
+            "others": [
+                "NM_000111.2:c.344delT",
+                "NG_008046.1:g.16366delT",
+                "NP_000102.1:p.Ile115Thrfs"
+            ]
+        },
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-09-21T22:47:10.000000+00:00",
@@ -181,10 +210,10 @@
     },
     {
         "uuid": "ad310ea9-e215-498c-a001-a6c216105e4c",
-        "dbSNPId": "",
-        "clinVarRCV": "",
+        "dbSNPIds": [],
+        "clinVarRCVs": [],
         "clinvarVariantTitle": "",
-        "hgvsNames": [],
+        "hgvsNames": {},
         "otherDescription": "hgvs",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-10-21T22:47:10.000000+00:00",
@@ -193,10 +222,10 @@
     {
         "uuid": "30f092b3-e87c-4d85-aa3f-10479644953c",
         "clinvarVariantId": "9492",
-        "dbSNPId": "",
-        "clinVarRCV": "RCV000010100",
+        "dbSNPIds": [],
+        "clinVarRCVs": ["RCV000010100"],
         "clinvarVariantTitle": "NM_005502.3(ABCA1):c.1584_1597delTGAGAGGAAGTTCTinsCGGGCGTGGTGGCAGGAGCTGTAATCCCAGCTACTTGGGAGGCTGAGGCACGAGAATCACTTGAACTCAGGAGGCAGAGGTTGCAGTGAGCTGAGGTCACGCCACTGTAC (p.Glu529_Gly867delinsGlyArgGlyGlyArgSerCysAsnProSerTyrLeuGlyGlyTer)",
-        "hgvsNames": [],
+        "hgvsNames": {},
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2015-10-21T22:47:10.000000+00:00",
@@ -205,10 +234,10 @@
     {
         "uuid": "e7c5ff6e-bc3a-4474-a07c-8538efe124e2",
         "clinvarVariantId": "90973",
-        "dbSNPId": "",
-        "clinVarRCV": "RCV000076475",
+        "dbSNPIds": [],
+        "clinVarRCVs": ["RCV000076475"],
         "clinvarVariantTitle": "NM_000251.2(MSH2):c.243_273del31insCTGACAAGCGCCTATAGCACTCGAATAATTCTTCTCACCCTAACAGGTCAGCCTCGCTTCCCAGCCCTCACTAACATTAACGAAAACAACCCACCCACTAAACCCCATTAAACGCCTAACAATCGGAAGCCTATTTTGCAGGGTTTCTCCATCACCAACAGCATTCTCCCCACATCCACCCCCCAAATGACAATCCCACTTTACTTAAAACTCACAG (p.Lys82_Glu425delinsTer)",
-        "hgvsNames": [],
+        "hgvsNames": {},
         "otherDescription": "",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2016-02-02T22:47:10.000000+00:00",

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -87,19 +87,17 @@ def variant_2_3(value, system):
     if 'dbSNPId' in value:
         value['dbSNPIds'] = [value['dbSNPId']]
         value.pop('dbSNPId', None)
-
-    if 'dbSNPIds' not in value:
+    elif 'dbSNPIds' not in value:
         value['dbSNPIds'] = []
 
     if 'clinVarRCV' in value:
         value['clinVarRCVs'] = [value['clinVarRCV']]
         value.pop('clinVarRCV', None)
-
-    if 'clinVarRCVs' not in value:
+    elif 'clinVarRCVs' not in value:
         value['clinVarRCVs'] = []
 
     if 'clinVarSCVs' not in value:
-        value['clinVarRCVs'] = []
+        value['clinVarSCVs'] = []
 
     if 'hgvsNames' in value and value['hgvsNames'] == []:
         value['hgvsNames'] = {}

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -81,4 +81,26 @@ def variant_1_2(value, system):
 
 @upgrade_step('variant', '2', '3')
 def variant_2_3(value, system):
-    pass
+    if 'carId' not in value:
+        value['carId'] = ''
+
+    if 'dbSNPId' in value:
+        value['dbSNPIds'] = [value['dbSNPId']]
+        value.pop('dbSNPId', None)
+
+    if 'dbSNPIds' not in value:
+        value['dbSNPIds'] = []
+
+    if 'clinVarRCV' in value:
+        value['clinVarRCVs'] = [value['clinVarRCV']]
+        value.pop('clinVarRCV', None)
+
+    if 'clinVarRCVs' not in value:
+        value['clinVarRCVs'] = []
+
+    if 'clinVarSCVs' not in value:
+        value['clinVarRCVs'] = []
+
+    if 'hgvsNames' in value and value['hgvsNames'] == []:
+        value['clinVarRCVs'] = {}
+

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -78,3 +78,7 @@ def variant_1_2(value, system):
 
         else:
             value['clinvarVariantTitle'] = ''
+
+@upgrade_step('variant', '2', '3')
+def variant_2_3(value, system):
+    pass

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -102,5 +102,5 @@ def variant_2_3(value, system):
         value['clinVarRCVs'] = []
 
     if 'hgvsNames' in value and value['hgvsNames'] == []:
-        value['clinVarRCVs'] = {}
+        value['hgvsNames'] = {}
 

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -86,15 +86,21 @@ def variant_2_3(value, system):
         value['carId'] = ''
 
     if 'dbSNPId' in value:
-        value['dbSNPIds'] = [value['dbSNPId']]
+        if value['dbSNPId'] != '':
+            value['dbSNPIds'] = [value['dbSNPId']]
+        else:
+            value['dbSNPIds'] = []
         value.pop('dbSNPId', None)
-    elif 'dbSNPIds' not in value:
+    if 'dbSNPIds' not in value and 'dbSNPId' not in value:
         value['dbSNPIds'] = []
 
     if 'clinVarRCV' in value:
-        value['clinVarRCVs'] = [value['clinVarRCV']]
+        if value['clinVarRCV'] != '':
+            value['clinVarRCVs'] = [value['clinVarRCV']]
+        else:
+            value['clinVarRCVs'] = []
         value.pop('clinVarRCV', None)
-    elif 'clinVarRCVs' not in value:
+    if 'clinVarRCVs' not in value and 'clinVarRCV' not in value:
         value['clinVarRCVs'] = []
 
     if 'clinVarSCVs' not in value:

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -81,6 +81,7 @@ def variant_1_2(value, system):
 
 @upgrade_step('variant', '2', '3')
 def variant_2_3(value, system):
+    # Related to ticket #676 (https://github.com/ClinGen/clincoded/issues/676#issuecomment-218564765)
     if 'carId' not in value:
         value['carId'] = ''
 


### PR DESCRIPTION
Change in schema:
1. Added a new property "carId" to store CAR id.
2. Changed type of "dbSNPId" and "clinvarRCV" to array for storing multiple values.
3. Changed type of "hgvsNames" to object for storing terms of RGCh37, RGCh38 and others separately.
4. Added a new property "clinvarSCVs" for storing ClinVar SCV ids in feature.

Change in test data:
1. Added CAR ids in variant 55962, 55964, 55966 and 55996.
2. HGVS terms were reformed as: {"gRCh37": "....", "gRCh38": "....", "others": ["...", "..."]}

View sample:
go to ../variants and select 55962, 55964, 55966 or 55996

Test instance with production data: https://676-kl-edit-variant-schema-ca40197-kangliu.demo.clinicalgenome.org