### PR TITLE
Connects to #700. Connects to #742. Add Variant ID display to VCI modal results. Fix console errors.

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -31,7 +31,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
     mixins: [ModalMixin],
     propTypes: {
         resourceType: React.PropTypes.string, // specify what the resource you're trying to add is (passed to Modal)
-        label: React.PropTypes.string, // text for the button's label
+        label: React.PropTypes.object, // html for the button's label
         labelVisible: React.PropTypes.bool, // specify whether or not the label is visible
         buttonText: React.PropTypes.string, // text for the button
         clearButtonText: React.PropTypes.string, // text for clear button
@@ -106,7 +106,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
         } else {
             return (
                 <div className="form-group">
-                    <span className="col-sm-5 control-label">{this.props.labelVisible ? <label>{this.props.label}</label> : null}</span>
+                    <span className="col-sm-5 control-label">{this.props.labelVisible ? this.props.label : null}</span>
                     <span className="col-sm-7">
                         <div className={"inline-button-wrapper button-push" + (this.props.wrapperClass ? " " + this.props.wrapperClass : "")}>
                             {this.buttonRender()}
@@ -378,6 +378,10 @@ function clinvarRenderResourceResult() {
             <span className="p-break">{this.state.tempResource.clinvarVariantTitle}</span>
             {this.state.tempResource && this.state.tempResource.hgvsNames ?
                 <div className="row">
+                    <div className="row">
+                        <span className="col-sm-5 col-md-3 control-label"><label>ClinVar Variant ID</label></span>
+                        <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                    </div>
                     {this.state.tempResource.hgvsNames.others && this.state.tempResource.hgvsNames.others.length > 0 ?
                         <div className="row">
                             <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>
@@ -523,6 +527,16 @@ function carRenderResourceResult() {
             <span className="p-break">{this.state.tempResource.clinvarVariantTitle}</span>
             {this.state.tempResource && this.state.tempResource.hgvsNames ?
                 <div className="row">
+                    <div className="row">
+                        <span className="col-sm-5 col-md-3 control-label"><label>CA ID</label></span>
+                        <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong> <i className="icon icon-external-link"></i></a></span>
+                    </div>
+                    {this.state.tempResource.clinvarVariantId ?
+                        <div className="row">
+                            <span className="col-sm-5 col-md-3 control-label"><label>ClinVar Variant ID</label></span>
+                            <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                        </div>
+                    : null}
                     {this.state.tempResource.hgvsNames.others && this.state.tempResource.hgvsNames.others.length > 0 ?
                         <div className="row">
                             <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -91,14 +91,14 @@ var SelectVariant = React.createClass({
                             : null}
                             {this.state.variantIdType == "ClinVar Variation ID" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="clinvar" label="ClinVar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
+                                <AddResourceId resourceType="clinvar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
                                     buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
                                     modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                             {this.state.variantIdType == "ClinGen Allele Registry ID (CA ID)" ?
                             <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="car" label="ClinGen Allele Registry" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
+                                <AddResourceId resourceType="car" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
                                     buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
                                     modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>

--- a/src/clincoded/static/scss/fontawesome/_icons.scss
+++ b/src/clincoded/static/scss/fontawesome/_icons.scss
@@ -146,7 +146,7 @@
 //.#{$fa-css-prefix}-sign-out:before { content: $fa-var-sign-out; }
 //.#{$fa-css-prefix}-linkedin-square:before { content: $fa-var-linkedin-square; }
 //.#{$fa-css-prefix}-thumb-tack:before { content: $fa-var-thumb-tack; }
-//.#{$fa-css-prefix}-external-link:before { content: $fa-var-external-link; }
+.#{$fa-css-prefix}-external-link:before { content: $fa-var-external-link; }
 //.#{$fa-css-prefix}-sign-in:before { content: $fa-var-sign-in; }
 //.#{$fa-css-prefix}-trophy:before { content: $fa-var-trophy; }
 //.#{$fa-css-prefix}-github-square:before { content: $fa-var-github-square; }


### PR DESCRIPTION
#### Connects to #700:

ClinVar modal:
![image](https://cloud.githubusercontent.com/assets/4326866/16468179/7aad01c0-3dff-11e6-9b21-63afc3679a5e.png)

CAR modal with ClinVar data:
![image](https://cloud.githubusercontent.com/assets/4326866/16468212/9bf843e4-3dff-11e6-91bd-5966b3d857e8.png)

CAR modal with no ClinVar data:
![image](https://cloud.githubusercontent.com/assets/4326866/16468229/b4907624-3dff-11e6-96a1-bf1e564e7235.png)

Testing:

1. Add variant via VCI, via both ClinVar and CA IDs
2. Check that ClinVar and/or CA IDs display and link out properly

#### Connects to #742:

Testing:

1. Load select variant page in VCI and check console logs
2. Load Family/Individual/Experimental curation pages and check console logs