### PR TITLE
Connects to #694 ignore compiled and versioned css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,7 @@ parts/
 *.pyc
 production.ini
 session-secret.b64
-src/clincoded/static/css/bootstrap.css
-src/clincoded/static/css/responsive.css
-src/clincoded/static/css/style.css
+src/clincoded/static/css/
 src/clincoded/static/scss/_variables.original.scss
 src/clincoded/static/build/
 src/clincoded/tests/js/build/


### PR DESCRIPTION
To prevent inadvertent additions of compiled and versioned css files `.gitignore` was modified.

Changed: 
`src/clincoded/static/css/bootstrap.css`
`src/clincoded/static/css/responsive.css`
`src/clincoded/static/css/style.css`

To:
`src/clincoded/static/css/`


To test:
From commandline: 
 - run `bin/buildout -c buildout-dev.cfg`  or `bin/buildout` as usual
 - use `git status` command

Result:
 -  You should no longer show the compiled css directory `src/clincoded/static/css/` in the git `Untracked files` list


 
