### PR TITLE
Connects to #685. HGVS term wrapping

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1928,7 +1928,7 @@ var variantHgvsRender = module.exports.variantHgvsRender = function(hgvsNames) {
             {hgvsNames.others && hgvsNames.others.length > 0 ?
             <span>
                 {hgvsNames.others.map(function(hgvs, i) {
-                    return <span key={hgvs} className="title-ellipsis title-ellipsis-short dotted" title={hgvs}>{hgvs}<br /></span>;
+                    return <span><span key={hgvs} className="title-ellipsis title-ellipsis-shorter dotted" title={hgvs}>{hgvs}</span><br /></span>;
                 })}
             </span>
             : null}

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1920,15 +1920,15 @@ var variantHgvsRender = module.exports.variantHgvsRender = function(hgvsNames) {
     return (
         <div>
             {hgvsNames.GRCh38 ?
-                <span>{hgvsNames.GRCh38} (GRCh38)<br /></span>
+                <span><span className="title-ellipsis title-ellipsis-shorter dotted" title={hgvsNames.GRCh38}>{hgvsNames.GRCh38}</span> (GRCh38)<br /></span>
             : null}
             {hgvsNames.GRCh37 ?
-                <span>{hgvsNames.GRCh37} (GRCh37)<br /></span>
+                <span><span className="title-ellipsis title-ellipsis-shorter dotted" title={hgvsNames.GRCh37}>{hgvsNames.GRCh37}</span> (GRCh37)<br /></span>
             : null}
             {hgvsNames.others && hgvsNames.others.length > 0 ?
             <span>
                 {hgvsNames.others.map(function(hgvs, i) {
-                    return <span key={hgvs}>{hgvs}<br /></span>;
+                    return <span key={hgvs} className="title-ellipsis title-ellipsis-short dotted" title={hgvs}>{hgvs}<br /></span>;
                 })}
             </span>
             : null}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -467,6 +467,14 @@
     }
 }
 
+.title-ellipsis-shorter {
+    max-width: 80%;
+
+    @media screen and (min-width: $screen-sm-min) {
+        max-width: 77%;
+    }
+}
+
 .dotted {
     border-bottom: 1px dotted #000;
 }


### PR DESCRIPTION
Test with ClinVar IDs 9492 and 90973 (or CA ID CA212917)

Long HGVS terms should ellipsis properly.

![image](https://cloud.githubusercontent.com/assets/4326866/15443709/44a8603a-1e9f-11e6-9627-0436c24039c1.png)
![image](https://cloud.githubusercontent.com/assets/4326866/15443719/61c2205c-1e9f-11e6-8f79-f689eb8dfaa9.png)
