### PR TITLE
Connects to #653 Dev tooling -- grunt watch for js and css compile, mods to "make" command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,6 +180,34 @@ module.exports = function(grunt) {
                     {expand: true, flatten: true, src: ['src/clincoded/static/build/*.js'], dest: 'src/clincoded/static/build/'}
                 ]
             }
+        },
+        compass: {
+            dist: {
+                options: {
+                    basePath: '/Users/karen/cherry/github/clincoded/parts/rubygems/bin/compass'
+                    // ,
+                    // watch: true
+                }
+            }
+        },
+        watch: {
+            scripts: {
+                files: 'src/clincoded/static/components/**/*.js',
+                tasks: ['browserify', 'filerev', 'replace']
+                // ,
+                // options: {
+                //   interrupt: true,
+                // },
+            },
+            css: {
+                files: 'src/clincoded/static/scss/**/*.scss',
+                tasks: ['compass']
+                // tasks: ['compass', 'filerev', 'replace']
+                // ,
+                // options: {
+                //   livereload: true,
+                // },
+            }
         }
     });
 
@@ -275,9 +303,11 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-filerev');
     grunt.loadNpmTasks('grunt-replace');
+    grunt.loadNpmTasks('grunt-contrib-compass');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 
     grunt.registerTask('default', ['browserify', 'copy', 'filerev', 'replace']);
-    grunt.registerTask('watch', ['browserify:*:watch', 'wait']);
+    //grunt.registerTask('watch', ['browserify:*:watch', 'wait']);
 
 };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -179,41 +179,42 @@ module.exports = function(grunt) {
                 files: [
                     {expand: true, flatten: true, src: ['src/clincoded/static/build/*.js'], dest: 'src/clincoded/static/build/'}
                 ]
+            },
+            dev: {
+                options: {
+                    patterns: [
+                        {
+                            match: 'bundleJsFile',
+                            replacement: "/static/build/bundle.js"
+                        },
+                        {
+                            match: 'cssFile',
+                            replacement: "/static/css/style.css"
+                        }
+                    ]
+                },
+                files: [
+                    {expand: true, flatten: true, src: ['src/clincoded/static/build/*.js'], dest: 'src/clincoded/static/build/'}
+                ]
             }
         },
         compass: {
-            dist: {
-                options: {
-                    basePath: '/Users/karen/cherry/github/clincoded/parts/rubygems/bin/compass'
-                    // ,
-                    // watch: true
-                }
-            }
+            dev: {}
         },
         watch: {
             scripts: {
                 files: 'src/clincoded/static/components/**/*.js',
-                tasks: ['browserify', 'filerev', 'replace']
-                // ,
-                // options: {
-                //   interrupt: true,
-                // },
+                tasks: ['browserify:browser', 'browserify:server', 'replace:dev']
             },
             css: {
                 files: 'src/clincoded/static/scss/**/*.scss',
                 tasks: ['compass']
-                // tasks: ['compass', 'filerev', 'replace']
-                // ,
-                // options: {
-                //   livereload: true,
-                // },
             }
         }
     });
 
-    grunt.registerMultiTask('browserify', function (watch) {
+    grunt.registerMultiTask('browserify', function () {
         var browserify = require('browserify');
-        var watchify = require('watchify');
         var _ = grunt.util._;
         var path = require('path');
         var fs = require('fs');
@@ -222,15 +223,10 @@ module.exports = function(grunt) {
         var options = _.extend({
             debug: true,
             cache: {},
-            packageCache: {},
-            fullPaths: watch
+            packageCache: {}
         }, data.options);
 
         var b = browserify(options);
-        if (watch) {
-            b = watchify(b);
-        }
-
         var i;
         var reqs = [];
         (data.src || []).forEach(function (src) {
@@ -306,8 +302,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-compass');
     grunt.loadNpmTasks('grunt-contrib-watch');
 
-    grunt.registerTask('default', ['browserify', 'copy', 'filerev', 'replace']);
-    //grunt.registerTask('watch', ['browserify:*:watch', 'wait']);
+    grunt.registerTask('default', ['browserify', 'copy', 'filerev', 'replace:dist']);
+    grunt.registerTask('dev', ['browserify','replace:dev', 'watch']);
 
 };
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
+all:
+	rm -rf node_modules eggs parts bin
+	rm -rf .sass-cache
+	rm -rf src/clincoded/static/css
+	rm -rf src/clincoded/static/build/*.js*
+
 clean:
 	rm -rf node_modules eggs parts bin
 	rm -rf .sass-cache
 	rm -rf src/clincoded/static/css
+
+clean-css:
+	rm -rf src/clincoded/static/css/style*.css
+
+clean-js:
+	rm -rf src/clincoded/static/build/*.js*

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "exorcist": "^0.4.0",
     "grunt-contrib-compass": "^1.1.1",
     "grunt-contrib-watch": "^1.0.0",
-    "jest-cli": "^0.9.2",
-    "watchify": "^3.7.0"
+    "jest-cli": "^0.9.2"
   },
   "dependencies": {
     "babel-core": "^6.7.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "devDependencies": {
     "exorcist": "^0.4.0",
+    "grunt-contrib-compass": "^1.1.1",
+    "grunt-contrib-watch": "^1.0.0",
     "jest-cli": "^0.9.2",
     "watchify": "^3.7.0"
   },


### PR DESCRIPTION
## Dev tooling enhancements

- `bin/grunt dev` - watch for js and scss changes and browserify bundle minimal js files or compass compile  
- `make clean-css` - clean all compiled style.css and versioned style files
- `make clean-js`  - remove all previous browserify compiled js files and versioned bundle files



Added npm packages:
 - grunt-contrib-compass
 - grunt-contrib-watch


Removed npm package:
 - watchify


**TO USE:**
 - Run `bin/buildout -c buildout-dev.cfg` at least once to get the additional npm packages if you don't run it regularly
 - Run `bin/grunt dev` to watch js and css changes. This will also remove the dependency on versioned files (i.e. you must run this command *at least one time* to set the js bundle to point to an unversioned style.css even if you want to use `bin/compass compile` separately)

## Other Tips
**Browser auto-refresh**
 - If you use a Chrome plugin like [ChromeReloadPlus](https://chrome.google.com/webstore/detail/chromereloadplus/nbbpjdmdkcmpimmhloehkojhbhjlboog) you can set a browser tab in focus to to refresh at some time interval that you set (example 15 sec)


**Shortcut: Open localhost in a new window in Chrome (bash on Macs)**
- Add to your `.bash_profile`:
 - `alias ocl='open -a "Google Chrome" --new --args --new-window http://localhost:6543'`
- run: `source ~/.bash_profile`
- type: `ocl` at commandline  (hint: open chrome localhost)



## Notes

**NOTE** js bundle re-gen currently takes ~50 seconds. It is unknown (to me) if the `watch` task can listen to and queue events while it is working on a task (i.e. can it "hear" and queue a rebuild for js changes while a browserify task is already going? [prob not, but not tested here])

**NOTE2** for `bin/grunt dev` to work you should have compass installed as a ruby gem, i.e. `compass` at the commandline should work for you. (There is a local version of compass in the project [`bin/compass` which is really a bash executable file that point to the local ruby and ruby gems], but it doesn't seem to work with the plugin properly



