### PR TITLE
Connects to #704. Connects to #701. Tab info appended to URI. Change modal button name

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -108,6 +108,11 @@ module.exports.addQueryKey = function(href, key, value) {
     return href + '?' + key + '=' + value;
 };
 
+module.exports.queryHashValue = function (href) {
+    var hashParsed = href && url.parse(href, true).hash;
+    return hashParsed.substr(1);
+};
+
 
 module.exports.productionHost = {'curation.clinicalgenome.org':1};
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -108,9 +108,21 @@ module.exports.addQueryKey = function(href, key, value) {
     return href + '?' + key + '=' + value;
 };
 
-module.exports.queryHashValue = function (href) {
+// get the hash in the href. Remove the '#' in the string that the url package returns
+module.exports.queryHashValue = function(href) {
     var hashParsed = href && url.parse(href, true).hash;
-    return hashParsed.substr(1);
+    if (hashParsed) {
+        hashParsed.substr(1);
+    }
+    return hashParsed;
+};
+
+// return the full href, but with the new hash value specified by value. Leave value as
+// null or undefined and the hash will be removed
+module.exports.setHashValue = function(href, value) {
+    var inputHref = href && url.parse(href, true);
+    inputHref.hash = value ? value : null;
+    return url.format(inputHref);
 };
 
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -98,6 +98,21 @@ module.exports.queryKeyValue = function (key, href) {
     return undefined;
 };
 
+// modify key's value from the query string in the url given in 'href'
+// if value is null, undefined, or '', the key is removed from the query string
+module.exports.editQueryValue = function(href, key, value) {
+    var queryParsed = href && url.parse(href, true);
+    delete queryParsed['search'];
+    if (queryParsed.query) {
+        if (value && value != '') {
+            queryParsed.query[key] = value;
+        } else {
+            delete queryParsed.query[key];
+        }
+    }
+    return url.format(queryParsed);
+};
+
 // Add a key-value pair as a query string to the given href. If href already
 // has query string values, this function adds the given key value to it.
 module.exports.addQueryKey = function(href, key, value) {
@@ -106,23 +121,6 @@ module.exports.addQueryKey = function(href, key, value) {
         return href + '&' + key + '=' + value;
     }
     return href + '?' + key + '=' + value;
-};
-
-// get the hash in the href. Remove the '#' in the string that the url package returns
-module.exports.queryHashValue = function(href) {
-    var hashParsed = href && url.parse(href, true).hash;
-    if (hashParsed) {
-        hashParsed.substr(1);
-    }
-    return hashParsed;
-};
-
-// return the full href, but with the new hash value specified by value. Leave value as
-// null or undefined and the hash will be removed
-module.exports.setHashValue = function(href, value) {
-    var inputHref = href && url.parse(href, true);
-    inputHref.hash = value ? value : null;
-    return url.format(inputHref);
 };
 
 

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -93,14 +93,14 @@ var SelectVariant = React.createClass({
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper"
                                     buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
-                                    modalButtonText="View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                             {this.state.variantIdType == "ClinGen Allele Registry ID (CA ID)" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                 <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper"
                                     buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
-                                    modalButtonText="View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                         </Form>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -50,7 +50,7 @@ var VariantCurationHub = React.createClass({
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
                 <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
-                <VariantCurationInterpretation variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} loadingComplete={isLoadingComplete} />
+                <VariantCurationInterpretation variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} href={this.props.href} loadingComplete={isLoadingComplete} />
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -2,6 +2,8 @@
 var React = require('react');
 var globals = require('../globals');
 
+var queryHashValue = globals.queryHashValue;
+
 // Import react-tabs npm to create tabs
 var ReactTabs = require('react-tabs');
 var Tab = ReactTabs.Tab;
@@ -25,11 +27,44 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     propTypes: {
         variantData: React.PropTypes.object, // ClinVar data payload
         interpretationUuid: React.PropTypes.string,
-        loadingComplete: React.PropTypes.bool
+        loadingComplete: React.PropTypes.bool,
+        href: React.PropTypes.string
+    },
+
+    getInitialState: function() {
+        return {
+            selectedTab: (this.props.href ? this.convertTabToNum(queryHashValue(this.props.href)) : 0)
+        };
     },
 
     handleSelect: function (index, last) {
         console.log('Selected tab: ' + index + ', Last tab: ' + last);
+        console.log(queryHashValue(this.props.href));
+    },
+
+    convertTabToNum: function(tab) {
+        var num = 0;
+        switch(tab) {
+            case '#basic-info':
+                num = 0;
+                break;
+            case '#population':
+                num = 1;
+                break;
+            case '#computational':
+                num = 2;
+                break;
+            case '#functional':
+                num = 3;
+                break;
+            case '#segregation-case':
+                num = 4;
+                break;
+            case '#gene-specific':
+                num = 5;
+                break;
+        }
+        return num;
     },
 
     render: function() {
@@ -41,7 +76,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         // Adding or deleting a tab also requires its corresponding TabPanel to be added/deleted
         return (
             <div className="container curation-variant-tab-group">
-                <Tabs onSelect={this.handleSelect} selectedIndex={0}>
+                <Tabs onSelect={this.handleSelect} selectedIndex={this.state.selectedTab}>
                     <TabList className="tab-label-list">
                         <Tab className="tab-label col-sm-2">Basic Information</Tab>
                         <Tab className="tab-label col-sm-2">Population</Tab>

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -2,8 +2,8 @@
 var React = require('react');
 var globals = require('../globals');
 
-var queryHashValue = globals.queryHashValue;
-var setHashValue = globals.setHashValue;
+var queryKeyValue = globals.queryKeyValue;
+var editQueryValue = globals.editQueryValue;
 
 // Import react-tabs npm to create tabs
 var ReactTabs = require('react-tabs');
@@ -45,7 +45,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     getInitialState: function() {
         return {
-            selectedTab: (this.props.href ? tabList.indexOf(queryHashValue(this.props.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
+            selectedTab: (this.props.href ? tabList.indexOf(queryKeyValue('tab', this.props.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
         };
     },
 
@@ -53,9 +53,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     handleSelect: function (index, last) {
         this.setState({selectedTab: index});
         if (index == 0) {
-            window.history.replaceState(window.state, '', setHashValue(this.props.href, null));
+            window.history.replaceState(window.state, '', editQueryValue(this.props.href, 'tab', null));
         } else {
-            window.history.replaceState(window.state, '', setHashValue(this.props.href, tabList[index]));
+            window.history.replaceState(window.state, '', editQueryValue(this.props.href, 'tab', tabList[index]));
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -24,7 +24,7 @@ var CurationInterpretationSegregation = require('./interpretation/segregation').
 var CurationInterpretationGeneSpecific = require('./interpretation/gene_specific').CurationInterpretationGeneSpecific;
 
 // list of tabs, in order of how they appear on the tab list
-// these values will be appended to the URI as you switch tabs
+// these values will be appended to the address as you switch tabs
 var tabList = [
     'basic-info',
     'population',
@@ -45,11 +45,11 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     getInitialState: function() {
         return {
-            selectedTab: (this.props.href ? tabList.indexOf(queryHashValue(this.props.href)) : 0) // set selectedTab to whatever is defined in URI; default to first tab if not set
+            selectedTab: (this.props.href ? tabList.indexOf(queryHashValue(this.props.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
         };
     },
 
-    // set selectedTab to whichever tab the user switches to, and update the URI accordingly
+    // set selectedTab to whichever tab the user switches to, and update the address accordingly
     handleSelect: function (index, last) {
         this.setState({selectedTab: index});
         if (index == 0) {

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -3,6 +3,7 @@ var React = require('react');
 var globals = require('../globals');
 
 var queryHashValue = globals.queryHashValue;
+var setHashValue = globals.setHashValue;
 
 // Import react-tabs npm to create tabs
 var ReactTabs = require('react-tabs');
@@ -22,6 +23,17 @@ var CurationInterpretationFunctional = require('./interpretation/functional').Cu
 var CurationInterpretationSegregation = require('./interpretation/segregation').CurationInterpretationSegregation;
 var CurationInterpretationGeneSpecific = require('./interpretation/gene_specific').CurationInterpretationGeneSpecific;
 
+// list of tabs, in order of how they appear on the tab list
+// these values will be appended to the URI as you switch tabs
+var tabList = [
+    'basic-info',
+    'population',
+    'computational',
+    'functional',
+    'segregation-case',
+    'gene-specific'
+];
+
 // Curation data header for Gene:Disease
 var VariantCurationInterpretation = module.exports.VariantCurationInterpretation = React.createClass({
     propTypes: {
@@ -33,38 +45,18 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     getInitialState: function() {
         return {
-            selectedTab: (this.props.href ? this.convertTabToNum(queryHashValue(this.props.href)) : 0)
+            selectedTab: (this.props.href ? tabList.indexOf(queryHashValue(this.props.href)) : 0) // set selectedTab to whatever is defined in URI; default to first tab if not set
         };
     },
 
+    // set selectedTab to whichever tab the user switches to, and update the URI accordingly
     handleSelect: function (index, last) {
-        console.log('Selected tab: ' + index + ', Last tab: ' + last);
-        console.log(queryHashValue(this.props.href));
-    },
-
-    convertTabToNum: function(tab) {
-        var num = 0;
-        switch(tab) {
-            case '#basic-info':
-                num = 0;
-                break;
-            case '#population':
-                num = 1;
-                break;
-            case '#computational':
-                num = 2;
-                break;
-            case '#functional':
-                num = 3;
-                break;
-            case '#segregation-case':
-                num = 4;
-                break;
-            case '#gene-specific':
-                num = 5;
-                break;
+        this.setState({selectedTab: index});
+        if (index == 0) {
+            window.history.replaceState(window.state, '', setHashValue(this.props.href, null));
+        } else {
+            window.history.replaceState(window.state, '', setHashValue(this.props.href, tabList[index]));
         }
-        return num;
     },
 
     render: function() {


### PR DESCRIPTION
Connects to #704:

* When switching between tabs, the URL should update with the proper `tab` value in the URL query string for the tab you switched to
  * When switching to the basic info tab, the `tab` query should be removed from the URL. But manually navigating the basic info tab by appending `&tab=basic-info` to the URL should still work
* When reloading or navigating directly, if a tab is specified via a the `tab` query in the URL, that particular tab should be loaded

Connects to #701:
* Confirm correct button text:
![image](https://cloud.githubusercontent.com/assets/4326866/15942845/1f1f9e0e-2e3b-11e6-850c-29b917c7123e.png)
