### PR TITLE
Connects #713 experimental functional links

### DIFF
--- a/src/clincoded/schemas/experimental.json
+++ b/src/clincoded/schemas/experimental.json
@@ -481,19 +481,19 @@
             "title": "Label",
             "type": "string"
         },
+        "uuid": {
+            "title": "ExperimentalData",
+            "type": "string"
+        },
+        "date_created": {
+            "title": "Creation Date",
+            "type": "string"
+        },
         "evidenceType": {
             "title": "Type",
             "type": "string"
         },
-        "variant_count": {
-            "title": "# Variants",
-            "type": "number"
-        },
-        "assessment_count": {
-            "title": "# Assessments",
-            "type": "number"
-        },
-        "submitted_by.title": {
+        "submitted_by.uuid": {
             "title": "Submitted by",
             "type": "string"
         }

--- a/src/clincoded/schemas/experimental.json
+++ b/src/clincoded/schemas/experimental.json
@@ -481,19 +481,19 @@
             "title": "Label",
             "type": "string"
         },
-        "uuid": {
-            "title": "ExperimentalData",
-            "type": "string"
-        },
-        "date_created": {
-            "title": "Creation Date",
-            "type": "string"
-        },
         "evidenceType": {
             "title": "Type",
             "type": "string"
         },
-        "submitted_by.uuid": {
+        "variant_count": {
+            "title": "# Variants",
+            "type": "number"
+        },
+        "assessment_count": {
+            "title": "# Assessments",
+            "type": "number"
+        },
+        "submitted_by.title": {
             "title": "Submitted by",
             "type": "string"
         }

--- a/src/clincoded/tests/data/inserts/experimental.json
+++ b/src/clincoded/tests/data/inserts/experimental.json
@@ -182,8 +182,7 @@
             "phenotypeHPO": "HP:0012345"
         },
         "variants": [
-            "df8135d4-2685-11e5-af19-60f81dc5b05a",
-            "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a"
+            "df8135d4-2685-11e5-af19-60f81dc5b05a"
         ],
         "assessments": [
             "a4aeb035-0a9c-41e0-9963-1deeb4e1301d",

--- a/src/clincoded/tests/data/inserts/experimental.json
+++ b/src/clincoded/tests/data/inserts/experimental.json
@@ -132,6 +132,8 @@
             "evidenceLocationInPaper": "Paragraph 31-32, page 2"
         },
         "variants": [
+            "c71fc085-2683-11e5-b9fe-60f81dc5b05a",
+            "df8135d4-2685-11e5-af19-60f81dc5b05a",
             "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a"
         ],
         "assessments": [
@@ -155,6 +157,7 @@
             "evidenceInPaper": "Paragraph 2-5, page 5"
         },
         "variants": [
+            "df8135d4-2685-11e5-af19-60f81dc5b05a",
             "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a"
         ]
     },
@@ -179,6 +182,7 @@
             "phenotypeHPO": "HP:0012345"
         },
         "variants": [
+            "df8135d4-2685-11e5-af19-60f81dc5b05a",
             "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a"
         ],
         "assessments": [

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -129,6 +129,7 @@
             "RCV000049263",
             "RCV000175486"
         ],
+        "clinvarVariantTitle": "NM_032682.5(FOXP1):c.1702C>T (p.Pro568Ser)",
         "hgvsNames": {
             "gRCh37": "NC_000003.12:g.70970756G>A",
             "gRCh38": "NC_000003.11:g.71019907G>A",

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -125,7 +125,7 @@ class Variant(Item):
         'associatedInterpretations.transcripts',
         'associatedInterpretations.proteins',
         'experimental_associated',
-        'experimental_associated.associatedAnnotations.article',
+        'experimental_associated.associatedAnnotations.article'
     ]
     rev = {
         'associatedPathogenicities': ('pathogenicity', 'variant'),
@@ -166,9 +166,8 @@ class Variant(Item):
     def experimental_associated(self, request, experimental_associated):
         return paths_filtered_by_status(request, experimental_associated)
 
-
     @calculated_property(schema={
-        "title": "Variant Representation",
+        "title": "Variant Identifier",
         "type": "string"
     })
     def variant_identifier(self, clinvarVariantId='', carId='', otherDescription=''):

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -124,10 +124,13 @@ class Variant(Item):
         'associatedInterpretations.disease',
         'associatedInterpretations.transcripts',
         'associatedInterpretations.proteins',
+        'experimental_associated',
+        'experimental_associated.associatedAnnotations.article',
     ]
     rev = {
         'associatedPathogenicities': ('pathogenicity', 'variant'),
-        'associatedInterpretations': ('interpretation', 'variant')
+        'associatedInterpretations': ('interpretation', 'variant'),
+        'experimental_associated': ('experimental', 'variants')
     }
 
     @calculated_property(schema={
@@ -153,16 +156,28 @@ class Variant(Item):
         return paths_filtered_by_status(request, associatedInterpretations)
 
     @calculated_property(schema={
+        "title": "Experimental Associated",
+        "type": "array",
+        "items": {
+            "type": ['string', 'object'],
+            "linkFrom": "experimental.variants",
+        },
+    })
+    def experimental_associated(self, request, experimental_associated):
+        return paths_filtered_by_status(request, experimental_associated)
+
+
+    @calculated_property(schema={
         "title": "Variant Representation",
         "type": "string"
     })
     def variant_identifier(self, clinvarVariantId='', carId='', otherDescription=''):
         if clinvarVariantId != '':
-            return clinvarVariantId
+            return "ClinVar Variation ID: " + clinvarVariantId
         elif carId != '':
-            return carId
+            return "CAR ID: " + carId
         elif otherDescription != '':
-            return otherDescription
+            return "Other Description: " + otherDescription
         else:
             return ''
 
@@ -786,6 +801,20 @@ class Experimental(Item):
     def associatedAnnotations(self, request, associatedAnnotations):
         return paths_filtered_by_status(request, associatedAnnotations)
 
+    @calculated_property(schema={
+        "title": "# Assessments",
+        "type": "number"
+    })
+    def assessment_count(self, assessments=[]):
+        return len(assessments)
+
+    @calculated_property(schema={
+        "title": "# Variants",
+        "type": "number"
+    })
+    def variant_count(self, variants=[]):
+        return len(variants)
+
 
 @collection(
     name='pathogenicity',
@@ -1024,38 +1053,30 @@ class Interpretation(Item):
 
     @calculated_property(schema={
         "title": "Transcripts",
-        "type": "string",
+        "type": "number",
     })
     def interpretation_transcripts(self, transcripts=[]):
-        if len(transcripts) == 0:
-            return ''
         return len(transcripts)
 
     @calculated_property(schema={
         "title": "Proteins",
-        "type": "string",
+        "type": "number",
     })
     def interpretation_proteins(self, proteins=[]):
-        if len(proteins) == 0:
-            return ''
         return len(proteins)
 
     @calculated_property(schema={
         "title": "Evaluations",
-        "type": "string",
+        "type": "number",
     })
     def evaluation_count(self, evaluations=[]):
-        if len(evaluations) == 0:
-            return ''
         return len(evaluations)
 
     @calculated_property(schema={
         "title": "Provisionals",
-        "type": "string",
+        "type": "number",
     })
     def provisional_count(self, provisional_variant=[]):
-        if len(provisional_variant) == 0:
-            return ''
         return len(provisional_variant)
 
 
@@ -1064,7 +1085,7 @@ class Interpretation(Item):
     unique_key='evaluation:uuid',
     properties={
         'title': 'Evaluations',
-        'description': 'Listing of Evaluations',
+        'description': 'List of Evaluations',
     })
 class Evaluation(Item):
     item_type = 'evaluation'
@@ -1077,7 +1098,9 @@ class Evaluation(Item):
         'variant.associatedInterpretations.submitted_by',
         'disease',
         'population',
+        'population.evaluation_associated',
         'computational',
+        'computational.evaluation_associated',
         'interpretation_associated'
     ]
     rev = {
@@ -1114,7 +1137,7 @@ class Evaluation(Item):
     unique_key='population:uuid',
     properties={
         'title': 'Populations',
-        'description': 'Listing of Populations',
+        'description': 'List of Population Evidence',
     })
 class Population(Item):
     item_type = 'population'
@@ -1148,6 +1171,18 @@ class Population(Item):
     def maf_count(self, populationData={}):
         return len(populationData)
 
+    @calculated_property(schema={
+        "title": "Criteria Met",
+        "type": "string"
+    })
+    def criteria_list(self, request, evaluation_associated=[]):
+        if len(evaluation_associated) > 0:
+            c_list = []
+            for evaluation in evaluation_associated:
+                e_obj = request.embed(evaluation, '@@object')
+                c_list.append(e_obj['criteria'] + ': ' + e_obj['value'])
+            return '; '.join(c_list)
+        return ''
 
 @collection(
     name='computational',
@@ -1162,12 +1197,10 @@ class Computational(Item):
     name_key = 'uuid'
     embedded = [
         'variant',
-        'disease',
         'variant.associatedInterpretations',
         'variant.associatedInterpretations.submitted_by',
         'evaluation_associated',
-        'evaluation_associated.interpretation_associated',
-        'evaluation_associated.interpretation_associated.disease'
+        'evaluation_associated.interpretation_associated'
     ]
     rev = {
         'evaluation_associated': ('evaluation', 'computational')
@@ -1182,13 +1215,16 @@ class Computational(Item):
         return paths_filtered_by_status(request, evaluation_associated)
 
     @calculated_property(schema={
-        "title": "Disease",
+        "title": "Criteria Met",
         "type": "string"
     })
-    def disease_present(self, request, disease=''):
-        if disease != '':
-            diseaseObj = request.embed(disease, '@@object')
-            return diseaseObj['term']
+    def criteria_list(self, request, evaluation_associated=[]):
+        if len(evaluation_associated) > 0:
+            c_list = []
+            for evaluation in evaluation_associated:
+                e_obj = request.embed(evaluation, '@@object')
+                c_list.append(e_obj['criteria'] + ': ' + e_obj['value'])
+            return '; '.join(c_list)
         return ''
 
 


### PR DESCRIPTION
**Changes** in file `src/clincoded/types/__init__.py`
1. Added a calculated property "experimental_associated" in class variant. It functions as a reverse link to embed experimental data to variant.
2. At line 175, 177 and 179, added a string to clarify source of variant in each return.

**Changes in Test Data** in dir `src/clincoded/tests/data/inserts/`
1. Edited file `experimental.json` to test the reverse link.
2. Added ClinVar preferred name to variant 55847. It is missed currently.

**Other Change**
Generated new dump files

**View Test Data**
[http://localhost:6543/variants/df8135d4-2685-11e5-af19-60f81dc5b05a/](http://localhost:6543/variants/df8135d4-2685-11e5-af19-60f81dc5b05a/), expect to see 3 experimental objects embedded in "experimental_associated" and PMID in field "associatedAnnotations.article" in each experimental