### PR TITLE
Connects to #726. Use globals for external URLs; support http/https protocol switching

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -349,7 +349,7 @@ function clinvarQueryResource() {
     // for pinging and parsing data from ClinVar
     this.saveFormValue('resourceId', this.state.inputValue);
     if (clinvarValidateForm.call(this)) {
-        var url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=';
+        var url = this.props.protocol + external_url_map['ClinVarEutils'];
         var data;
         var id = this.state.inputValue;
         this.getRestDataXml(url + id).then(xml => {
@@ -472,14 +472,14 @@ function carQueryResource() {
     this.saveFormValue('resourceId', this.state.inputValue);
     var error_msg;
     if (carValidateForm.call(this)) {
-        var url = 'http://reg.genome.network/allele/';
+        var url = this.props.protocol + external_url_map['CARallele'];
         var data;
         var id = this.state.inputValue;
         this.getRestData(url + id).then(json => {
             data = parseCAR(json);
             if (data.clinvarVariantId) {
                 // if the CAR result has a ClinVar variant ID, query ClinVar with it, and use its data
-                url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=';
+                url = this.props.protocol + external_url_map['ClinVarEutils'];
                 this.getRestDataXml(url + data.clinvarVariantId).then(xml => {
                     var data_cv = parseClinvar(xml);
                     if (data_cv.clinvarVariantId) {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2195,7 +2195,7 @@ var ExperimentalDataVariant = function() {
                                 error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                             <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]}
-                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" }
+                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                 updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                             <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC || this.cv.othersAssessed}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1719,7 +1719,7 @@ var FamilyVariant = function() {
                             error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                             labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                         <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]}
-                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" }
+                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                             updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -164,6 +164,7 @@ module.exports.external_url_map = {
     'OMIM': 'http://omim.org/',
     'ClinVar': 'http://www.ncbi.nlm.nih.gov/clinvar/',
     'ClinVarSearch': 'http://www.ncbi.nlm.nih.gov/clinvar/variation/',
+    'ClinVarEutils': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=',
     'HPO': 'http://compbio.charite.de/hpoweb/showterm?id=',
     'HPOBrowser': 'http://compbio.charite.de/hpoweb/showterm?id=HP:0000118',
     'Uberon': 'http://uberon.github.io/',
@@ -175,7 +176,7 @@ module.exports.external_url_map = {
     'EFO': 'http://www.ebi.ac.uk/efo/',
     'dbSNP': 'http://www.ncbi.nlm.nih.gov/snp/',
     'CAR': 'http://reg.genome.network/site/cg-registry',
-    'CARallele': 'http://reg.genome.network/allele/',
+    'CARallele': '//reg.genome.network/allele/',
     'CAR-test': 'http://reg.test.genome.network/site/registry',
     'CARallele-test': 'http://reg.test.genome.network/allele/'
 };

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -182,7 +182,10 @@ module.exports.external_url_map = {
     'CARallele-test': '//reg.test.genome.network/allele/',
     'EnsemblVEP': '//rest.ensembl.org/vep/human/id/',
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
-    'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/'
+    'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
+    'MyVariantInfo': '//myvariant.info/v1/variant/',
+    'EXAC': '//exac.broadinstitute.org/variant/',
+    'ESP_EVS': '//evs.gs.washington.edu/EVS/PopStatsServlet?'
 };
 
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -132,6 +132,7 @@ module.exports.clincodedVersionMap = {
 
 module.exports.dbxref_prefix_map = {
     "UniProtKB": "http://www.uniprot.org/uniprot/",
+    "ESP_EVS": "http://evs.gs.washington.edu/EVS/PopStatsServlet?",
     "HGNC": "http://www.genecards.org/cgi-bin/carddisp.pl?gene=",
     // ENSEMBL link only works for human
     "ENSEMBL": "http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=",
@@ -184,8 +185,7 @@ module.exports.external_url_map = {
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',
-    'EXAC': '//exac.broadinstitute.org/variant/',
-    'ESP_EVS': '//evs.gs.washington.edu/EVS/PopStatsServlet?'
+    'EXAC': '//exac.broadinstitute.org/variant/'
 };
 
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -159,6 +159,7 @@ module.exports.external_url_map = {
     'OrphaNet': 'http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=',
     'OrphanetHome': 'http://www.orpha.net/',
     'HGNC': 'http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=',
+    'HGNCFetch': '//rest.genenames.org/fetch/symbol/',
     'HGNCHome': 'http://www.genenames.org/',
     'Entrez': 'http://www.ncbi.nlm.nih.gov/gene/',
     'OMIM': 'http://omim.org/',
@@ -178,7 +179,10 @@ module.exports.external_url_map = {
     'CAR': 'http://reg.genome.network/site/cg-registry',
     'CARallele': '//reg.genome.network/allele/',
     'CAR-test': 'http://reg.test.genome.network/site/registry',
-    'CARallele-test': 'http://reg.test.genome.network/allele/'
+    'CARallele-test': '//reg.test.genome.network/allele/',
+    'EnsemblVEP': '//rest.ensembl.org/vep/human/id/',
+    'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
+    'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/'
 };
 
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1347,7 +1347,7 @@ var IndividualVariantInfo = function() {
                                     error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]}
-                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" }
+                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                     updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -91,14 +91,14 @@ var SelectVariant = React.createClass({
                             : null}
                             {this.state.variantIdType == "ClinVar Variation ID" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper"
+                                <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
                                     buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
                                     modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                             {this.state.variantIdType == "ClinGen Allele Registry ID (CA ID)" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper"
+                                <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
                                     buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
                                     modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -50,7 +50,8 @@ var VariantCurationHub = React.createClass({
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
                 <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
-                <VariantCurationInterpretation variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} href={this.props.href} loadingComplete={isLoadingComplete} />
+                <VariantCurationInterpretation variantData={variantData} interpretationUuid={interpretationUuid} editKey={editKey} session={session}
+                    loadingComplete={isLoadingComplete} href_url={this.props.href_url} />
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -40,12 +40,12 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         variantData: React.PropTypes.object, // ClinVar data payload
         interpretationUuid: React.PropTypes.string,
         loadingComplete: React.PropTypes.bool,
-        href: React.PropTypes.string
+        href_url: React.PropTypes.object
     },
 
     getInitialState: function() {
         return {
-            selectedTab: (this.props.href ? tabList.indexOf(queryKeyValue('tab', this.props.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
+            selectedTab: (this.props.href_url.href ? tabList.indexOf(queryKeyValue('tab', this.props.href_url.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
         };
     },
 
@@ -53,9 +53,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     handleSelect: function (index, last) {
         this.setState({selectedTab: index});
         if (index == 0) {
-            window.history.replaceState(window.state, '', editQueryValue(this.props.href, 'tab', null));
+            window.history.replaceState(window.state, '', editQueryValue(this.props.href_url.href, 'tab', null));
         } else {
-            window.history.replaceState(window.state, '', editQueryValue(this.props.href, 'tab', tabList[index]));
+            window.history.replaceState(window.state, '', editQueryValue(this.props.href_url.href, 'tab', tabList[index]));
         }
     },
 
@@ -78,22 +78,38 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <Tab className="tab-label col-sm-2">Gene-specific</Tab>
                     </TabList>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationBasicInfo data={variant} shouldFetchData={loadingComplete} /></div>
+                        <div className="tab-panel"><CurationInterpretationBasicInfo data={variant} shouldFetchData={loadingComplete}
+                            protocol={this.props.href_url.protocol} /></div>
                     </TabPanel>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationPopulation data={variant} shouldFetchData={loadingComplete} interpretationUuid={interpretationUuid} /></div>
+                        <div className="tab-panel">
+                            <CurationInterpretationPopulation data={variant} shouldFetchData={loadingComplete}
+                            interpretationUuid={interpretationUuid} protocol={this.props.href_url.protocol} />
+                        </div>
                     </TabPanel>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationComputational data={variant} shouldFetchData={loadingComplete} interpretationUuid={interpretationUuid} /></div>
+                        <div className="tab-panel">
+                            <CurationInterpretationComputational data={variant} shouldFetchData={loadingComplete}
+                            interpretationUuid={interpretationUuid} protocol={this.props.href_url.protocol} />
+                        </div>
                     </TabPanel>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationFunctional data={variant} shouldFetchData={loadingComplete} interpretationUuid={interpretationUuid} /></div>
+                        <div className="tab-panel">
+                            <CurationInterpretationFunctional data={variant} shouldFetchData={loadingComplete}
+                            interpretationUuid={interpretationUuid} protocol={this.props.href_url.protocol} />
+                        </div>
                     </TabPanel>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationSegregation data={variant} shouldFetchData={loadingComplete} interpretationUuid={interpretationUuid} /></div>
+                        <div className="tab-panel">
+                            <CurationInterpretationSegregation data={variant} shouldFetchData={loadingComplete}
+                            interpretationUuid={interpretationUuid} protocol={this.props.href_url.protocol} />
+                        </div>
                     </TabPanel>
                     <TabPanel>
-                        <div className="tab-panel"><CurationInterpretationGeneSpecific data={variant} shouldFetchData={loadingComplete} interpretationUuid={interpretationUuid} /></div>
+                        <div className="tab-panel">
+                            <CurationInterpretationGeneSpecific data={variant} shouldFetchData={loadingComplete}
+                            interpretationUuid={interpretationUuid} protocol={this.props.href_url.protocol} />
+                        </div>
                     </TabPanel>
                 </Tabs>
             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -9,6 +9,7 @@ var LocalStorageMixin = require('react-localstorage');
 var SO_terms = require('./mapping/SO_term.json');
 
 var external_url_map = globals.external_url_map;
+var dbxref_prefix_map = globals.dbxref_prefix_map;
 
 // Display the curator data of the curation data
 var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasicInfo = React.createClass({
@@ -118,7 +119,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
             var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
-            this.getRestData('http://rest.ensembl.org/vep/human/id/rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
                 this.setState({ensembl_transcripts: response[0].transcript_consequences});
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);
@@ -165,7 +166,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     // Used to construct LinkOut URL to Uniprot
     getUniprotId: function(gene_symbol) {
         if (gene_symbol) {
-            this.getRestData('http://rest.genenames.org/fetch/symbol/' + gene_symbol).then(result => {
+            this.getRestData(this.props.protocol + external_url_map['HGNCFetch'] + gene_symbol).then(result => {
                 this.setState({uniprot_id: result.response.docs[0].uniprot_ids[0]});
             }).catch(function(e) {
                 console.log('HGNC Fetch Error=: %o', e);
@@ -179,7 +180,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var url = '';
         array.forEach(SequenceLocationObj => {
             if (SequenceLocationObj.Assembly === assembly) {
-                url = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=' + db + '&position=Chr' + SequenceLocationObj.Chr + '%3A' + SequenceLocationObj.start + '-' + SequenceLocationObj.stop;
+                url = this.props.protocol + external_url_map['UCSCGenomeBrowser'] + '?db=' + db + '&position=Chr' + SequenceLocationObj.Chr + '%3A' + SequenceLocationObj.start + '-' + SequenceLocationObj.stop;
             }
         });
         return url;
@@ -191,7 +192,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var url = '';
         array.forEach(SequenceLocationObj => {
             if (SequenceLocationObj.Assembly === assembly) {
-                url = 'http://www.ncbi.nlm.nih.gov/variation/view/?chr=' + SequenceLocationObj.Chr + '&q=' + gene_symbol + '&assm=' + SequenceLocationObj.AssemblyAccessionVersion + '&from=' + SequenceLocationObj.start + '&to=' + SequenceLocationObj.stop;
+                url = this.props.protocol + external_url_map['NCBIVariationViewer'] + '?chr=' + SequenceLocationObj.Chr + '&q=' + gene_symbol + '&assm=' + SequenceLocationObj.AssemblyAccessionVersion + '&from=' + SequenceLocationObj.start + '&to=' + SequenceLocationObj.stop;
             }
         });
         return url;
@@ -292,9 +293,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="panel-body">
                         <dl className="inline-dl clearfix">
                             <dd>Variation Viewer [<a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh38')} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> - <a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh37')} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a>]</dd>
-                            <dd>Ensembl Browser [<a href={'http://uswest.ensembl.org/Homo_sapiens/Gene/Summary?g=' + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>GRCh38</a>]</dd>
+                            <dd>Ensembl Browser [<a href={dbxref_prefix_map['ENSEMBL'] + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>GRCh38</a>]</dd>
                             <dd>UCSC [<a href={this.ucscViewerURL(sequence_location, 'hg38', 'GRCh38')} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> - <a href={this.ucscViewerURL(sequence_location, 'hg19', 'GRCh37')} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a>]</dd>
-                            <dd><a href={'http://www.uniprot.org/uniprot/' + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd>
+                            <dd><a href={dbxref_prefix_map['UniProtKB'] + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd>
                         </dl>
                     </div>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -16,7 +16,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
-        shouldFetchData: React.PropTypes.bool
+        shouldFetchData: React.PropTypes.bool,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -51,7 +52,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     fetchRefseqData: function() {
         //var refseq_data = {};
         var variant = this.props.data;
-        var url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=';
+        var url = this.props.protocol + external_url_map['ClinVarEutils'];
         if (variant) {
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
             // Extract genomic substring from HGVS name whose assembly is GRCh37 or GRCh38

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -63,6 +63,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     }
 });
 
+// FIXME: all functions below here are examples; references to these in above render() should also be removed
 var comp_crit_1 = function() {
     return (
         <div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -10,7 +10,8 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     mixins: [RestMixin],
 
     propTypes: {
-        data: React.PropTypes.object
+        data: React.PropTypes.object,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -10,7 +10,8 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
     mixins: [RestMixin],
 
     propTypes: {
-        data: React.PropTypes.object
+        data: React.PropTypes.object,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -10,7 +10,8 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
     mixins: [RestMixin],
 
     propTypes: {
-        data: React.PropTypes.object
+        data: React.PropTypes.object,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -137,7 +137,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     // Retrieve ExAC population data from myvariant.info
     fetchMyVariantInfo: function() {
         var variant = this.props.data;
-        var url = 'http://myvariant.info/v1/variant/';
+        var url = this.props.protocol + external_url_map['MyVariantInfo'];
         if (variant) {
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
@@ -150,7 +150,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             var found = genomic_chr_mapping.find((entry) => entry.GenomicRefSeq === NC_genomic);
             // Format variant_id for use of myvariant.info REST API
             var variant_id = found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':'));
-            this.getRestData('http://rest.ensembl.org/vep/human/id/rs' + rsid + '?content-type=application/json').then(exac_allele_frequency => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(exac_allele_frequency => {
                 // Calling method to update global object with ExAC Allele Frequency data
                 this.assignAlleleFrequencyData(exac_allele_frequency);
             }).catch(function(e) {
@@ -234,7 +234,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
             var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
-            this.getRestData('http://rest.ensembl.org/variation/human/rs' + rsid + '?content-type=application/json;pops=1;population_genotypes=1').then(response => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json;pops=1;population_genotypes=1').then(response => {
                 this.setState({
                     ensembl_variation_data: response,
                     ensembl_populations: response.populations,
@@ -246,7 +246,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Get ExAC allele frequency as a fallback strategy
             // In the event where myvariant.info doesn't return ExAC allele frequency info
             // FIXME: Need to remove this when switching to using the global population object for table UI
-            this.getRestData('http://rest.ensembl.org/vep/human/id/rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
                 this.setState({ensembl_exac_allele: response[0].colocated_variants[0]});
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);
@@ -379,7 +379,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                 {(this.state.hasExacData) ?
                     <div className="panel panel-info datasource-ExAC">
-                        <div className="panel-heading"><h3 className="panel-title">ExAC {exac.chrom + ':' + exac.pos + ' ' + exac.ref + '/' + exac.alt}<a href={'http://exac.broadinstitute.org/variant/' + exac.chrom + '-' + exac.pos + '-' + exac.ref + '-' + exac.alt} target="_blank">(See ExAC data)</a></h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">ExAC {exac.chrom + ':' + exac.pos + ' ' + exac.ref + '/' + exac.alt}<a href={this.props.protocol + external_url_map['EXAC'] + exac.chrom + '-' + exac.pos + '-' + exac.ref + '-' + exac.alt} target="_blank">(See ExAC data)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -458,7 +458,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found. Please see <a href={'http://exac.broadinstitute.org/variant/' + exac.chrom + '-' + exac.pos + '-' + exac.ref + '-' + exac.alt} target="_blank">variant data</a> at ExAC.</th>
+                                    <th>Variant information could not be found. Please see <a href={this.props.protocol + external_url_map['EXAC'] + exac.chrom + '-' + exac.pos + '-' + exac.ref + '-' + exac.alt} target="_blank">variant data</a> at ExAC.</th>
                                 </tr>
                             </thead>
                         </table>
@@ -561,7 +561,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                 {(this.state.hasEspData) ?
                     <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp.rsid + '; ' + esp.chrom + '.' + esp.hg19_start + '; Alleles ' + esp.ref + '>' + esp.alt}<a href={'http://evs.gs.washington.edu/EVS/PopStatsServlet?searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">(See ESP data)</a></h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp.rsid + '; ' + esp.chrom + '.' + esp.hg19_start + '; Alleles ' + esp.ref + '>' + esp.alt}<a href={this.props.protocol + external_url_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">(See ESP data)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -610,7 +610,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found. Please see <a href={'http://evs.gs.washington.edu/EVS/PopStatsServlet?searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.</th>
+                                    <th>Variant information could not be found. Please see <a href={this.props.protocol + external_url_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.</th>
                                 </tr>
                             </thead>
                         </table>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -85,7 +85,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
         interpretationUuid: React.PropTypes.string,
-        shouldFetchData: React.PropTypes.bool
+        shouldFetchData: React.PropTypes.bool,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -375,7 +376,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </li>
                 </ul>
                 : null}
-                
+
                 {(this.state.hasExacData) ?
                     <div className="panel panel-info datasource-ExAC">
                         <div className="panel-heading"><h3 className="panel-title">ExAC {exac.chrom + ':' + exac.pos + ' ' + exac.ref + '/' + exac.alt}<a href={'http://exac.broadinstitute.org/variant/' + exac.chrom + '-' + exac.pos + '-' + exac.ref + '-' + exac.alt} target="_blank">(See ExAC data)</a></h3></div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -99,7 +99,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     getInitialState: function() {
         return {
-            data: {test: 'hey', test2: 'asdfasfasfdaas'},
+            data: {test: 'hey', test2: 'asdfasfasfdaas'}, // FIXME: test data to pass to evaluation forms; remove
             clinvar_id: null, // ClinVar ID
             car_id: null, // ClinGen Allele Registry ID
             interpretation: this.props.interpretation,
@@ -628,7 +628,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     }
 });
 
-
+// FIXME: all functions below here are examples; references to these in above render() should also be removed
 var pop_crit_1 = function() {
     return (
         <div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -11,6 +11,7 @@ var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
 var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
 
 var external_url_map = globals.external_url_map;
+var dbxref_prefix_map = globals.dbxref_prefix_map;
 var queryKeyValue = globals.queryKeyValue;
 
 var form = require('../../../libs/bootstrap/form');
@@ -568,7 +569,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                 {(this.state.hasEspData) ?
                     <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp.rsid + '; ' + esp.chrom + '.' + esp.hg19_start + '; Alleles ' + esp.ref + '>' + esp.alt}<a href={this.props.protocol + external_url_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">(See ESP data)</a></h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp.rsid + '; ' + esp.chrom + '.' + esp.hg19_start + '; Alleles ' + esp.ref + '>' + esp.alt}<a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">(See ESP data)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -617,7 +618,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found. Please see <a href={this.props.protocol + external_url_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.</th>
+                                    <th>Variant information could not be found. Please see <a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.</th>
                                 </tr>
                             </thead>
                         </table>

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -10,7 +10,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
     mixins: [RestMixin],
 
     propTypes: {
-        data: React.PropTypes.object
+        data: React.PropTypes.object,
+        protocol: React.PropTypes.string
     },
 
     getInitialState: function() {

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 // Derived from:
 // https://github.com/standard-analytics/pubmed-schema-org/blob/master/lib/pubmed.js
 module.exports.parseClinvar = parseClinvar;
-function parseClinvar(xml, mixin){
+function parseClinvar(xml, extended){
     var variant = {};
     var doc = new DOMParser().parseFromString(xml, 'text/xml');
 
@@ -43,8 +43,8 @@ function parseClinvar(xml, mixin){
                     }
                 }
                 // Call to extract more ClinVar data from XML response
-                if (mixin) {
-                    parseClinvarMixin(variant, $Allele, $HGVSlist_raw, $VariationReport);
+                if (extended) {
+                    parseClinvarExtended(variant, $Allele, $HGVSlist_raw, $VariationReport);
                 }
             }
         }
@@ -53,7 +53,7 @@ function parseClinvar(xml, mixin){
 }
 
 // Function to extract more ClinVar data than what the db stores
-function parseClinvarMixin(variant, allele, hgvs_list, dataset) {
+function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.RefSeqTranscripts = {};
     variant.gene = {};
     variant.allele = {};


### PR DESCRIPTION
**Related to #726:**

* Extract URLs in curation pages out to globals
* Update URL builders so they use http or https protocols depending on context

**Misc:**

* Add `FIXME` comments to temporary form code
* Rename `parseClinvarMixin` to `parseClinvarExtended` since 'Mixin' is a reserved nomenclature in React

**Demo instance:**
https://726-mc-httphttps-aeb8562-minchoi.demo.clinicalgenome.org/
(A commit or two behind, but the commits are adding comments so should not have any functional impact)

**Testing:**

1. Create Variant via VCI (both via ClinVar ID and CA ID)
2. Confirm that the external data gathering works on https protocol for basic info and populations tab

**Caveats:**

* CAR is still half-working at best due to fake certificates
* Still lots of errors on rendering
* I think global's URL dictionaries need to be cleaned up and unified a bit
