### PR TITLE
Connects to #672. VCI Basic Information Tab UI.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -21,7 +21,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
     getInitialState: function() {
         return {
-            clinvar_id: null, // ClinVar JSON response from NCBI
+            clinvar_id: null, // ClinVar ID
+            car_id: null, // ClinGen Allele Registry ID
+            dbSNP_id: null,
             nucleotide_change: [],
             molecular_consequence: [],
             protein_change: [],
@@ -52,6 +54,11 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (variant) {
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
             this.setState({
+                clinvar_id: clinVarId,
+                car_id: variant.carId,
+                dbSNP_id: variant.dbSNPIds[0],
+                hgvs_GRCh37: variant.hgvsNames.gRCh37,
+                hgvs_GRCh37: variant.hgvsNames.gRCh37,
                 hgvs_GRCh37: variant.hgvsNames.gRCh37,
                 hgvs_GRCh38: variant.hgvsNames.gRCh38,
             });
@@ -179,6 +186,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     render: function() {
+        var clinvar_id = this.state.clinvar_id;
+        var car_id = this.state.car_id;
+        var dbSNP_id = this.state.dbSNP_id;
         var nucleotide_change = this.state.nucleotide_change;
         var molecular_consequence = this.state.molecular_consequence;
         var protein_change = this.state.protein_change;
@@ -193,15 +203,25 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
         return (
             <div className="variant-interpretation basic-info">
-                {(GRCh37 || GRCh38) ?
-                    <div className="bs-callout bs-callout-info">
+                <div className="bs-callout bs-callout-info clearfix">
+                    <div className="bs-callout-content-container">
+                        <h4>IDs</h4>
+                        <ul>
+                            {(clinvar_id) ? <li><span>ClinVar Variation ID: {clinvar_id}</span></li> : null}
+                            {(car_id) ? <li><span>ClinGen Allele ID: {car_id}</span></li> : null}
+                            {(dbSNP_id) ? <li><span>dbSNP ID: {dbSNP_id}</span></li> : null}
+                        </ul>
+                    </div>
+                    {(GRCh37 || GRCh38) ?
+                    <div className="bs-callout-content-container">
                         <h4>Genomic</h4>
                         <ul>
                             {(GRCh38) ? <li><span>{GRCh38 + ' (GRCh38)'}</span></li> : null}
                             {(GRCh37) ? <li><span>{GRCh37 + ' (GRCh37)'}</span></li> : null}
                         </ul>
                     </div>
-                : null}
+                    : null}
+                </div>
 
                 <div className="panel panel-info">
                     <div className="panel-heading"><h3 className="panel-title">Primary Transcript</h3></div>
@@ -260,7 +280,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="panel-body">
                         <dl className="inline-dl clearfix">
                             <dd>Variation Viewer [<a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh38')} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> - <a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh37')} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a>]</dd>
-                            <dd><a href={'http://uswest.ensembl.org/Homo_sapiens/Gene/Summary?g=' + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>Ensembl Browser</a></dd>
+                            <dd>Ensembl Browser [<a href={'http://uswest.ensembl.org/Homo_sapiens/Gene/Summary?g=' + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>GRCh38</a>]</dd>
                             <dd>UCSC [<a href={this.ucscViewerURL(sequence_location, 'hg38', 'GRCh38')} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> - <a href={this.ucscViewerURL(sequence_location, 'hg19', 'GRCh37')} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a>]</dd>
                             <dd><a href={'http://www.uniprot.org/uniprot/' + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd>
                         </dl>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -4,8 +4,9 @@ var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
-var parseString = require('xml2js').parseString;
+var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
 var LocalStorageMixin = require('react-localstorage');
+var SO_terms = require('./mapping/SO_term.json');
 
 var external_url_map = globals.external_url_map;
 
@@ -21,9 +22,16 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     getInitialState: function() {
         return {
             clinvar_id: null, // ClinVar JSON response from NCBI
-            dbSNP_id: null,
-            variant_type: null,
+            nucleotide_change: [],
+            molecular_consequence: [],
+            protein_change: [],
+            ensembl_transcripts: [],
+            sequence_location: [],
+            primary_transcript: {},
+            hgvs_GRCh37: null,
+            hgvs_GRCh38: null,
             gene_symbol: null,
+            uniprot_id: null,
             shouldFetchData: false
         };
     },
@@ -31,88 +39,249 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     componentWillReceiveProps: function(nextProps) {
         this.setState({shouldFetchData: nextProps.shouldFetchData});
         if (this.state.shouldFetchData === true) {
-            this.fetchData();
+            this.fetchRefseqData();
+            this.fetchEnsemblData();
         }
     },
 
-    // Retrieve the variant data from NCBI
-    fetchData: function() {
+    // Retrieve the variant data from NCBI REST API
+    fetchRefseqData: function() {
+        //var refseq_data = {};
         var variant = this.props.data;
+        var url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=';
         if (variant) {
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
-            this.getRestData('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=clinvar&retmode=json&id=' + clinVarId).then(response => {
-                var clinvar_data = response.result[clinVarId];
+            this.setState({
+                hgvs_GRCh37: variant.hgvsNames.gRCh37,
+                hgvs_GRCh38: variant.hgvsNames.gRCh38,
+            });
+            this.getRestDataXml(url + clinVarId).then(xml => {
+                // Passing 'true' option to invoke 'mixin' function
+                // To extract more ClinVar data for 'basic info' tab
+                var d = parseClinvar(xml, true);
                 this.setState({
-                    clinvar_id: clinvar_data.uid,
-                    dbSNP_id: clinvar_data.variation_set[0].variation_xrefs[0].db_id,
-                    variant_type: clinvar_data.variation_set[0].variant_type,
-                    gene_symbol: clinvar_data.genes[0].symbol
+                    nucleotide_change: d.RefSeqTranscripts.NucleotideChangeList,
+                    protein_change: d.RefSeqTranscripts.ProteinChangeList,
+                    molecular_consequence: d.RefSeqTranscripts.MolecularConsequenceList,
+                    sequence_location: d.allele.SequenceLocation,
+                    gene_symbol: d.gene.symbol
                 });
+                this.getUniprotId(this.state.gene_symbol);
+                this.getPrimaryTranscript(d.clinvarVariantTitle, this.state.nucleotide_change, this.state.protein_change, this.state.molecular_consequence);
             }).catch(function(e) {
-                console.log('GETGDM ERROR=: %o', e);
+                console.log('RefSeq Fetch Error=: %o', e);
             });
         }
     },
 
-    // Alternative method to retrieve the xml data from NCBI
-    fetchXMLData: function(id) {
-        var xmlData;
-        if (id) {
-            this.getRestDataXml('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=' + id).then(response => {
-                parseString(response, function (err, result) {
-                    xmlData = JSON.stringify(result);
-                });
+    // Create primary transcript object
+    // Called in the "fetchRefseqData" method after various states are set
+    getPrimaryTranscript: function(str, nucleotide_change, protein_change, molecular_consequence) {
+        var transcript = {};
+        var SO_id_term = '';
+        for (var i=0; i<nucleotide_change.length; i++) {
+            // Match AccessionVersion within clinvarVariantTitle string
+            if (str.indexOf(nucleotide_change[i].AccessionVersion) > -1) {
+                // Find associated SO_id and SO_term. Concatenate them.
+                if (typeof molecular_consequence !== 'undefined' && molecular_consequence.length) {
+                    for (var x=0; x<molecular_consequence.length; x++) {
+                        if (molecular_consequence[x].HGVS === nucleotide_change[i].HGVS) {
+                            // 'SO_terms' is defined via requiring external mapping file
+                            for (var y=0; y<SO_terms.length; y++) {
+                                if (molecular_consequence[x].SOid === SO_terms[y].SO_id) {
+                                    SO_id_term = SO_terms[y].SO_id + ' ' + SO_terms[y].SO_term;
+                                }
+                            }
+                        }
+                    }
+                }
+                // FIXME: temporarily use protein_change[0] due to lack of mapping
+                // associated with nucleotide_change[i] in ClinVar data
+                transcript = {
+                    "nucleotide": nucleotide_change[i].HGVS,
+                    "protein": protein_change[0].HGVS,
+                    "molecular": SO_id_term
+                };
+            }
+        }
+        this.setState({primary_transcript: transcript});
+    },
+
+    // Retrieve variant data from Ensembl REST API
+    fetchEnsemblData: function() {
+        var variant = this.props.data;
+        if (variant) {
+            var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0] : 'Unknown';
+            this.getRestData('http://rest.ensembl.org/vep/human/id/' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
+                this.setState({ensembl_transcripts: response[0].transcript_consequences});
             }).catch(function(e) {
-                console.log('GETGDM ERROR=: %o', e);
+                console.log('Ensembl Fetch Error=: %o', e);
             });
         }
-        return xmlData;
+    },
+
+    // Use Ensembl consequence_terms to find matching SO_id and SO_term pair
+    // Then concatenate all pairs into string
+    handleSOTerms: function(array) {
+        var newArray = [],
+            newObj,
+            newStr = '';
+        for (var x=0; x<array.length; x++) {
+            // 'SO_terms' is defined via requiring external mapping file
+            for (var y=0; y<SO_terms.length; y++) {
+                if (array[x] === SO_terms[y].SO_term) {
+                    newObj = SO_terms[y].SO_id + ' ' + SO_terms[y].SO_term;
+                }
+            }
+            newArray.push(newObj);
+        }
+        for (var i=0; i<newArray.length; i++) {
+            if (i === 0) {
+                newStr += newArray[i];
+            }
+            if (i > 0) {
+                newStr += ', ' + newArray[i];
+            }
+        }
+        return newStr;
+    },
+
+    // Find gene_id from Ensembl REST API response
+    // Used to construct LinkOut URL to Ensembl Browser
+    getGeneId: function(array) {
+        var gene_id = '';
+        if (array.length && array[0].gene_id) {
+            gene_id = array[0].gene_id;
+        }
+        return gene_id;
+    },
+
+    // Find Uniprot id given the gene_symbol from ClinVar
+    // Called in the "fetchRefseqData" method after gene_symbol state is set
+    // Used to construct LinkOut URL to Uniprot
+    getUniprotId: function(gene_symbol) {
+        if (gene_symbol) {
+            this.getRestData('http://rest.genenames.org/fetch/symbol/' + gene_symbol).then(result => {
+                this.setState({uniprot_id: result.response.docs[0].uniprot_ids[0]});
+            }).catch(function(e) {
+                console.log('HGNC Fetch Error=: %o', e);
+            });
+        }
+    },
+
+    // Construct LinkOut URLs to UCSC Viewer
+    // For both GRCh38/hg38 and GRCh37/hg19
+    ucscViewerURL: function(array, db, assembly) {
+        var url = '';
+        for (var x=0; x<array.length; x++) {
+            if (array[x].Assembly === assembly) {
+                url = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=' + db + '&position=Chr' + array[x].Chr + '%3A' + array[x].start + '-' + array[x].stop;
+            }
+        }
+        return url;
+    },
+
+    // Construct LinkOut URLs to NCBI Variation Viewer
+    // For both GRCh38 and GRCh37
+    variationViewerURL: function(array, gene_symbol, assembly) {
+        var url = '';
+        for (var x=0; x<array.length; x++) {
+            if (array[x].Assembly === assembly) {
+                url = 'http://www.ncbi.nlm.nih.gov/variation/view/?chr=' + array[x].Chr + '&q=' + gene_symbol + '&assm=' + array[x].AssemblyAccessionVersion + '&from=' + array[x].start + '&to=' + array[x].stop;
+            }
+        }
+        return url;
     },
 
     render: function() {
-        var clinvar_id = this.state.clinvar_id;
-        var dbSNP_id = this.state.dbSNP_id;
-        var variant_type = this.state.variant_type;
+        var nucleotide_change = this.state.nucleotide_change;
+        var molecular_consequence = this.state.molecular_consequence;
+        var protein_change = this.state.protein_change;
+        var ensembl_data = this.state.ensembl_transcripts;
+        var sequence_location = this.state.sequence_location;
         var gene_symbol = this.state.gene_symbol;
+        var uniprot_id = this.state.uniprot_id;
+        var GRCh37 = this.state.hgvs_GRCh37;
+        var GRCh38 = this.state.hgvs_GRCh38;
+        var primary_transcript = this.state.primary_transcript;
+        var self = this;
 
         return (
             <div className="variant-interpretation basic-info">
-                <ul className="clearfix">
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Variant IDs</div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div><span>ClinVar Variantion ID: {clinvar_id}</span></div>
-                        <div><span>dbSNP ID: rs{dbSNP_id}</span></div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Other description</div>
-                    </li>
-                </ul>
+                {(GRCh37 || GRCh38) ?
+                    <div className="bs-callout bs-callout-info">
+                        <h4>Genomic</h4>
+                        <ul>
+                            {(GRCh38) ? <li><span>{GRCh38 + ' (GRCh38)'}</span></li> : null}
+                            {(GRCh37) ? <li><span>{GRCh37 + ' (GRCh37)'}</span></li> : null}
+                        </ul>
+                    </div>
+                : null}
 
-                <ul className="clearfix">
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Variant Type</div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div><span>{variant_type}</span></div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Other description</div>
-                    </li>
-                </ul>
+                <div className="panel panel-info">
+                    <div className="panel-heading"><h3 className="panel-title">Primary Transcript</h3></div>
+                    <table className="table">
+                        <thead>
+                            <tr>
+                                <th>Nucleotide Change</th>
+                                <th>Protein Change</th>
+                                <th>Molecular Consequence</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    {(primary_transcript) ? primary_transcript.nucleotide : '--'}
+                                </td>
+                                <td>
+                                    {(primary_transcript) ? primary_transcript.protein : '--'}
+                                </td>
+                                <td>
+                                    {(primary_transcript) ? primary_transcript.molecular : '--'}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
 
-                <ul className="clearfix">
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Associated Gene</div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div><span>{gene_symbol}</span></div>
-                    </li>
-                    <li className="col-xs-12 col-sm-4 gutter-exc">
-                        <div>Other description</div>
-                    </li>
-                </ul>
+                <div className="panel panel-info">
+                    <div className="panel-heading"><h3 className="panel-title">All Transcripts</h3></div>
+                    <table className="table">
+                        <thead>
+                            <tr>
+                                <th>Nucleotide Change</th>
+                                <th>Protein Change</th>
+                                <th>Molecular Consequence</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {ensembl_data.map(function(item, i) {
+                                return (
+                                    <tr key={i}>
+                                        <td>{item.hgvsc}</td>
+                                        <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
+                                        <td>
+                                            {(item.consequence_terms) ? self.handleSOTerms(item.consequence_terms) : '--'}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="panel panel-info">
+                    <div className="panel-heading"><h3 className="panel-title">LinkOut to external resources</h3></div>
+                    <div className="panel-body">
+                        <dl className="inline-dl clearfix">
+                            <dd>Variation Viewer [<a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh38')} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> - <a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh37')} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a>]</dd>
+                            <dd><a href={'http://uswest.ensembl.org/Homo_sapiens/Gene/Summary?g=' + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>Ensembl Browser</a></dd>
+                            <dd>UCSC [<a href={this.ucscViewerURL(sequence_location, 'hg38', 'GRCh38')} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> - <a href={this.ucscViewerURL(sequence_location, 'hg19', 'GRCh37')} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a>]</dd>
+                            <dd><a href={'http://www.uniprot.org/uniprot/' + uniprot_id + '#family_and_domains'} target="_blank" title={'Uniprot page for ' + uniprot_id + ' in a new window'}>Uniprot</a></dd>
+                        </dl>
+                    </div>
+                </div>
+
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/SO_term.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/SO_term.json
@@ -1,0 +1,142 @@
+[
+  {
+    "SO_term": "transcript_ablation",
+    "SO_id": "SO:0001893"
+  },
+  {
+    "SO_term": "splice_acceptor_variant",
+    "SO_id": "SO:0001574"
+  },
+  {
+    "SO_term": "splice_donor_variant",
+    "SO_id": "SO:0001575"
+  },
+  {
+    "SO_term": "stop_gained",
+    "SO_id": "SO:0001587"
+  },
+  {
+    "SO_term": "frameshift_variant",
+    "SO_id": "SO:0001589"
+  },
+  {
+    "SO_term": "stop_lost",
+    "SO_id": "SO:0001578"
+  },
+  {
+    "SO_term": "start_lost",
+    "SO_id": "SO:0002012"
+  },
+  {
+    "SO_term": "transcript_amplification",
+    "SO_id": "SO:0001889"
+  },
+  {
+    "SO_term": "inframe_insertion",
+    "SO_id": "SO:0001821"
+  },
+  {
+    "SO_term": "inframe_deletion",
+    "SO_id": "SO:0001822"
+  },
+  {
+    "SO_term": "missense_variant",
+    "SO_id": "SO:0001583"
+  },
+  {
+    "SO_term": "protein_altering_variant",
+    "SO_id": "SO:0001818"
+  },
+  {
+    "SO_term": "splice_region_variant",
+    "SO_id": "SO:0001630"
+  },
+  {
+    "SO_term": "incomplete_terminal_codon_variant",
+    "SO_id": "SO:0001626"
+  },
+  {
+    "SO_term": "stop_retained_variant",
+    "SO_id": "SO:0001567"
+  },
+  {
+    "SO_term": "synonymous_variant",
+    "SO_id": "SO:0001819"
+  },
+  {
+    "SO_term": "coding_sequence_variant",
+    "SO_id": "SO:0001580"
+  },
+  {
+    "SO_term": "mature_miRNA_variant",
+    "SO_id": "SO:0001620"
+  },
+  {
+    "SO_term": "5_prime_UTR_variant",
+    "SO_id": "SO:0001623"
+  },
+  {
+    "SO_term": "3_prime_UTR_variant",
+    "SO_id": "SO:0001624"
+  },
+  {
+    "SO_term": "non_coding_transcript_exon_variant",
+    "SO_id": "SO:0001792"
+  },
+  {
+    "SO_term": "intron_variant",
+    "SO_id": "SO:0001627"
+  },
+  {
+    "SO_term": "NMD_transcript_variant",
+    "SO_id": "SO:0001621"
+  },
+  {
+    "SO_term": "non_coding_transcript_variant",
+    "SO_id": "SO:0001619"
+  },
+  {
+    "SO_term": "upstream_gene_variant",
+    "SO_id": "SO:0001631"
+  },
+  {
+    "SO_term": "downstream_gene_variant",
+    "SO_id": "SO:0001632"
+  },
+  {
+    "SO_term": "TFBS_ablation",
+    "SO_id": "SO:0001892"
+  },
+  {
+    "SO_term": "TFBS_amplification",
+    "SO_id": "SO:0001892"
+  },
+  {
+    "SO_term": "TF_binding_site_variant",
+    "SO_id": "SO:0001782"
+  },
+  {
+    "SO_term": "regulatory_region_ablation",
+    "SO_id": "SO:0001894"
+  },
+  {
+    "SO_term": "regulatory_region_amplification",
+    "SO_id": "SO:0001891"
+  },
+  {
+    "SO_term": "feature_elongation",
+    "SO_id": "SO:0001907"
+  },
+  {
+    "SO_term": "regulatory_region_variant",
+    "SO_id": "SO:0001566"
+  },
+  {
+    "SO_term": "feature_truncation",
+    "SO_id": "SO:0001906"
+  },
+  {
+    "SO_term": "intergenic_variant",
+    "SO_id": "SO:0001628"
+  }
+]

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -65,29 +65,29 @@ function parseClinvarMixin(variant, allele, hgvs_list, dataset) {
     // Parse <MolecularConsequence> nodes
     var MolecularConsequenceList = allele.getElementsByTagName('MolecularConsequenceList')[0];
     var MolecularConsequence = MolecularConsequenceList.getElementsByTagName('MolecularConsequence');
-    for(var n = 0; n < MolecularConsequence.length; n++) {
+    for(let n of MolecularConsequence) {
         var MolecularObj = {
-            "HGVS": MolecularConsequence[n].getAttribute('HGVS'),
-            "SOid": MolecularConsequence[n].getAttribute('SOid'),
-            "Function": MolecularConsequence[n].getAttribute('Function')
+            "HGVS": n.getAttribute('HGVS'),
+            "SOid": n.getAttribute('SOid'),
+            "Function": n.getAttribute('Function')
         };
         variant.RefSeqTranscripts.MolecularConsequenceList.push(MolecularObj);
     }
     // Parse <HGVS> nodes
     var HGVSnodes = hgvs_list.getElementsByTagName('HGVS');
-    for (var x = 0; x < HGVSnodes.length; x++) {
+    for (let x of HGVSnodes) {
         var hgvsObj = {
-            "HGVS": HGVSnodes[x].textContent,
-            "Change": HGVSnodes[x].getAttribute('Change'),
-            "AccessionVersion": HGVSnodes[x].getAttribute('AccessionVersion'),
-            "Type": HGVSnodes[x].getAttribute('Type')
+            "HGVS": x.textContent,
+            "Change": x.getAttribute('Change'),
+            "AccessionVersion": x.getAttribute('AccessionVersion'),
+            "Type": x.getAttribute('Type')
         };
         // nucleotide change
-        if (HGVSnodes[x].getAttribute('Type') === 'HGVS, coding, RefSeq') {
+        if (x.getAttribute('Type') === 'HGVS, coding, RefSeq') {
             variant.RefSeqTranscripts.NucleotideChangeList.push(hgvsObj);
         }
         // protein change
-        if (HGVSnodes[x].getAttribute('Type') === 'HGVS, protein, RefSeq') {
+        if (x.getAttribute('Type') === 'HGVS, protein, RefSeq') {
             variant.RefSeqTranscripts.ProteinChangeList.push(hgvsObj);
         }
     }
@@ -98,15 +98,15 @@ function parseClinvarMixin(variant, allele, hgvs_list, dataset) {
     variant.gene.full_name = geneNode.getAttribute('FullName');
     // Parse <SequenceLocation> nodes
     var SequenceLocationNodes = allele.getElementsByTagName('SequenceLocation');
-    for(var y = 0; y < SequenceLocationNodes.length; y++) {
+    for(let y of SequenceLocationNodes) {
         var SequenceLocationObj = {
-            "Assembly": SequenceLocationNodes[y].getAttribute('Assembly'),
-            "AssemblyAccessionVersion": SequenceLocationNodes[y].getAttribute('AssemblyAccessionVersion'),
-            "AssemblyStatus": SequenceLocationNodes[y].getAttribute('AssemblyStatus'),
-            "Chr": SequenceLocationNodes[y].getAttribute('Chr'),
-            "Accession": SequenceLocationNodes[y].getAttribute('Accession'),
-            "start": SequenceLocationNodes[y].getAttribute('start'),
-            "stop": SequenceLocationNodes[y].getAttribute('stop')
+            "Assembly": y.getAttribute('Assembly'),
+            "AssemblyAccessionVersion": y.getAttribute('AssemblyAccessionVersion'),
+            "AssemblyStatus": y.getAttribute('AssemblyStatus'),
+            "Chr": y.getAttribute('Chr'),
+            "Accession": y.getAttribute('Accession'),
+            "start": y.getAttribute('start'),
+            "stop": y.getAttribute('stop')
         };
         variant.allele.SequenceLocation.push(SequenceLocationObj);
     }

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -76,9 +76,10 @@ function parseClinvarMixin(variant, allele, hgvs_list, dataset) {
     // Parse <HGVS> nodes
     var HGVSnodes = hgvs_list.getElementsByTagName('HGVS');
     for (var x = 0; x < HGVSnodes.length; x++) {
-        var hgvsObj =  {
+        var hgvsObj = {
             "HGVS": HGVSnodes[x].textContent,
             "Change": HGVSnodes[x].getAttribute('Change'),
+            "AccessionVersion": HGVSnodes[x].getAttribute('AccessionVersion'),
             "Type": HGVSnodes[x].getAttribute('Type')
         };
         // nucleotide change

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1164,6 +1164,11 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     h4 {
         color: #1b809e;
     }
+
+    .bs-callout-content-container {
+        float: left;
+        margin-right: 10%;
+    }
 }
 
 .bs-callout+.bs-callout {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1062,6 +1062,11 @@ div.react-tabs .ReactTabs__TabPanel--selected {
                 margin-right: 20px;
             }
         }
+
+        .basic-info .table th,
+        .basic-info .table td {
+            width: 33%;
+        }
     }
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1054,19 +1054,15 @@ div.react-tabs .ReactTabs__TabPanel--selected {
             margin: 0;
             padding: 0;
         }
+
+        dl {
+            margin-bottom: 0;
+
+            dd {
+                margin-right: 20px;
+            }
+        }
     }
-}
-
-.react-tabs .tab-panel .basic-info ul li {
-    padding: 5px 3px;
-}
-
-.react-tabs .tab-panel .basic-info ul:nth-child(odd) {
-    background: #f6f6f6;
-}
-
-.react-tabs .tab-panel .basic-info ul:nth-child(even) {
-    background: #fff;
 }
 
 /* FIXME - temp styles for placeholders */
@@ -1140,4 +1136,35 @@ div.react-tabs .ReactTabs__TabPanel--selected {
             padding: 0;
         }
     }
+}
+
+/* bootstrap callout component styles */
+.bs-callout {
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #eee;
+    border-left-width: 5px;
+    border-radius: 3px;
+    background: #fff;
+
+    h4 {
+        margin-top: 0;
+        margin-bottom: 5px;
+    }
+}
+
+.bs-callout-info {
+    border-left-color: #1b809e;
+
+    h4 {
+        color: #1b809e;
+    }
+}
+
+.bs-callout+.bs-callout {
+    margin-top: -5px;
+}
+
+.panel.panel-info .panel-title {
+    font-weight: bold;
 }


### PR DESCRIPTION
This PR consists of changes pertinent to Issue #672.

**Technical notes:**
1. Added a JSON mapping file (e.g. SO_term.json) consisting of **SO term** and **SO id** pairs. The list of mapping pairs are taken from http://uswest.ensembl.org/info/genome/variation/predicted_data.html#consequence_type_table
2. Created a new "mapping" sub-directory in the anticipation of more mapping files being required, such as NM-to-NC and NM-to-EN.

**Known issues:**
1. The sortable "All Transcripts" table columns have not yet been implemented (as requested in https://github.com/ClinGen/clincoded/issues/672#issuecomment-223381387).
2. The RefSeq transcripts have not been merged into the "All Transcripts" table with the Ensembl transcripts (as requested in https://github.com/ClinGen/clincoded/issues/672#issuecomment-223381387). This is because the logical mapping of NM-to-NC has not yet been figured out.
3. The NC value in the "Protein Change" column in the "Primary Transcript" table is temporarily using the 1st index in the NC array. This also is because the logical mapping of NM-to-NC has not yet been figured out.

**Steps to test this PR:**
1. Login and go to http://localhost:6543/variant-central/?variant=35eedfdc-2685-11e5-b6a0-60f81dc5b05a
2. In the "Basic Information" tab, expect to see data being displayed in both tables. Also clicking on various LinkOut links should result in new windows with the expected destinations.