### PR TITLE
Connects to #732. Population tab

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -182,6 +182,7 @@ module.exports.external_url_map = {
     'CAR-test': 'http://reg.test.genome.network/site/registry',
     'CARallele-test': '//reg.test.genome.network/allele/',
     'EnsemblVEP': '//rest.ensembl.org/vep/human/id/',
+    'EnsemblVariation': '//rest.ensembl.org/variation/human/',
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -40,6 +40,14 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         };
     },
 
+    componentDidMount: function() {
+        if (this.props.data) {
+            this.setState({shouldFetchData: true});
+            this.fetchRefseqData();
+            this.fetchEnsemblData();
+        }
+    },
+
     componentWillReceiveProps: function(nextProps) {
         if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {
             this.setState({shouldFetchData: true});

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -5,6 +5,7 @@ var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
+//var LocalStorageMixin = require('react-localstorage');
 var SO_terms = require('./mapping/SO_term.json');
 
 var external_url_map = globals.external_url_map;

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -41,8 +41,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     componentWillReceiveProps: function(nextProps) {
-        this.setState({shouldFetchData: nextProps.shouldFetchData});
-        if (this.state.shouldFetchData === true) {
+        if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {
+            this.setState({shouldFetchData: nextProps.shouldFetchData});
             window.localStorage.clear();
             this.fetchRefseqData();
             this.fetchEnsemblData();

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -5,7 +5,6 @@ var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
-var LocalStorageMixin = require('react-localstorage');
 var SO_terms = require('./mapping/SO_term.json');
 
 var external_url_map = globals.external_url_map;
@@ -13,7 +12,7 @@ var dbxref_prefix_map = globals.dbxref_prefix_map;
 
 // Display the curator data of the curation data
 var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasicInfo = React.createClass({
-    mixins: [RestMixin, LocalStorageMixin],
+    mixins: [RestMixin],
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
@@ -42,8 +41,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
     componentWillReceiveProps: function(nextProps) {
         if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {
-            this.setState({shouldFetchData: nextProps.shouldFetchData});
-            window.localStorage.clear();
+            this.setState({shouldFetchData: true});
             this.fetchRefseqData();
             this.fetchEnsemblData();
         }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -106,8 +106,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretation: nextProps.interpretation});
-        this.setState({shouldFetchData: nextProps.shouldFetchData});
-        if (this.state.shouldFetchData === true) {
+        if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {
+            this.setState({shouldFetchData: nextProps.shouldFetchData});
             window.localStorage.clear();
             this.fetchMyVariantInfo();
             this.fetchEnsemblData();

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -26,68 +26,6 @@ var InputMixin = form.InputMixin;
 // They should contain pre-existing values if they exist in the db. Or 'null' if not.
 var populationObj = {
     exac: {
-        allele_count: {},
-        allele_number: {},
-        hom_number: {},
-        allele_frequency: {
-            african: '',
-            east_asian: '',
-            european_non_finnish: '',
-            european_finnish: '',
-            latino: '',
-            other: '',
-            south_asian: '',
-            total: ''
-        },
-        chrom: '',
-        pos: '',
-        ref: '',
-        alt: ''
-    },
-    thousand_genome: {
-        allele: {
-            african: [],
-            all: [],
-            east_asian: [],
-            european: [],
-            latino: [],
-            south_asian: [],
-            esp6500_african_american: [],
-            esp6500_european_american: []
-        },
-        genotype: {
-            african: [],
-            all: [],
-            east_asian: [],
-            european: [],
-            latino: [],
-            south_asian: [],
-            esp6500_african_american: [],
-            esp6500_european_american: []
-        }
-    },
-    esp: {
-        allele_count: {
-            african_american: {},
-            all: {},
-            european_american: {}
-        },
-        genotype_count: {
-            african_american: {},
-            all: {},
-            european_american: {}
-        },
-        avg_sample_read: '',
-        rsid: '',
-        chrom: '',
-        hg19_start: '',
-        ref: '',
-        alt: ''
-    }
-};
-
-var populationObjTwo = {
-    exac: {
         afr: {}, amr: {}, eas: {}, fin: {}, nfe: {}, oth: {}, sas: {}, _tot: {}, _extra: {},
         _order: ['afr', 'oth', 'amr', 'sas', 'nfe', 'eas', 'fin'],
         _labels: {afr: 'African', amr: 'Latino', eas: 'East Asian', fin: 'European (Finnish)', nfe: 'European (Non-Finnish)', oth: 'Other', sas: 'South Asian'}
@@ -187,7 +125,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 console.log('VEP');
                 console.log(exac_allele_frequency);
                 this.assignAlleleFrequencyData(exac_allele_frequency);
-                this.setState({external_data: populationObjTwo});
+                this.setState({external_data: populationObj});
             }).catch(function(e) {
                 console.log('VEP Allele Frequency Fetch Error=: %o', e);
             });
@@ -201,7 +139,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 // for comparison of any potential changed values
                 this.assignExacData(response);
                 this.assignEspData(response);
-                this.setState({external_data: populationObjTwo});
+                this.setState({external_data: populationObj});
             }).catch(function(e) {
                 console.log('MyVariant Fetch Error=: %o', e);
             });
@@ -211,10 +149,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     // Get ExAC allele frequency from Ensembl (VEP) directly
     // Because myvariant.info doesn't always return ExAC allele frequency data
     assignAlleleFrequencyData: function(allele_frequency) {
-        populationObjTwo.exac._order.map(key => {
-            populationObjTwo.exac[key].af = allele_frequency[0].colocated_variants[0]['exac_' + key + '_maf'];
+        populationObj.exac._order.map(key => {
+            populationObj.exac[key].af = allele_frequency[0].colocated_variants[0]['exac_' + key + '_maf'];
         });
-        populationObjTwo.exac._tot.af = allele_frequency[0].colocated_variants[0].exac_adj_maf;
+        populationObj.exac._tot.af = allele_frequency[0].colocated_variants[0].exac_adj_maf;
     },
 
     // Method to assign ExAC population data to global population object
@@ -223,18 +161,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         // Do nothing if the exac{...} object is not returned from myvariant.info
         if (response.exac) {
             // Get other ExAC population data from myvariant.info, such allele_count, allele_number, homozygotes number, etc
-            populationObjTwo.exac._order.map(key => {
-                populationObjTwo.exac[key].ac = response.exac.ac['ac_' + key];
-                populationObjTwo.exac[key].an = response.exac.an['an_' + key];
-                populationObjTwo.exac[key].hom = response.exac.hom['hom_' + key];
+            populationObj.exac._order.map(key => {
+                populationObj.exac[key].ac = response.exac.ac['ac_' + key];
+                populationObj.exac[key].an = response.exac.an['an_' + key];
+                populationObj.exac[key].hom = response.exac.hom['hom_' + key];
             });
-            populationObjTwo.exac._tot.ac = response.exac.ac.ac_adj;
-            populationObjTwo.exac._tot.an = response.exac.an.an_adj;
-            populationObjTwo.exac._tot.hom = response.exac.hom.ac_hom;
-            populationObjTwo.exac._extra.chrom = response.exac.chrom;
-            populationObjTwo.exac._extra.pos = response.exac.pos;
-            populationObjTwo.exac._extra.ref = response.exac.ref;
-            populationObjTwo.exac._extra.alt = response.exac.alt;
+            populationObj.exac._tot.ac = response.exac.ac.ac_adj;
+            populationObj.exac._tot.an = response.exac.an.an_adj;
+            populationObj.exac._tot.hom = response.exac.hom.ac_hom;
+            populationObj.exac._extra.chrom = response.exac.chrom;
+            populationObj.exac._extra.pos = response.exac.pos;
+            populationObj.exac._extra.ref = response.exac.ref;
+            populationObj.exac._extra.alt = response.exac.alt;
             // Set a flag to display data in the table
             this.setState({hasExacData: true});
         }
@@ -244,18 +182,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     assignEspData: function(response) {
         // Not all variants return the evs{...} object from myvariant.info
         if (response.evs) {
-            populationObjTwo.esp.aa.ac = response.evs.allele_count.african_american;
-            populationObjTwo.esp.aa.gc = response.evs.genotype_count.african_american;
-            populationObjTwo.esp.ea.ac = response.evs.allele_count.european_american;
-            populationObjTwo.esp.ea.gc = response.evs.genotype_count.european_american;
-            populationObjTwo.esp._tot.ac = response.evs.allele_count.all;
-            populationObjTwo.esp._tot.gc = response.evs.genotype_count.all_genotype;
-            populationObjTwo.esp._extra.avg_sample_read = response.evs.avg_sample_read;
-            populationObjTwo.esp._extra.rsid = response.evs.rsid;
-            populationObjTwo.esp._extra.chrom = response.evs.chrom;
-            populationObjTwo.esp._extra.hg19_start = response.evs.hg19.start;
-            populationObjTwo.esp._extra.ref = response.evs.ref;
-            populationObjTwo.esp._extra.alt = response.evs.alt;
+            populationObj.esp.aa.ac = response.evs.allele_count.african_american;
+            populationObj.esp.aa.gc = response.evs.genotype_count.african_american;
+            populationObj.esp.ea.ac = response.evs.allele_count.european_american;
+            populationObj.esp.ea.gc = response.evs.genotype_count.european_american;
+            populationObj.esp._tot.ac = response.evs.allele_count.all;
+            populationObj.esp._tot.gc = response.evs.genotype_count.all_genotype;
+            populationObj.esp._extra.avg_sample_read = response.evs.avg_sample_read;
+            populationObj.esp._extra.rsid = response.evs.rsid;
+            populationObj.esp._extra.chrom = response.evs.chrom;
+            populationObj.esp._extra.hg19_start = response.evs.hg19.start;
+            populationObj.esp._extra.ref = response.evs.ref;
+            populationObj.esp._extra.alt = response.evs.alt;
             // Set a flag to display data in the table
             this.setState({hasEspData: true});
         }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -122,16 +122,12 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             var variant_id = found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':'));
             this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(exac_allele_frequency => {
                 // Calling method to update global object with ExAC Allele Frequency data
-                console.log('VEP');
-                console.log(exac_allele_frequency);
                 this.assignAlleleFrequencyData(exac_allele_frequency);
                 this.setState({external_data: populationObj});
             }).catch(function(e) {
                 console.log('VEP Allele Frequency Fetch Error=: %o', e);
             });
             this.getRestData(url + variant_id).then(response => {
-                console.log('EXAC');
-                console.log(response);
                 this.setState({myvariant_exac_population: response.exac});
                 // Calling methods to update global object with ExAC & ESP population data
                 // FIXME: Need to create a new copy of the global object with new data
@@ -212,6 +208,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             var numberPattern = /\d+/g;
             var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
             this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json;pops=1;population_genotypes=1').then(response => {
+                console.log(response);
                 this.setState({
                     ensembl_variation_data: response,
                     ensembl_populations: response.populations,

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -121,9 +121,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             var found = genomic_chr_mapping.find((entry) => entry.GenomicRefSeq === NC_genomic);
             // Format variant_id for use of myvariant.info REST API
             var variant_id = found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':'));
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(exac_allele_frequency => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(response => {
                 // Calling method to update global object with ExAC Allele Frequency data
-                this.parseAlleleFrequencyData(exac_allele_frequency);
+                this.parseAlleleFrequencyData(response);
                 this.setState({external_data: populationObj});
             }).catch(function(e) {
                 console.log('VEP Allele Frequency Fetch Error=: %o', e);
@@ -158,22 +158,25 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Get ExAC allele frequency as a fallback strategy
             // In the event where myvariant.info doesn't return ExAC allele frequency info
             // FIXME: Need to remove this when switching to using the global population object for table UI
-            if (populationObj.)
+            // FIXME_MC: Also need to figure out how to make sure the promises do not conflict: they're not chained, but dependent on the result of the other
+            /*
             this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
+                this.parseAlleleFrequencyData(response);
                 this.setState({ensembl_exac_allele: response[0].colocated_variants[0]});
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);
             });
+            */
         }
     },
 
     // Get ExAC allele frequency from Ensembl (VEP) directly
     // Because myvariant.info doesn't always return ExAC allele frequency data
-    parseAlleleFrequencyData: function(allele_frequency) {
+    parseAlleleFrequencyData: function(response) {
         populationObj.exac._order.map(key => {
-            populationObj.exac[key].af = allele_frequency[0].colocated_variants[0]['exac_' + key + '_maf'];
+            populationObj.exac[key].af = response[0].colocated_variants[0]['exac_' + key + '_maf'];
         });
-        populationObj.exac._tot.af = allele_frequency[0].colocated_variants[0].exac_adj_maf;
+        populationObj.exac._tot.af = response[0].colocated_variants[0].exac_adj_maf;
     },
 
     // Method to assign ExAC population data to global population object

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -85,6 +85,15 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         };
     },
 
+    componentDidMount: function() {
+        this.setState({interpretation: this.props.interpretation});
+        if (this.props.data) {
+            this.setState({shouldFetchData: true});
+            this.fetchMyVariantInfo();
+            this.fetchEnsemblData();
+        }
+    },
+
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretation: nextProps.interpretation});
         if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -71,20 +71,12 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             clinvar_id: null, // ClinVar ID
             car_id: null, // ClinGen Allele Registry ID
             interpretation: this.props.interpretation,
-            dbSNP_id: null,
             hgvs_GRCh37: null,
-            gene_symbol: null,
-            ensembl_variation_data: {},
-            ensembl_populations: [],
-            ensembl_population_genotypes: [],
             ensembl_exac_allele: {},
-            myvariant_exac_population: {}, // ExAC population counts from myvariant.info
-            myvariant_exac_allele: {}, // ExAC population frequencies from myvariant.info
-            myvariant_esp_population: {}, // ESP (EVS) population allele from myvariant.info
             interpretationUuid: this.props.interpretationUuid,
             hasExacData: false, // flag to display ExAC table
-            hasEspData: false, // flag to display ESP table
             hasTGenomesData: false,
+            hasEspData: false, // flag to display ESP table
             shouldFetchData: false
         };
     },
@@ -137,7 +129,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 console.log('VEP Allele Frequency Fetch Error=: %o', e);
             });
             this.getRestData(url + variant_id).then(response => {
-                this.setState({myvariant_exac_population: response.exac});
                 // Calling methods to update global object with ExAC & ESP population data
                 // FIXME: Need to create a new copy of the global object with new data
                 // while leaving the original object with pre-existing data
@@ -167,7 +158,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Get ExAC allele frequency as a fallback strategy
             // In the event where myvariant.info doesn't return ExAC allele frequency info
             // FIXME: Need to remove this when switching to using the global population object for table UI
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVariation'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
+            if (populationObj.)
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
                 this.setState({ensembl_exac_allele: response[0].colocated_variants[0]});
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);
@@ -282,10 +274,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return (
             <tr key={key} className={className ? className : ''}>
                 <td>{rowName}</td>
-                <td>{this.ifNullOrUndefined(exac[key].ac) ? exac[key].ac : '--'}</td>
-                <td>{this.ifNullOrUndefined(exac[key].an) ? exac[key].an : '--'}</td>
-                <td>{this.ifNullOrUndefined(exac[key].hom) ? exac[key].hom : '--'}</td>
-                <td>{this.ifNullOrUndefined(exac[key].af) ? exac[key].af : '--'}</td>
+                <td>{exac[key].ac ? exac[key].ac : '--'}</td>
+                <td>{exac[key].an ? exac[key].an : '--'}</td>
+                <td>{exac[key].hom ? exac[key].hom : '--'}</td>
+                <td>{exac[key].af ? exac[key].af : '--'}</td>
             </tr>
         );
     },
@@ -298,11 +290,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return (
             <tr key={key} className={className ? className : ''}>
                 <td>{rowName}</td>
-                <td>{this.ifNullOrUndefined(tGenomes[key].af[tGenomes._extra.ref]) ? tGenomes._extra.ref + ': ' + tGenomes[key].af[tGenomes._extra.ref] : '--'}{this.ifNullOrUndefined(tGenomes[key].ac[tGenomes._extra.ref]) ? ' (' + tGenomes[key].ac[tGenomes._extra.ref] + ')' : ''}</td>
-                <td>{this.ifNullOrUndefined(tGenomes[key].af[tGenomes._extra.alt]) ? tGenomes._extra.alt + ': ' + tGenomes[key].af[tGenomes._extra.alt] : '--'}{this.ifNullOrUndefined(tGenomes[key].ac[tGenomes._extra.alt]) ? ' (' + tGenomes[key].ac[tGenomes._extra.alt] + ')' : ''}</td>
-                <td>{this.ifNullOrUndefined(tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.ref]) ? tGenomes._extra.ref + '|' + tGenomes._extra.ref + ': ' + tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.ref] : '--'}{this.ifNullOrUndefined(tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.ref]) ? ' (' + tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.ref] + ')' : ''}</td>
-                <td>{this.ifNullOrUndefined(tGenomes[key].gf[tGenomes._extra.alt + '|' + tGenomes._extra.alt]) ? tGenomes._extra.alt + '|' + tGenomes._extra.alt + ': ' + tGenomes[key].gf[tGenomes._extra.alt + '|' + tGenomes._extra.alt] : '--'}{this.ifNullOrUndefined(tGenomes[key].gc[tGenomes._extra.alt + '|' + tGenomes._extra.alt]) ? ' (' + tGenomes[key].gc[tGenomes._extra.alt + '|' + tGenomes._extra.alt] + ')' : ''}</td>
-                <td>{this.ifNullOrUndefined(tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.alt]) ? tGenomes._extra.ref + '|' + tGenomes._extra.alt + ': ' + tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.alt] : '--'}{this.ifNullOrUndefined(tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.alt]) ? ' (' + tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.alt] + ')' : ''}</td>
+                <td>{tGenomes[key].af[tGenomes._extra.ref] ? tGenomes._extra.ref + ': ' + tGenomes[key].af[tGenomes._extra.ref] : '--'}{tGenomes[key].ac[tGenomes._extra.ref] ? ' (' + tGenomes[key].ac[tGenomes._extra.ref] + ')' : ''}</td>
+                <td>{tGenomes[key].af[tGenomes._extra.alt] ? tGenomes._extra.alt + ': ' + tGenomes[key].af[tGenomes._extra.alt] : '--'}{tGenomes[key].ac[tGenomes._extra.alt] ? ' (' + tGenomes[key].ac[tGenomes._extra.alt] + ')' : ''}</td>
+                <td>{tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.ref] ? tGenomes._extra.ref + '|' + tGenomes._extra.ref + ': ' + tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.ref] : '--'}{tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.ref] ? ' (' + tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.ref] + ')' : ''}</td>
+                <td>{tGenomes[key].gf[tGenomes._extra.alt + '|' + tGenomes._extra.alt] ? tGenomes._extra.alt + '|' + tGenomes._extra.alt + ': ' + tGenomes[key].gf[tGenomes._extra.alt + '|' + tGenomes._extra.alt] : '--'}{tGenomes[key].gc[tGenomes._extra.alt + '|' + tGenomes._extra.alt] ? ' (' + tGenomes[key].gc[tGenomes._extra.alt + '|' + tGenomes._extra.alt] + ')' : ''}</td>
+                <td>{tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.alt] ? tGenomes._extra.ref + '|' + tGenomes._extra.alt + ': ' + tGenomes[key].gf[tGenomes._extra.ref + '|' + tGenomes._extra.alt] : '--'}{tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.alt] ? ' (' + tGenomes[key].gc[tGenomes._extra.ref + '|' + tGenomes._extra.alt] + ')' : ''}</td>
             </tr>
         );
     },
@@ -315,28 +307,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return (
             <tr key={key} className={className ? className : ''}>
                 <td>{rowName}</td>
-                <td>{this.ifNullOrUndefined(esp[key].ac[esp._extra.ref]) ? esp._extra.ref + ': ' + esp[key].ac[esp._extra.ref] : '--'}</td>
-                <td>{this.ifNullOrUndefined(esp[key].ac[esp._extra.alt]) ? esp._extra.alt + ': ' + esp[key].ac[esp._extra.alt] : '--'}</td>
-                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.ref + esp._extra.ref]) ? esp._extra.ref + esp._extra.ref + ': ' + esp[key].gc[esp._extra.ref + esp._extra.ref] : '--'}</td>
-                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.alt + esp._extra.alt]) ? esp._extra.alt + esp._extra.alt + ': ' + esp[key].gc[esp._extra.alt + esp._extra.alt] : '--'}</td>
-                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.alt + esp._extra.ref]) ? esp._extra.alt + esp._extra.ref + ': ' + esp[key].gc[esp._extra.alt + esp._extra.ref] : '--'}</td>
+                <td>{esp[key].ac[esp._extra.ref] ? esp._extra.ref + ': ' + esp[key].ac[esp._extra.ref] : '--'}</td>
+                <td>{esp[key].ac[esp._extra.alt] ? esp._extra.alt + ': ' + esp[key].ac[esp._extra.alt] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.ref + esp._extra.ref] ? esp._extra.ref + esp._extra.ref + ': ' + esp[key].gc[esp._extra.ref + esp._extra.ref] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.alt + esp._extra.alt] ? esp._extra.alt + esp._extra.alt + ': ' + esp[key].gc[esp._extra.alt + esp._extra.alt] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.alt + esp._extra.ref] ? esp._extra.alt + esp._extra.ref + ': ' + esp[key].gc[esp._extra.alt + esp._extra.ref] : '--'}</td>
             </tr>
         );
     },
 
-    ifNullOrUndefined: function(value) {
-        if (typeof value !== 'undefined' && value !== null) {
-            return true;
-        } else {
-            return false;
-        }
-    },
-
     render: function() {
-        // FIXME: Need to switch to using the global population object
-        var ensembl_variation = this.state.ensembl_variation_data,
-            ensembl_populations = this.state.ensembl_populations,
-            ensembl_population_genotypes = this.state.ensembl_population_genotypes;
         // Genotype alleles (e.g. 'C|C', 'T|T', 'C|T') used by 1000G
         var allele_ancestral, allele_minor, allele_mixed;
         if (ensembl_variation) {

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -271,15 +271,37 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return displayVal;
     },
 
-    // Function to get 1000G genotype values and populate table cells
-    handleEspData: function(alleleObj, allele) {
-        var displayVal = '--';
-        Object.keys(alleleObj).forEach(function(key) {
-            if (key === allele) {
-                displayVal = key + ': ' + alleleObj[key];
-            }
-        });
-        return displayVal;
+    renderExacRow: function(key, exac, rowNameCustom, className) {
+        let rowName = exac._labels[key];
+        if (key == '_tot') {
+            rowName = rowNameCustom;
+        }
+        return (
+            <tr key={key} className={className ? className : ''}>
+                <td>{rowName}</td>
+                <td>{exac[key].ac !== null ? exac[key].ac : '--'}</td>
+                <td>{exac[key].an !== null ? exac[key].an : '--'}</td>
+                <td>{exac[key].hom !== null ? exac[key].hom : '--'}</td>
+                <td>{exac[key].af !== null ? exac[key].af : '--'}</td>
+            </tr>
+        );
+    },
+
+    renderEspRow: function(key, esp, rowNameCustom, className) {
+        let rowName = esp._labels[key];
+        if (key == '_tot') {
+            rowName = rowNameCustom;
+        }
+        return (
+            <tr key={key} className={className ? className : ''}>
+                <td>{rowName}</td>
+                <td>{esp[key].ac[esp._extra.ref] !== null ? esp._extra.ref + ': ' + esp[key].ac[esp._extra.ref] : '--'}</td>
+                <td>{esp[key].ac[esp._extra.alt] !== null ? esp._extra.alt + ': ' + esp[key].ac[esp._extra.alt] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.ref + esp._extra.ref] !== null ? esp._extra.ref + esp._extra.ref + ': ' + esp[key].gc[esp._extra.ref + esp._extra.ref] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.alt + esp._extra.alt] !== null ? esp._extra.alt + esp._extra.alt + ': ' + esp[key].gc[esp._extra.alt + esp._extra.alt] : '--'}</td>
+                <td>{esp[key].gc[esp._extra.alt + esp._extra.ref] !== null ? esp._extra.alt + esp._extra.ref + ': ' + esp[key].gc[esp._extra.alt + esp._extra.ref] : '--'}</td>
+            </tr>
+        );
     },
 
     render: function() {
@@ -312,11 +334,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 <div className="row">
                     <div className="col-sm-12">
                         <CurationInterpretationForm formTitle={"Population Demo Criteria Group 1"} renderedFormContent={pop_crit_1}
-                            evidenceType={'population'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                            evidenceType={'population'} evidenceData={this.state.external_data} evidenceDataUpdated={true}
                             formDataUpdater={pop_crit_1_update} variantUuid={this.props.data['@id']} criteria={['pm2']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         <CurationInterpretationForm formTitle={"Population Demo Criteria Group 2"} renderedFormContent={pop_crit_2}
-                            evidenceType={'population'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                            evidenceType={'population'} evidenceData={this.state.external_data} evidenceDataUpdated={true}
                             formDataUpdater={pop_crit_2_update} variantUuid={this.props.data['@id']} criteria={['ps4', 'ps5']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     </div>
@@ -367,25 +389,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </thead>
                             <tbody>
                                 {exac._order.map(key => {
-                                    return (
-                                        <tr key={key}>
-                                            <td>{exac._labels[key]}</td>
-                                            <td>{exac[key].ac}</td>
-                                            <td>{exac[key].an}</td>
-                                            <td>{exac[key].hom}</td>
-                                            <td>{exac[key].af}</td>
-                                        </tr>
-                                    );
+                                    return (this.renderExacRow(key, exac));
                                 })}
                             </tbody>
                             <tfoot>
-                                <tr className="count">
-                                    <td>Total</td>
-                                    <td>{exac._tot.ac}</td>
-                                    <td>{exac._tot.an}</td>
-                                    <td>{exac._tot.hom}</td>
-                                    <td>{exac._tot.af}</td>
-                                </tr>
+                                {this.renderExacRow('_tot', exac, 'Total', 'count')}
                             </tfoot>
                         </table>
                     </div>
@@ -508,7 +516,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                     <th colSpan="3">Genotype Count</th>
                                 </tr>
                             </thead>
-
+                            <tbody>
+                                {esp._order.map(key => {
+                                    return (this.renderEspRow(key, esp));
+                                })}
+                                {this.renderEspRow('_tot', esp, 'All Allele', 'count')}
+                            </tbody>
+                            <tfoot>
+                                <tr className="count">
+                                    <td>Average Sample Read Depth</td>
+                                    <td colSpan="5">{esp._extra.avg_sample_read}</td>
+                                </tr>
+                            </tfoot>
                         </table>
                     </div>
                 :

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -207,7 +207,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
             var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json;pops=1;population_genotypes=1').then(response => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVariation'] + 'rs' + rsid + '?content-type=application/json;pops=1;population_genotypes=1').then(response => {
+                console.log('ENSEMBL1');
                 console.log(response);
                 this.setState({
                     ensembl_variation_data: response,
@@ -220,7 +221,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Get ExAC allele frequency as a fallback strategy
             // In the event where myvariant.info doesn't return ExAC allele frequency info
             // FIXME: Need to remove this when switching to using the global population object for table UI
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
+            this.getRestData(this.props.protocol + external_url_map['EnsemblVariation'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1').then(response => {
+                console.log('ENSEMBL2');
+                console.log(response);
                 this.setState({ensembl_exac_allele: response[0].colocated_variants[0]});
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -282,10 +282,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return (
             <tr key={key} className={className ? className : ''}>
                 <td>{rowName}</td>
-                <td>{exac[key].ac !== null ? exac[key].ac : '--'}</td>
-                <td>{exac[key].an !== null ? exac[key].an : '--'}</td>
-                <td>{exac[key].hom !== null ? exac[key].hom : '--'}</td>
-                <td>{exac[key].af !== null ? exac[key].af : '--'}</td>
+                <td>{this.ifNullOrUndefined(exac[key].ac) ? exac[key].ac : '--'}</td>
+                <td>{this.ifNullOrUndefined(exac[key].an) ? exac[key].an : '--'}</td>
+                <td>{this.ifNullOrUndefined(exac[key].hom) ? exac[key].hom : '--'}</td>
+                <td>{this.ifNullOrUndefined(exac[key].af) ? exac[key].af : '--'}</td>
             </tr>
         );
     },
@@ -315,11 +315,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return (
             <tr key={key} className={className ? className : ''}>
                 <td>{rowName}</td>
-                <td>{esp[key].ac[esp._extra.ref] !== null ? esp._extra.ref + ': ' + esp[key].ac[esp._extra.ref] : '--'}</td>
-                <td>{esp[key].ac[esp._extra.alt] !== null ? esp._extra.alt + ': ' + esp[key].ac[esp._extra.alt] : '--'}</td>
-                <td>{esp[key].gc[esp._extra.ref + esp._extra.ref] !== null ? esp._extra.ref + esp._extra.ref + ': ' + esp[key].gc[esp._extra.ref + esp._extra.ref] : '--'}</td>
-                <td>{esp[key].gc[esp._extra.alt + esp._extra.alt] !== null ? esp._extra.alt + esp._extra.alt + ': ' + esp[key].gc[esp._extra.alt + esp._extra.alt] : '--'}</td>
-                <td>{esp[key].gc[esp._extra.alt + esp._extra.ref] !== null ? esp._extra.alt + esp._extra.ref + ': ' + esp[key].gc[esp._extra.alt + esp._extra.ref] : '--'}</td>
+                <td>{this.ifNullOrUndefined(esp[key].ac[esp._extra.ref]) ? esp._extra.ref + ': ' + esp[key].ac[esp._extra.ref] : '--'}</td>
+                <td>{this.ifNullOrUndefined(esp[key].ac[esp._extra.alt]) ? esp._extra.alt + ': ' + esp[key].ac[esp._extra.alt] : '--'}</td>
+                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.ref + esp._extra.ref]) ? esp._extra.ref + esp._extra.ref + ': ' + esp[key].gc[esp._extra.ref + esp._extra.ref] : '--'}</td>
+                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.alt + esp._extra.alt]) ? esp._extra.alt + esp._extra.alt + ': ' + esp[key].gc[esp._extra.alt + esp._extra.alt] : '--'}</td>
+                <td>{this.ifNullOrUndefined(esp[key].gc[esp._extra.alt + esp._extra.ref]) ? esp._extra.alt + esp._extra.ref + ': ' + esp[key].gc[esp._extra.alt + esp._extra.ref] : '--'}</td>
             </tr>
         );
     },

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -202,6 +202,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
     },
 
+    // parse 1000Genome data
     parseTGenomesData: function(response) {
         populationObj.tGenomes._extra.name = response.name;
         populationObj.tGenomes._extra.var_class = response.var_class;
@@ -269,6 +270,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
     },
 
+    // method to render a row of data for the ExAC table
     renderExacRow: function(key, exac, rowNameCustom, className) {
         let rowName = exac._labels[key];
         if (key == '_tot') {
@@ -285,6 +287,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         );
     },
 
+    // method to render a row of data for the 1000Genomes table
     renderTGenomesRow: function(key, tGenomes, rowNameCustom, className) {
         let rowName = tGenomes._labels[key];
         if (key == '_tot') {
@@ -302,6 +305,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         );
     },
 
+    // method to render a row of data for the ESP table
     renderEspRow: function(key, esp, rowNameCustom, className) {
         let rowName = esp._labels[key];
         if (key == '_tot') {
@@ -320,24 +324,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     render: function() {
-        // Genotype alleles (e.g. 'C|C', 'T|T', 'C|T') used by 1000G
-        var allele_ancestral, allele_minor, allele_mixed;
-        if (ensembl_variation) {
-            allele_ancestral = ensembl_variation.ancestral_allele + '|' + ensembl_variation.ancestral_allele;
-            allele_minor = ensembl_variation.minor_allele + '|' + ensembl_variation.minor_allele;
-            allele_mixed = ensembl_variation.ancestral_allele + '|' + ensembl_variation.minor_allele;
-        }
-
         var exac = this.state.external_data && this.state.external_data.exac ? this.state.external_data.exac : null; // Get ExAC data from global population object
         var tGenomes = this.state.external_data && this.state.external_data.tGenomes ? this.state.external_data.tGenomes : null;
         var esp = this.state.external_data && this.state.external_data.esp ? this.state.external_data.esp : null; // Get ESP data from global population object
-        // Genotype alleles (e.g. 'CC', 'TT', 'TC') used by ESP
-        var esp_allele_ref, esp_allele_alt, esp_allele_mixed;
-        if (esp) {
-            esp_allele_ref = esp.ref + esp.ref;
-            esp_allele_alt = esp.alt + esp.alt;
-            esp_allele_mixed = esp.alt + esp.ref;
-        }
 
         return (
             <div className="variant-interpretation population">
@@ -419,6 +408,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </thead>
                         </table>
                     </div>
+                    // FIXME: below URL is dependent on a response, but this block is executed on lack of a response
                     //Please see <a href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">variant data</a> at ExAC.
                 }
                 {this.state.hasTGenomesData ?
@@ -488,6 +478,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </thead>
                         </table>
                     </div>
+                    // FIXME: below URL is dependent on a response, but this block is executed on lack of a response
                     // Please see <a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.
                 }
             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
+//var LocalStorageMixin = require('react-localstorage');
 var CurationInterpretationForm = require('./shared/form').CurationInterpretationForm;
 var parseAndLogError = require('../../mixins').parseAndLogError;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;


### PR DESCRIPTION
Test instance: http://732-mc-population-tab-try2.instance.clinicalgenome.org/

* Re-structured `populationObj`
* Updated the parsers to support new model
* Revised rendering of tables to use loops
* Re-implemented 1000G parser
* Connected `populationObj` to evaluation/assessment forms

![image](https://cloud.githubusercontent.com/assets/4326866/16395971/6a09b23a-3c71-11e6-9f37-eb0430386eb7.png)

Testing:

1. Load variant (tested with 139214, 139215)
2. Check population tab for proper rendering and linkouts of data
3. Create interpretation and save it
4. Confirm that the interpretation has saved properly, and the interpretation evaluation evidence is also saved properly

Caveats/To-Do's:

* ~~When navigating away from the VCI page, a bunch of `setState` errors pop up. Maybe a separate ticket:~~
![image](https://cloud.githubusercontent.com/assets/4326866/16397008/afb9c856-3c76-11e6-8006-d90bf26c1c6a.png)
  * Fixed as of commit 57b85e1 - test by loading VCI, then pressing the Header image to go to dashboard. Console should not have above errors.
* #730 and #731 not addressed here
* Top section of Populations Tab + CI stuff not implemented yet
