### PR TITLE
Connects to #683. Added lifecycle method to invoke data fetching for Population tab.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -109,6 +109,19 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         };
     },
 
+    componentDidMount: function() {
+        console.log("population component is mounted");
+        if (this.state.shouldFetchData === false) {
+            this.setState({shouldFetchData: true});
+            if (this.state.hasExacData === false) {
+                this.fetchMyVariantInfo();
+            }
+            if (this.state.hasEspData === false) {
+                this.fetchEnsemblData();
+            }
+        }
+    },
+
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretationUuid: nextProps.interpretationUuid});
         this.setState({shouldFetchData: nextProps.shouldFetchData});


### PR DESCRIPTION
This PR is to address the issue in which clicking on the Population tab does not invoke data fetching if the default tab (e.g. selectedIndex={0}) is the Basic Information tab.

**Technical note:**
Since the default tab is normally set to 0 (e.g. selectedIndex={0}), when the page loads, the "Basic Information" tab receives the props and invokes fetching. When clicking on other subsequent tabs, fetching is not invoked because the props had been received.

So as a temp hack for the population tab development, I set to the selectedIndex to 1 for two reasons: 1) it defaults to the population tab every time the page is refreshed (so it saves a click each time during debugging; 2) it fetches data immediately after the page refresh.

By confirming that each time clicking on a tab incurs the “componentDidMount” lifecycle method (in the context of react-tabs). So the **componentDidMount** lifecycle method is added to invoke data fetching on the Population tab (or other tabs potentially going forward) while setting the "Basic Information" tab as the default. It indeed works for both tabs in terms of fetching data.

**Steps to test this PR:**
1. Use "139214" as the variant ID on the variant selection page and then navigate to the "hub" page where the "Basic Information" tab is the default tab.
2. Expect to see data being displayed in the 2 tables on the tab.
3. Click on the "Population" tab and expect to see data being displayed in the 3 tables on the tab.