### PR TITLE
Connects to #744 kl load interpretation, evaluation, population and computational

### DIFF
--- a/src/clincoded/schemas/computational.json
+++ b/src/clincoded/schemas/computational.json
@@ -35,7 +35,7 @@
         }
     },
     "columns": {
-        "variant.represent": {
+        "variant.variant_identifier": {
             "title": "Variant",
             "type": "string"
         },

--- a/src/clincoded/schemas/evaluation.json
+++ b/src/clincoded/schemas/evaluation.json
@@ -68,7 +68,7 @@
         }
     },
     "columns": {
-        "variant.represent": {
+        "variant.variant_identifier": {
             "title": "Variant",
             "type": "string"
         },

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -96,29 +96,21 @@
             "title": "Interpretation Status",
             "type": "string"
         },
+        "interpretation_genes": {
+            "title": "Genes",
+            "type": "string"
+        },
         "interpretation_disease": {
             "title": "Disease",
             "type": "string"
         },
         "evaluation_count": {
             "title": "# Evaluations",
-            "type": "string"
+            "type": "number"
         },
         "provisional_count": {
             "title": "# Provisional",
-            "type": "string"
-        },
-        "interpretation_genes": {
-            "title": "Genes",
-            "type": "string"
-        },
-        "interpretation_transcripts": {
-            "title": "# Transcripts",
-            "type": "string"
-        },
-        "interpretation_proteins": {
-            "title": "# Proteins",
-            "type": "string"
+            "type": "number"
         },
         "submitted_by.title": {
             "title": "Creator",

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -89,7 +89,11 @@
     },
     "columns": {
         "variant.variant_identifier": {
-            "title": "Variant",
+            "title": "Variant ID",
+            "type": "string"
+        },
+        "variant.source": {
+            "title": "Variant Source",
             "type": "string"
         },
         "interpretation_status": {

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -88,7 +88,7 @@
         }
     },
     "columns": {
-        "variant.represent": {
+        "variant.variant_identifier": {
             "title": "Variant",
             "type": "string"
         },

--- a/src/clincoded/schemas/population.json
+++ b/src/clincoded/schemas/population.json
@@ -30,7 +30,7 @@
         }
     },
     "columns": {
-        "variant.represent": {
+        "variant.variant_identifier": {
             "title": "Variant",
             "type": "string"
         },

--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -107,7 +107,7 @@
     },
     "columns": {
         "variant_identifier": {
-            "title": "Variant ID",
+            "title": "Variant",
             "type": "string"
         },
         "source": {

--- a/src/clincoded/schemas/variant.json
+++ b/src/clincoded/schemas/variant.json
@@ -107,7 +107,7 @@
     },
     "columns": {
         "variant_identifier": {
-            "title": "Variant",
+            "title": "Variant ID",
             "type": "string"
         },
         "source": {

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -1022,9 +1022,6 @@ class Interpretation(Item):
             return genes[0][7:-1]
         return ''
 
-    def interpretation_proteins(self, proteins=[]):
-        return len(proteins)
-
     @calculated_property(schema={
         "title": "Evaluations",
         "type": "number",

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -158,11 +158,11 @@ class Variant(Item):
     })
     def variant_identifier(self, clinvarVariantId='', carId='', otherDescription=''):
         if clinvarVariantId != '':
-            return 'ClinVar ID: ' + clinvarVariantId
+            return clinvarVariantId
         elif carId != '':
-            return 'CAR ID: ' + carId
+            return carId
         elif otherDescription != '':
-            return 'Other Description: ' + otherDescription
+            return otherDescription
         else:
             return ''
 

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -153,7 +153,7 @@ class Variant(Item):
         return paths_filtered_by_status(request, associatedInterpretations)
 
     @calculated_property(schema={
-        "title": "Variant Identifier",
+        "title": "Variant ID",
         "type": "string"
     })
     def variant_identifier(self, clinvarVariantId='', carId='', otherDescription=''):

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -1022,40 +1022,21 @@ class Interpretation(Item):
             return genes[0][7:-1]
         return ''
 
-    @calculated_property(schema={
-        "title": "Transcripts",
-        "type": "string",
-    })
-    def interpretation_transcripts(self, transcripts=[]):
-        if len(transcripts) == 0:
-            return ''
-        return len(transcripts)
-
-    @calculated_property(schema={
-        "title": "Proteins",
-        "type": "string",
-    })
     def interpretation_proteins(self, proteins=[]):
-        if len(proteins) == 0:
-            return ''
         return len(proteins)
 
     @calculated_property(schema={
         "title": "Evaluations",
-        "type": "string",
+        "type": "number",
     })
     def evaluation_count(self, evaluations=[]):
-        if len(evaluations) == 0:
-            return ''
         return len(evaluations)
 
     @calculated_property(schema={
         "title": "Provisionals",
-        "type": "string",
+        "type": "number",
     })
     def provisional_count(self, provisional_variant=[]):
-        if len(provisional_variant) == 0:
-            return ''
         return len(provisional_variant)
 
 

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -153,16 +153,16 @@ class Variant(Item):
         return paths_filtered_by_status(request, associatedInterpretations)
 
     @calculated_property(schema={
-        "title": "Variant Representation",
+        "title": "Variant Identifier",
         "type": "string"
     })
     def variant_identifier(self, clinvarVariantId='', carId='', otherDescription=''):
         if clinvarVariantId != '':
-            return clinvarVariantId
+            return 'ClinVar ID: ' + clinvarVariantId
         elif carId != '':
-            return carId
+            return 'CAR ID: ' + carId
         elif otherDescription != '':
-            return otherDescription
+            return 'Other Description: ' + otherDescription
         else:
             return ''
 


### PR DESCRIPTION
This PR corrects errors issued in ticket #744, including failed to display interpretation/evaluation/population/computational objects, wrong type of a couple of properties and unnecessary calculated properties.

**Changes in schema Files** in dir `src/clincoded/schemas/`
1. Replaced columns property "variant.represent" with "variant.variant_identifier" in file `computational.json`, `evaluation.json`, `interpretation.json` and `population.json`.
2. Added columns property "variant.source" and changed type of columns properties "evaluation_count" and "provisional_count" to number in file `interpretation.json`.

**Changes in File** `src/clincoded/types/__init__.py`
1. Edited calculated properties "Evaluations", "Provisionals" and their functions to match the changes in schema files.
2. Removed calculated properties "Transcripts ", "Proteins" and their functions in class Interpretation. They were built for test before.

**Test**
[http://localhost:6543/interpretations/](http://localhost:6543/interpretations/) to view interpretation
[http://localhost:6543/evaluations/](http://localhost:6543/evaluations/) to view evaluation
[http://localhost:6543/populations/](http://localhost:6543/populations/) to view population
[http://localhost:6543/computational/](http://localhost:6543/computational/) to view computational