### PR TITLE
Connects to #681. Forwarding from select variant page

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -35,6 +35,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
         labelVisible: React.PropTypes.bool, // specify whether or not the label is visible
         buttonText: React.PropTypes.string, // text for the button
         clearButtonText: React.PropTypes.string, // text for clear button
+        modalButtonText: React.PropTypes.string, // text for submit button in modal
         initialFormValue: React.PropTypes.string, // specify the initial value of the resource, in case of editing (passed to Modal)
         fieldNum: React.PropTypes.string, // specify which field on the main form this should edit (passed to Modal)
         updateParentForm: React.PropTypes.func, // function to call upon pressing the Save button
@@ -76,7 +77,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
             <span className={"inline-button-wrapper button-push" + (this.props.buttonWrapperClass ? " " + this.props.buttonWrapperClass : "")}>
                 <Modal title={this.state.txtModalTitle} className="input-inline" modalClass="modal-default">
                     <a className={"btn btn-default" + (this.props.buttonClass ? " " + this.props.buttonClass : "") + (this.props.disabled ? " disabled" : "")}
-                        modal={<AddResourceIdModal resourceType={this.props.resourceType} initialFormValue={this.props.initialFormValue}
+                        modal={<AddResourceIdModal resourceType={this.props.resourceType} initialFormValue={this.props.initialFormValue} modalButtonText={this.props.modalButtonText}
                         fieldNum={this.props.fieldNum} updateParentForm={this.props.updateParentForm} protocol={this.props.protocol} closeModal={this.closeModal} />}>
                             {this.props.buttonText}
                     </a>
@@ -127,6 +128,7 @@ var AddResourceIdModal = React.createClass({
     propTypes: {
         resourceType: React.PropTypes.string, // specify what the resource you're trying to add is
         initialFormValue: React.PropTypes.string, // specify the initial value of the resource, in case of editing
+        modalButtonText: React.PropTypes.string, // text for submit button in modal
         fieldNum: React.PropTypes.string, // specify which field on the main form this should edit
         closeModal: React.PropTypes.func, // Function to call to close the modal
         protocol: React.PropTypes.string, // Protocol to use to access PubMed ('http:' or 'https:')
@@ -273,7 +275,7 @@ var AddResourceIdModal = React.createClass({
                 <div className='modal-footer'>
                     <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
                     <Input type="button-button" inputClassName={this.getFormError('resourceId') === null || this.getFormError('resourceId') === undefined || this.getFormError('resourceId') === '' ?
-                        "btn-primary btn-inline-spacer" : "btn-primary btn-inline-spacer disabled"} title="Save" clickHandler={this.submitResource} inputDisabled={!this.state.resourceFetched} submitBusy={this.state.submitResourceBusy} />
+                        "btn-primary btn-inline-spacer" : "btn-primary btn-inline-spacer disabled"} title={this.props.modalButtonText ? this.props.modalButtonText : "Save"} clickHandler={this.submitResource} inputDisabled={!this.state.resourceFetched} submitBusy={this.state.submitResourceBusy} />
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -170,7 +170,7 @@ var AddResourceIdModal = React.createClass({
                     txtInputLabel: tempTxtLabel,
                     txtInputButton: clinvarTxt('inputButton'),
                     txtHelpText: clinvarTxt('helpText'),
-                    txtResourceResponse: clinvarTxt('resourceResponse')
+                    txtResourceResponse: clinvarTxt('resourceResponse', this.props.modalButtonText ? this.props.modalButtonText : "Save")
                 });
                 break;
             case 'car':
@@ -185,7 +185,7 @@ var AddResourceIdModal = React.createClass({
                     txtInputLabel: tempTxtLabel,
                     txtInputButton: carTxt('inputButton'),
                     txtHelpText: carTxt('helpText'),
-                    txtResourceResponse: carTxt('resourceResponse')
+                    txtResourceResponse: carTxt('resourceResponse', this.props.modalButtonText ? this.props.modalButtonText : "Save")
                 });
                 break;
         }
@@ -294,9 +294,12 @@ The ___SubmitResource() functions hold the primary logic for submitting the pars
 */
 
 // Logic and helper functions for resource type 'clinvar' for AddResource modal
-function clinvarTxt(field) {
+function clinvarTxt(field, extra) {
     // Text to use for the resource type of 'clinvar'
     var txt;
+    if (!extra) {
+        extra = '';
+    }
     switch(field) {
         case 'modalTitle':
             txt = 'ClinVar Variant';
@@ -314,7 +317,7 @@ function clinvarTxt(field) {
             txt = <span>You must enter a ClinVar VariationID. The VariationID can be found in the light blue box on a variant page (example: <a href={external_url_map['ClinVarSearch'] + '139214'} target="_blank">139214</a>).</span>;
             break;
         case 'resourceResponse':
-            txt = "Below are the data from ClinVar for the VariationID you submitted. Press \"Save\" below if it is the correct Variant, otherwise revise your search above:";
+            txt = "Below are the data from ClinVar for the VariationID you submitted. Press \"" + extra + "\" below if it is the correct Variant, otherwise revise your search above:";
             break;
     }
     return txt;
@@ -419,9 +422,12 @@ function clinvarSubmitResource() {
 }
 
 // Logic and helper functions for resource type 'car' for AddResource modal
-function carTxt(field) {
+function carTxt(field, extra) {
     // Text to use for the resource type of 'car'
     var txt;
+    if (!extra) {
+        extra = '';
+    }
     switch(field) {
         case 'modalTitle':
             txt = 'ClinGen Allele Registry';
@@ -439,7 +445,7 @@ function carTxt(field) {
             txt = <span>You must enter a ClinGen Allele Registry ID (CA ID). This CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele-test'] + '139214.html'} target="_blank">CA139214</a>).</span>;
             break;
         case 'resourceResponse':
-            txt = "Below are the data from the ClinGen Allele Registry for the CA ID you submitted. Press \"Save\" below if it is the correct Variant, otherwise revise your search above:";
+            txt = "Below are the data from the ClinGen Allele Registry for the CA ID you submitted. Press \"" + extra + "\" below if it is the correct Variant, otherwise revise your search above:";
             break;
     }
     return txt;

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -39,29 +39,10 @@ var SelectVariant = React.createClass({
         };
     },
 
-    // When the form is submitted, we should already have the relevant variant saved in our db,
-    // and its uuid. Forward the user to the variant curation hub on click.
-    submitForm: function(e) {
-        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-        if (this.state.variantData && this.state.variantData.uuid) {
-            this.context.navigate('/variant-central/?variant=' + this.state.variantData.uuid);
-        }
-    },
-
     // Update the variantData upon interaction with the Add Resource modal
     updateVariantData: function(data) {
-        var newVariantInfo = _.clone(this.state.variantInfo);
-        var currVariantOption = this.state.variantOption;
-        var addVariantDisabled;
-        if (data) {
-            this.setState({variantLoaded: true, variantData: data});
-        }
-    },
-
-    // If the user clicks the Cancel Variant Selection button, reset the page
-    cancelVariantSelection: function() {
-        this.setState({variantLoaded: false, variantIdType: 'select'});
-        this.setState({variantData: null});
+        this.setState({submitResourceBusy: false});
+        this.context.navigate('/variant-central/?variant=' + data.uuid);
     },
 
     // Handle change of the select Variant Type dropdown
@@ -77,7 +58,7 @@ var SelectVariant = React.createClass({
                 <h1>{this.props.context.title}</h1>
                 <div className="col-md-8 col-md-offset-2 col-sm-9 col-sm-offset-1 form-variant-select">
                     <Panel panelClassName="panel-select-variant">
-                        <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
+                        <Form formClassName="form-horizontal form-std">
                             {!this.state.variantLoaded ?
                             <div>
                                 <div className="row">
@@ -108,23 +89,6 @@ var SelectVariant = React.createClass({
                                 </div>
                             </div>
                             : null}
-                            {this.state.variantData && this.state.variantData.clinvarVariantId ?
-                            <div className="row">
-                                <h4 className="clinvar-preferred-title">{this.state.variantData.clinvarVariantTitle}</h4>
-                                <div className="row">
-                                    <span className="col-sm-5 col-md-4 control-label"><label>ClinVar Variation ID</label></span>
-                                    <span className="col-sm-7 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantData.clinvarVariantId} target="_blank">{this.state.variantData.clinvarVariantId}</a></span>
-                                </div>
-                            </div>
-                            : null}
-                            {this.state.variantData && this.state.variantData.carId ?
-                            <div className="row">
-                                <div className="row">
-                                    <span className="col-sm-5 col-md-4 control-label"><label>CA ID</label></span>
-                                    <span className="col-sm-7 col-md-8 text-no-input"><a href={external_url_map['CARallele-test'] + this.state.variantData.carId + '.html'} target="_blank">{this.state.variantData.carId}</a></span>
-                                </div>
-                            </div>
-                            : null}
                             {this.state.variantIdType == "ClinVar Variation ID" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper"
@@ -136,21 +100,7 @@ var SelectVariant = React.createClass({
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper"
                                     buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
-                                    clearButtonText="Cancel Variant Selection" updateParentForm={this.updateVariantData} buttonOnly={true} clearButtonRender={false} />
-                            </div>
-                            : null}
-                            {this.state.variantData && this.state.variantData.hgvsNames && Object.keys(this.state.variantData.hgvsNames).length > 0 ?
-                            <div className="row">
-                                <span className="col-sm-5 col-md-4 control-label"><label>HGVS terms</label></span>
-                                <span className="col-sm-7 col-md-8 text-no-input">
-                                    {variantHgvsRender(this.state.variantData.hgvsNames)}
-                                </span>
-                            </div>
-                            : null}
-                            {this.state.variantData ?
-                            <div className="row submit-buttons-wrapper">
-                                <Input type="submit" inputClassName="btn-primary btn-inline-spacer pull-right" id="submit" title="View Variant" inputDisabled={!this.state.variantLoaded} />
-                                <Input type="button" inputClassName="btn-default btn-inline-spacer pull-right" title="Cancel Variant Selection" clickHandler={this.cancelVariantSelection} />
+                                    clearButtonText="Cancel Variant Selection" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                         </Form>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -93,14 +93,14 @@ var SelectVariant = React.createClass({
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper"
                                     buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
-                                    clearButtonText="Cancel Variant Selection" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    modalButtonText="View Variant" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                             {this.state.variantIdType == "ClinGen Allele Registry ID" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper"
                                     buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
-                                    clearButtonText="Cancel Variant Selection" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    modalButtonText="View Variant" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                         </Form>


### PR DESCRIPTION
New variant modal 'Save' button on select variant page:

![image](https://cloud.githubusercontent.com/assets/4326866/15444317/074b7f56-1ea4-11e6-89e2-2e3727b4c5f4.png)

Pressing the 'View Variant' button here should create the variant object then take you to `/variant-central/?variant=[UUID]` (page not yet implemented)

Removed a lot of code from `select_variant.js` page involving rendering of returned variant data from modal.