### PR TITLE
Connects #741 kl Bug associate variant

### DIFF
--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1030,7 +1030,8 @@ var ExperimentalCuration = React.createClass({
                             results.forEach(function(result, i) {
                                 if (result.total) {
                                     // Search got a result. Add a string for experimentalData.variants for this existing variant
-                                    experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                    experimentalDataVariants.push(result['@graph'][0]['@id']);
+                                    //experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 } else {
                                     // Search got no result; make a new variant and save it in an array so we can write them.
                                     // Look for the term in the filters to see what term failed to find a match
@@ -1079,7 +1080,8 @@ var ExperimentalCuration = React.createClass({
 
                                 // Add the newly written variants to the experimental data
                                 results.forEach(result => {
-                                    experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                    experimentalDataVariants.push(result['@graph'][0]['@id']);
+                                    //experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 });
                             }
                             return Promise.resolve(results);

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1031,7 +1031,6 @@ var ExperimentalCuration = React.createClass({
                                 if (result.total) {
                                     // Search got a result. Add a string for experimentalData.variants for this existing variant
                                     experimentalDataVariants.push(result['@graph'][0]['@id']);
-                                    //experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 } else {
                                     // Search got no result; make a new variant and save it in an array so we can write them.
                                     // Look for the term in the filters to see what term failed to find a match
@@ -1081,7 +1080,6 @@ var ExperimentalCuration = React.createClass({
                                 // Add the newly written variants to the experimental data
                                 results.forEach(result => {
                                     experimentalDataVariants.push(result['@graph'][0]['@id']);
-                                    //experimentalDataVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 });
                             }
                             return Promise.resolve(results);

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -682,7 +682,8 @@ var FamilyCuration = React.createClass({
                             results.forEach(function(result, i) {
                                 if (result.total) {
                                     // Search got a result. Add a string for family.variants for this existing variant
-                                    familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                    familyVariants.push(result['@graph'][0]['@id']);
+                                    //familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 } else {
                                     // Search got no result; make a new variant and save it in an array so we can write them.
                                     // Look for the term in the filters to see what term failed to find a match
@@ -731,7 +732,8 @@ var FamilyCuration = React.createClass({
 
                                 // Add the newly written variants to the family
                                 results.forEach(result => {
-                                    familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                    familyVariants.push(result['@graph'][0]['@id']);
+                                    //familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 });
                             }
                             return Promise.resolve(results);

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -683,7 +683,6 @@ var FamilyCuration = React.createClass({
                                 if (result.total) {
                                     // Search got a result. Add a string for family.variants for this existing variant
                                     familyVariants.push(result['@graph'][0]['@id']);
-                                    //familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 } else {
                                     // Search got no result; make a new variant and save it in an array so we can write them.
                                     // Look for the term in the filters to see what term failed to find a match
@@ -733,7 +732,6 @@ var FamilyCuration = React.createClass({
                                 // Add the newly written variants to the family
                                 results.forEach(result => {
                                     familyVariants.push(result['@graph'][0]['@id']);
-                                    //familyVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                 });
                             }
                             return Promise.resolve(results);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -511,7 +511,8 @@ var IndividualCuration = React.createClass({
                                 results.forEach(function(result, i) {
                                     if (result.total) {
                                         // Search got a result. Add a string for family.variants for this existing variant
-                                        individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                        individualVariants.push(result['@graph'][0]['@id']);
+                                        //individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                     } else {
                                         // Search got no result; make a new variant and save it in an array so we can write them.
                                         var termResult = _(result.filters).find(function(filter) { return filter.field === 'clinvarVariantId'; });
@@ -567,7 +568,8 @@ var IndividualCuration = React.createClass({
 
                                     // Add the newly written variants to the family
                                     results.forEach(result => {
-                                        individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
+                                        individualVariants.push(result['@graph'][0]['@id']);
+                                        //individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                     });
                                 }
                                 return Promise.resolve(results);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -512,7 +512,6 @@ var IndividualCuration = React.createClass({
                                     if (result.total) {
                                         // Search got a result. Add a string for family.variants for this existing variant
                                         individualVariants.push(result['@graph'][0]['@id']);
-                                        //individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                     } else {
                                         // Search got no result; make a new variant and save it in an array so we can write them.
                                         var termResult = _(result.filters).find(function(filter) { return filter.field === 'clinvarVariantId'; });
@@ -569,7 +568,6 @@ var IndividualCuration = React.createClass({
                                     // Add the newly written variants to the family
                                     results.forEach(result => {
                                         individualVariants.push(result['@graph'][0]['@id']);
-                                        //individualVariants.push('/variants/' + result['@graph'][0].uuid + '/');
                                     });
                                 }
                                 return Promise.resolve(results);


### PR DESCRIPTION
**Changes** in dir `src/clincoded/static/components/`
Replaced "uuid" with "@id" to get variant object in files `family_curation.js`, `individual_curation.js` and `experimental_curation.js`

No changes in schema and test data.

**Test Steps**
1. Create a GDM,
2. Add a PMID (any one, e.g. 123),
3. Add a new experimental (Expression, B Altered Expression in Patients), and associate a variant (e.g. ClinVar ID 12345) and click Save. Expect to see an experimental object added successfully.
4. Edit the experimental, associate another variant (e.g. 12346) and click Save. Expect to see the second variant associated to the experimental.
5. Add a family, enter ORPHA number (e.g. ORPHA15), associate a variant (e.g. 55962), enter a proband individual label and ORPHA number, and click Save. Expect to see a family object saved successfully.
6. Add an individual, select No to proband, associate a variant (e.g. 139214) and click Save. Expect to see an individual object saved successfully.