### PR TITLE
Connects to #731. Basic Info tab update.

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -62,7 +62,7 @@ var VariantCurationHub = React.createClass({
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
                 <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
-                    href_url={this.props.href_url} loadingComplete={isLoadingComplete} updateInterpretationObj={this.updateInterpretationObj} />
+                    href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -39,7 +39,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     propTypes: {
         variantData: React.PropTypes.object, // ClinVar data payload
         interpretation: React.PropTypes.object,
-        loadingComplete: React.PropTypes.bool,
         href_url: React.PropTypes.object,
         updateInterpretationObj: React.PropTypes.func
     },
@@ -63,7 +62,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     render: function() {
         var variant = this.props.variantData;
         var interpretation = this.props.interpretation;
-        var loadingComplete = this.props.loadingComplete;
 
         // The ordering of TabPanels are corresponding to that of tabs
         // Adding or deleting a tab also requires its corresponding TabPanel to be added/deleted

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -80,37 +80,37 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                     </TabList>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationBasicInfo data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationBasicInfo data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationPopulation data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationPopulation data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationComputational data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationComputational data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationFunctional data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationFunctional data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationSegregation data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationSegregation data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>
                     <TabPanel>
                         <div className="tab-panel">
-                            <CurationInterpretationGeneSpecific data={variant} shouldFetchData={loadingComplete} protocol={this.props.href_url.protocol}
+                            <CurationInterpretationGeneSpecific data={variant} protocol={this.props.href_url.protocol}
                                 interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </TabPanel>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -41,8 +41,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     componentWillReceiveProps: function(nextProps) {
-        this.setState({shouldFetchData: nextProps.shouldFetchData});
-        if (this.state.shouldFetchData === true) {
+        if (nextProps.data || this.props.data) {
             window.localStorage.clear();
             this.fetchRefseqData();
             this.fetchEnsemblData();

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -56,7 +56,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             hasRefseqData: false,
             hasEnsemblData: false
         });
-        window.localStorage.clear();
     },
 
     // Retrieve the variant data from NCBI REST API
@@ -180,11 +179,15 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     // Used to construct LinkOut URL to Uniprot
     getUniprotId: function(gene_symbol) {
         if (gene_symbol) {
+            // FIXME: Use hardcoded uniprot id for now until we find an alternate API to address SSL issue
+            /*
             this.getRestData(this.props.protocol + external_url_map['HGNCFetch'] + gene_symbol).then(result => {
                 this.setState({uniprot_id: result.response.docs[0].uniprot_ids[0]});
             }).catch(function(e) {
                 console.log('HGNC Fetch Error=: %o', e);
             });
+            */
+            this.setState({uniprot_id: 'P38398'});
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -17,7 +17,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
-        shouldFetchData: React.PropTypes.bool,
         protocol: React.PropTypes.string
     },
 
@@ -35,8 +34,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             hgvs_GRCh37: null,
             hgvs_GRCh38: null,
             gene_symbol: null,
-            uniprot_id: null,
-            shouldFetchData: false
+            uniprot_id: null
         };
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -20,7 +20,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
         interpretation: React.PropTypes.object,
-        shouldFetchData: React.PropTypes.bool,
         updateInterpretationObj: React.PropTypes.func,
         protocol: React.PropTypes.string
     },

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -43,7 +43,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
         interpretation: React.PropTypes.object,
-        shouldFetchData: React.PropTypes.bool,
         updateInterpretationObj: React.PropTypes.func,
         protocol: React.PropTypes.string
     },
@@ -59,7 +58,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             hasExacData: false, // flag to display ExAC table
             hasTGenomesData: false,
             hasEspData: false, // flag to display ESP table
-            shouldFetchData: false,
             populationObj: {
                 exac: {
                     afr: {}, amr: {}, eas: {}, fin: {}, nfe: {}, oth: {}, sas: {}, _tot: {}, _extra: {}
@@ -87,20 +85,26 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     componentDidMount: function() {
         this.setState({interpretation: this.props.interpretation});
-        if (this.props.data) {
-            this.setState({shouldFetchData: true});
-            this.fetchMyVariantInfo();
-            this.fetchEnsemblData();
-        }
     },
 
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretation: nextProps.interpretation});
-        if (this.state.shouldFetchData === false && nextProps.shouldFetchData === true) {
-            this.setState({shouldFetchData: true});
-            this.fetchMyVariantInfo();
-            this.fetchEnsemblData();
+        if (nextProps.data && this.props.data) {
+            if (!this.state.hasExacData || !this.state.hasEspData) {
+                this.fetchMyVariantInfo();
+            }
+            if (!this.state.hasTGenomesData) {
+                this.fetchEnsemblData();
+            }
         }
+    },
+
+    componentWillUnmount: function() {
+        this.setState({
+            hasExacData: false,
+            hasTGenomesData: false,
+            hasEspData: false
+        });
     },
 
     // Retrieve ExAC population data from myvariant.info


### PR DESCRIPTION
This PR consists of changes pertinent to addressing data not being displayed on the Basic Info tab initially upon the user navigating from the variant selection page.

**Known issues:**
1. In the related ticket #731, the intent is to address the looping of page reloads when the user deliberately refreshes the VCI hub page repeatedly. What has been discovered is that, if the time between each page refresh is longer than 2-3 minutes, the looping does not incur. The looping issue, which incurs when the page is refreshed within a few seconds after the prior refresh, is suspected to be pertinent to external API calls that needed time to complete. Due to shifting priority to the implementation of "static" evidence criteria bar (above the tabs) for the VCI interface, this looping issue will be revisited at a later time.
2. In the same related ticket, an "Uncaught Invariant Violation" error has also surfaced and appears to **alarm** that the server-rendered markup differs from client-rendered markup. However, it does not appear to affect the page rendering visible to the users. Again, due to shifting priority to the implementation of "static" evidence criteria bar (above the tabs) for the VCI interface, this looping issue will be revisited at a later time.

**Technical notes:**
1. Updated the lifecycle methods in the `basic_info.js` so that this default tab displays variant data when the user initially navigates to the VCI hub page upon selecting a ClinVar id.
2. Temporarily hardcoded the `uniprot_id` and commented out the original HGNC API call that results in network error due to its lack of https support.
3. Removed the dependency of `shouldFetchData` and `loadingComplete` props and states throughout various components as these flags are no longer needed.

**Steps to test this PR:**
1. Login and go to http://localhost:6543/select-variant/.
2. Add a ClinVar variation ID - 139214.
3. Upon arriving at the default Basic Info tab initially, expect to see data being displayed in the 2 tables.
4. At the bottom of the Basic Info tab, clicking on the `UniProtKB` link and expect to see the http://www.uniprot.org/uniprot/P38398 page as a result of the hardcoded `P38398` id.