### PR TITLE
Connects to #749. Static criteria bar for test alpha release.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -16,6 +16,7 @@ var TabPanel = ReactTabs.TabPanel;
 Tabs.setUseDefaultStyles(false);
 
 // Import individual tab components
+var CurationInterpretationCriteria = require('./interpretation/criteria').CurationInterpretationCriteria;
 var CurationInterpretationBasicInfo = require('./interpretation/basic_info').CurationInterpretationBasicInfo;
 var CurationInterpretationPopulation = require('./interpretation/population').CurationInterpretationPopulation;
 var CurationInterpretationComputational = require('./interpretation/computational').CurationInterpretationComputational;
@@ -69,6 +70,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         // Adding or deleting a tab also requires its corresponding TabPanel to be added/deleted
         return (
             <div className="container curation-variant-tab-group">
+                <CurationInterpretationCriteria interpretation={interpretation} />
                 <Tabs onSelect={this.handleSelect} selectedIndex={this.state.selectedTab} forceRenderTabPanel={true}>
                     <TabList className="tab-label-list">
                         <Tab className="tab-label col-sm-2">Basic Information</Tab>

--- a/src/clincoded/static/components/variant_central/interpretation/criteria.js
+++ b/src/clincoded/static/components/variant_central/interpretation/criteria.js
@@ -24,22 +24,38 @@ var CurationInterpretationCriteria = module.exports.CurationInterpretationCriter
     	}
     },
 
-    handleCriteria: function() {
-    	var criteria;
-    	for (let n of evidenceCodes) {
-
-    	}
+    // FIXME: fake data attribute to flag criteria that can be evaluated but not yet evaluated
+    // after associating a disease with interpretation.
+    // Shall be removed when actual functionality is implemented.
+    handleCriteria: function(criteria_code) {
+		var status;
+		var evaluated = ["BS1", "BS2", "BP1", "BP3", "BP7", "PP3", "PM2", "PM4", "PM5", "PS1", "PS4"];
+		var not_evaluated = ["BS3", "BS4", "BP2", "BP4", "PP1", "PP2", "PM1", "PS3"];
+		for (let x of evaluated) {
+			if (x === criteria_code) {
+				status = "evaluated";
+			}
+		}
+		for (let y of not_evaluated) {
+			if (y === criteria_code) {
+				status = "not_evaluated";
+			}
+		}
+		return status;
     },
 
 	render: function() {
+		var self =this;
+
         return (
             <div className="curation-criteria curation-variant">
             	{(this.state.interpretation) ?
             		<div className="criteria-bar btn-toolbar" role="toolbar" aria-label="Criteria bar with code buttons">
             			<div className="criteria-group btn-group btn-group-sm" role="group" aria-label="Criteria code button group">
+							{/* FIXME: Remove 'data-status' attribute when actual functionality is implemented to handle 'met' criteria */}
             				{evidenceCodes.map(function(evidence, i) {
             					return (
-                                    <button type="button" className={'btn btn-default ' + evidence.class} key={i}
+                                    <button type="button" className={'btn btn-default ' + evidence.class} key={i} data-status={self.handleCriteria(evidence.code)}
                                     	data-toggle="tooltip" data-placement="top" data-tooltip={evidence.definition}>
                                         <span>{evidence.code}</span>
                                     </button>

--- a/src/clincoded/static/components/variant_central/interpretation/criteria.js
+++ b/src/clincoded/static/components/variant_central/interpretation/criteria.js
@@ -1,0 +1,54 @@
+'use strict';
+var React = require('react');
+var globals = require('../../globals');
+var evidenceCodes = require('./mapping/evidence_code.json');
+
+var queryKeyValue = globals.queryKeyValue;
+var editQueryValue = globals.editQueryValue;
+
+// Display met criteria
+var CurationInterpretationCriteria = module.exports.CurationInterpretationCriteria = React.createClass({
+	propTypes: {
+        interpretation: React.PropTypes.object
+    },
+
+    getInitialState: function() {
+        return {
+            interpretation: this.props.interpretation
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+    	if (nextProps.interpretation && this.props.interpretation) {
+    		this.setState({interpretation: nextProps.interpretation});
+    	}
+    },
+
+    handleCriteria: function() {
+    	var criteria;
+    	for (let n of evidenceCodes) {
+
+    	}
+    },
+
+	render: function() {
+        return (
+            <div className="curation-criteria curation-variant">
+            	{(this.state.interpretation) ?
+            		<div className="criteria-bar btn-toolbar" role="toolbar" aria-label="Criteria bar with code buttons">
+            			<div className="criteria-group btn-group btn-group-sm" role="group" aria-label="Criteria code button group">
+            				{evidenceCodes.map(function(evidence, i) {
+            					return (
+                                    <button type="button" className={'btn btn-default ' + evidence.class} key={i}
+                                    	data-toggle="tooltip" data-placement="top" data-tooltip={evidence.definition}>
+                                        <span>{evidence.code}</span>
+                                    </button>
+                                );
+            				})}
+            			</div>
+            		</div>
+            	: null}
+            </div>
+        );
+    }
+});

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -1,0 +1,137 @@
+[
+  {
+    "code": "BS1",
+    "class": "benign-strong",
+    "definition": "MAF is too high for disorder"
+  },
+  {
+    "code": "BS2",
+    "class": "benign-strong",
+    "definition": "Observation in controls inconsistent with disease penetrance"
+  },
+  {
+    "code": "BS3",
+    "class": "benign-strong",
+    "definition": "Well-established functional studies show no deleterious effect"
+  },
+  {
+    "code": "BS4",
+    "class": "benign-strong",
+    "definition": "Nonsegregation with disease"
+  },
+  {
+    "code": "BP1",
+    "class": "benign-supporting",
+    "definition": "Missense in gene where only truncating cause disease"
+  },
+  {
+    "code": "BP2",
+    "class": "benign-supporting",
+    "definition": "Observed in trans with a dominant variant"
+  },
+  {
+    "code": "BP3",
+    "class": "benign-supporting",
+    "definition": "In-frame indels in repeat w/out known function"
+  },
+  {
+    "code": "BP4",
+    "class": "benign-supporting",
+    "definition": "Multiple lines of computational evidence suggest no impact on gene /gene product"
+  },
+  {
+    "code": "BP5",
+    "class": "benign-supporting",
+    "definition": "Found in case with an alternate cause"
+  },
+  {
+    "code": "BP6",
+    "class": "benign-supporting",
+    "definition": "Reputable source w/out shared data = benign"
+  },
+  {
+    "code": "BP7",
+    "class": "benign-supporting",
+    "definition": "Silent variant with non predicted splice impact"
+  },
+  {
+    "code": "PP1",
+    "class": "pathogenic-supporting",
+    "definition": "Cosegregation with disease in multiple affected family members"
+  },
+  {
+    "code": "PP2",
+    "class": "pathogenic-supporting",
+    "definition": "Missense in gene with low rate of benign missense variants and path. missenses common"
+  },
+  {
+    "code": "PP3",
+    "class": "pathogenic-supporting",
+    "definition": "Multiple lines of computational evidence support a deleterious effect on the gene /gene product"
+  },
+  {
+    "code": "PP4",
+    "class": "pathogenic-supporting",
+    "definition": "Patient's phenotype or FH highly specific for gene"
+  },
+  {
+    "code": "PP5",
+    "class": "pathogenic-supporting",
+    "definition": "Reputable source = pathogenic"
+  },
+  {
+    "code": "PM1",
+    "class": "pathogenic-moderate",
+    "definition": "Mutational hot spot or well-studied functional domain without benign variation"
+  },
+  {
+    "code": "PM2",
+    "class": "pathogenic-moderate",
+    "definition": "Absent in population databases"
+  },
+  {
+    "code": "PM3",
+    "class": "pathogenic-moderate",
+    "definition": "For recessive disorders, detected in trans with a pathogenic variant"
+  },
+  {
+    "code": "PM4",
+    "class": "pathogenic-moderate",
+    "definition": "Protein length changing variant"
+  },
+  {
+    "code": "PM5",
+    "class": "pathogenic-moderate",
+    "definition": "Novel missense change at an amino acid residue where a different pathogenic missense change has been seen before"
+  },
+  {
+    "code": "PM6",
+    "class": "pathogenic-moderate",
+    "definition": "De novo (without paternity & maternity confirmed)"
+  },
+  {
+    "code": "PS1",
+    "class": "pathogenic-strong",
+    "definition": "Same amino acid change as an established pathogenic variant"
+  },
+  {
+    "code": "PS2",
+    "class": "pathogenic-strong",
+    "definition": "De novo (paternity and maternity confirmed)"
+  },
+  {
+    "code": "PS3",
+    "class": "pathogenic-strong",
+    "definition": "Well-established functional studies show a deleterious effect"
+  },
+  {
+    "code": "PS4",
+    "class": "pathogenic-strong",
+    "definition": "Prevalence in affecteds statistically increased over controls"
+  },
+  {
+    "code": "PVS1",
+    "class": "pathogenic-very-strong",
+    "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease"
+  }
+]

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1223,7 +1223,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     background-color: #ddd;
     color: #555;
     cursor: default;
-    padding: 5px 0.745em;
+    padding: 5px 0.725em;
+    font-weight: bold;
 
     &.benign-strong[data-status='evaluated'] {
         background-color: #62387e;
@@ -1231,8 +1232,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     }
 
     &.benign-strong[data-status='not_evaluated'] {
-        background-color: lighten(#62387e, 30%);
-        color: #fff;
+        background-color: #fff;
+        color: #62387e;
     }
 
     &.benign-supporting[data-status='evaluated'] {
@@ -1241,8 +1242,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     }
 
     &.benign-supporting[data-status='not_evaluated'] {
-        background-color: lighten(#2b67a0, 30%);
-        color: #fff;
+        background-color: #fff;
+        color: #2b67a0;
     }
 
     &.pathogenic-supporting[data-status='evaluated']  {
@@ -1251,8 +1252,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     }
 
     &.pathogenic-supporting[data-status='not_evaluated']  {
-        background-color: lighten(#728b42, 30%);
-        color: #fff;
+        background-color: #fff;
+        color: #728b42;
     }
 
     &.pathogenic-moderate[data-status='evaluated'] {
@@ -1261,8 +1262,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     }
 
     &.pathogenic-moderate[data-status='not_evaluated'] {
-        background-color: lighten(#d36735, 30%);
-        color: #fff;
+        background-color: #fff;
+        color: #d36735;
     }
 
     &.pathogenic-strong[data-status='evaluated'] {
@@ -1271,8 +1272,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     }
 
     &.pathogenic-strong[data-status='not_evaluated'] {
-        background-color: lighten(#d33535, 30%);
-        color: #fff;
+        background-color: #fff;
+        color: #d33535;
     }
 
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1225,20 +1225,56 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     cursor: default;
     padding: 5px 0.745em;
 
-    &.benign-strong {
+    &.benign-strong[data-status='evaluated'] {
         background-color: #62387e;
         color: #fff;
     }
 
-    &.benign-supporting {
+    &.benign-strong[data-status='not_evaluated'] {
+        background-color: lighten(#62387e, 30%);
+        color: #fff;
+    }
+
+    &.benign-supporting[data-status='evaluated'] {
         background-color: #2b67a0;
         color: #fff;
     }
 
-    &.pathogenic-supporting {
+    &.benign-supporting[data-status='not_evaluated'] {
+        background-color: lighten(#2b67a0, 30%);
+        color: #fff;
+    }
+
+    &.pathogenic-supporting[data-status='evaluated']  {
         background-color: #728b42;
         color: #fff;
     }
+
+    &.pathogenic-supporting[data-status='not_evaluated']  {
+        background-color: lighten(#728b42, 30%);
+        color: #fff;
+    }
+
+    &.pathogenic-moderate[data-status='evaluated'] {
+        background-color: #d36735;
+        color: #fff;
+    }
+
+    &.pathogenic-moderate[data-status='not_evaluated'] {
+        background-color: lighten(#d36735, 30%);
+        color: #fff;
+    }
+
+    &.pathogenic-strong[data-status='evaluated'] {
+        background-color: #d33535;
+        color: #fff;
+    }
+
+    &.pathogenic-strong[data-status='not_evaluated'] {
+        background-color: lighten(#d33535, 30%);
+        color: #fff;
+    }
+
 }
 
 /**

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1212,3 +1212,98 @@ div.react-tabs .ReactTabs__TabPanel--selected {
         margin-left: 20px;
     }
 }
+
+/* variant curation interface - criteria bar */
+.criteria-group.btn-group-sm {
+    padding-bottom: 10px;
+}
+
+.criteria-group.btn-group-sm .btn {
+    background-color: #ddd;
+    color: #555;
+    cursor: default;
+    padding: 5px 0.745em;
+
+    &.benign-strong {
+        background-color: #62387e;
+        color: #fff;
+    }
+
+    &.benign-supporting {
+        background-color: #2b67a0;
+        color: #fff;
+    }
+
+    &.pathogenic-supporting {
+        background-color: #728b42;
+        color: #fff;
+    }
+}
+
+/**
+ * Tooltip Styles
+ */
+
+/* Add this attribute to the element that needs a tooltip */
+[data-tooltip] {
+  position: relative;
+  z-index: 2;
+  cursor: pointer;
+}
+
+/* Hide the tooltip content by default */
+[data-tooltip]:before,
+[data-tooltip]:after {
+  visibility: hidden;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Position tooltip above the element */
+[data-tooltip]:before {
+  position: absolute;
+  bottom: 120%;
+  left: 50%;
+  margin-bottom: 5px;
+  margin-left: -80px;
+  padding: 7px;
+  width: 160px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+  background-color: #000;
+  background-color: hsla(0, 0%, 20%, 0.9);
+  color: #fff;
+  content: attr(data-tooltip);
+  text-align: center;
+  font-size: 14px;
+  line-height: 1.2;
+  white-space: normal;
+}
+
+/* Triangle hack to make tooltip look like a speech bubble */
+[data-tooltip]:after {
+  position: absolute;
+  bottom: 120%;
+  left: 50%;
+  margin-left: -5px;
+  width: 0;
+  border-top: 5px solid #000;
+  border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  content: " ";
+  font-size: 0;
+  line-height: 0;
+}
+
+/* Show tooltip content on hover */
+[data-tooltip]:hover:before,
+[data-tooltip]:hover:after {
+  visibility: visible;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+  filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+  opacity: 1;
+}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1246,64 +1246,64 @@ div.react-tabs .ReactTabs__TabPanel--selected {
 
 /* Add this attribute to the element that needs a tooltip */
 [data-tooltip] {
-  position: relative;
-  z-index: 2;
-  cursor: pointer;
+    position: relative;
+    z-index: 2;
+    cursor: pointer;
 }
 
 /* Hide the tooltip content by default */
 [data-tooltip]:before,
 [data-tooltip]:after {
-  visibility: hidden;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-  filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-  opacity: 0;
-  pointer-events: none;
+    visibility: hidden;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    opacity: 0;
+    pointer-events: none;
 }
 
 /* Position tooltip above the element */
 [data-tooltip]:before {
-  position: absolute;
-  bottom: 120%;
-  left: 50%;
-  margin-bottom: 5px;
-  margin-left: -80px;
-  padding: 7px;
-  width: 160px;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  background-color: #000;
-  background-color: hsla(0, 0%, 20%, 0.9);
-  color: #fff;
-  content: attr(data-tooltip);
-  text-align: center;
-  font-size: 14px;
-  line-height: 1.2;
-  white-space: normal;
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    margin-bottom: 5px;
+    margin-left: -80px;
+    padding: 7px;
+    width: 160px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    background-color: #000;
+    background-color: hsla(0, 0%, 20%, 0.9);
+    color: #fff;
+    content: attr(data-tooltip);
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: normal;
 }
 
 /* Triangle hack to make tooltip look like a speech bubble */
 [data-tooltip]:after {
-  position: absolute;
-  bottom: 120%;
-  left: 50%;
-  margin-left: -5px;
-  width: 0;
-  border-top: 5px solid #000;
-  border-top: 5px solid hsla(0, 0%, 20%, 0.9);
-  border-right: 5px solid transparent;
-  border-left: 5px solid transparent;
-  content: " ";
-  font-size: 0;
-  line-height: 0;
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    margin-left: -5px;
+    width: 0;
+    border-top: 5px solid #000;
+    border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    content: " ";
+    font-size: 0;
+    line-height: 0;
 }
 
 /* Show tooltip content on hover */
 [data-tooltip]:hover:before,
 [data-tooltip]:hover:after {
-  visibility: visible;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-  filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-  opacity: 1;
+    visibility: visible;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+    filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+    opacity: 1;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1121,11 +1121,12 @@ div.react-tabs .ReactTabs__TabPanel--selected {
         padding: 20px 0;
 
         h2 {
+            left: 0;
             margin-top: 0;
             margin-bottom: 0;
             position: absolute;
             text-align: center;
-            width: 1128px;
+            width: 100%;
         }
     }
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1226,53 +1226,27 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     padding: 5px 0.725em;
     font-weight: bold;
 
-    &.benign-strong[data-status='evaluated'] {
-        background-color: #62387e;
-        color: #fff;
-    }
-
-    &.benign-strong[data-status='not_evaluated'] {
-        background-color: #fff;
+    &.benign-strong {
         color: #62387e;
     }
 
-    &.benign-supporting[data-status='evaluated'] {
-        background-color: #2b67a0;
-        color: #fff;
-    }
-
-    &.benign-supporting[data-status='not_evaluated'] {
-        background-color: #fff;
+    &.benign-supporting {
         color: #2b67a0;
     }
 
-    &.pathogenic-supporting[data-status='evaluated']  {
-        background-color: #728b42;
-        color: #fff;
-    }
-
-    &.pathogenic-supporting[data-status='not_evaluated']  {
-        background-color: #fff;
+    &.pathogenic-supporting  {
         color: #728b42;
     }
 
-    &.pathogenic-moderate[data-status='evaluated'] {
-        background-color: #d36735;
-        color: #fff;
-    }
-
-    &.pathogenic-moderate[data-status='not_evaluated'] {
-        background-color: #fff;
+    &.pathogenic-moderate {
         color: #d36735;
     }
 
-    &.pathogenic-strong[data-status='evaluated'] {
-        background-color: #d33535;
-        color: #fff;
+    &.pathogenic-strong {
+        color: #d33535;
     }
 
-    &.pathogenic-strong[data-status='not_evaluated'] {
-        background-color: #fff;
+    &.pathogenic-very-strong {
         color: #d33535;
     }
 


### PR DESCRIPTION
This PR consists of changes pertinent to implementing a _"static"_ criteria bar above the tabs for the test alpha release.

**Known issues:**
The _"static"_ criteria bar is not a functional UI. It is meant to show the intended functionality in the demo. 

**Technical notes:**
For the time being, I just followed the color scheme for the different groupings of codes as shown in the ACMG diagram. For example, **purple** is for "benign-strong" (BS) and **blue** is for "benign-supporting" (BP), and so on and so forth.
1. The _solid_ colored criteria codes indicate the use case in which it has been associated with disease and has been evaluated.
2. The _white_ with colored text criteria codes indicate the use case in which it has been associated with disease but has not been evaluated.
3. The _gray_ colored criteria codes indicate the use case in which it has not been associated with disease and thus is not able to be evaluated.

**Steps to test this PR:**
1. Login and go to http://localhost:6543/select-variant/.
2. Add a ClinVar variation ID - 139214.
3. Upon arriving at the default Basic Info tab initially, click on the "Start new interpretation" button toward the right above the tabs.
4. Then expect to see the color-coded "static" criteria bar to be displayed above the tabs.