### PR TITLE
Connects to #754. grch37 warnings

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -270,7 +270,7 @@ var AddResourceIdModal = React.createClass({
                         <p>&nbsp;<br />{this.state.txtResourceResponse}</p>
                         {this.renderResourceResult()}
                     </div>
-                    : <span><p className="alert alert-info">{this.state.txtHelpText}</p></span>}
+                    : this.state.txtHelpText}
                 </div>
                 <div className='modal-footer'>
                     <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
@@ -314,7 +314,12 @@ function clinvarTxt(field, extra) {
             txt = 'Retrieve from ClinVar';
             break;
         case 'helpText':
-            txt = <span>Enter a ClinVar VariationID. The VariationID can be found in the light blue box on a variant page (example: <a href={external_url_map['ClinVarSearch'] + '139214'} target="_blank">139214</a>).</span>;
+            txt =
+                <span>
+                    <p className="alert alert-info">
+                        <span>Enter a ClinVar VariationID. The VariationID can be found in the light blue box on a variant page (example: <a href={external_url_map['ClinVarSearch'] + '139214'} target="_blank">139214</a>).</span>
+                    </p>
+                </span>;
             break;
         case 'resourceResponse':
             txt = "Below are the data from ClinVar for the VariationID you submitted. Select \"" + extra + "\" below if it is the correct variant, otherwise revise your search above:";
@@ -451,7 +456,15 @@ function carTxt(field, extra) {
             txt = 'Retrieve from ClinGen Allele Registry';
             break;
         case 'helpText':
-            txt = <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>;
+            txt =
+                <span>
+                    <p className="alert alert-info">
+                        <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>
+                    </p>
+                    <p className="alert alert-warning">
+                        <span>Note: Currently, your allele needs to be registered using a GRCh37 HGVS representation in order for all Population evidence associated with the allele to be returned.</span>
+                    </p>
+                </span>;
             break;
         case 'resourceResponse':
             txt = "Below are the data from the ClinGen Allele Registry for the CA ID you submitted. Select \"" + extra + "\" below if it is the correct variant, otherwise revise your search above:";

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -462,7 +462,7 @@ function carTxt(field, extra) {
                         <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>
                     </p>
                     <p className="alert alert-warning">
-                        <span>Note: Currently, your allele needs to be registered using a <strong>GRCh37</strong> HGVS representation in order for all Population evidence associated with the allele to be returned.</span>
+                        <span>Note: Please register your allele with the ClinGen Allele Registry using a <strong>GRCh37</strong> HGVS representation in order to return all possible associated evidence.</span>
                     </p>
                 </span>;
             break;

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -462,7 +462,7 @@ function carTxt(field, extra) {
                         <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>
                     </p>
                     <p className="alert alert-warning">
-                        <span>Note: Currently, your allele needs to be registered using a GRCh37 HGVS representation in order for all Population evidence associated with the allele to be returned.</span>
+                        <span>Note: Currently, your allele needs to be registered using a <strong>GRCh37</strong> HGVS representation in order for all Population evidence associated with the allele to be returned.</span>
                     </p>
                 </span>;
             break;

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -186,7 +186,9 @@ module.exports.external_url_map = {
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',
-    'EXAC': '//exac.broadinstitute.org/variant/'
+    'EXAC': '//exac.broadinstitute.org/variant/',
+    'mutalyzer': 'https://mutalyzer.nl/',
+    'mutalyzerSnpConverter': 'https://mutalyzer.nl/snp-converter'
 };
 
 

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -76,7 +76,7 @@ var SelectVariant = React.createClass({
                                         </ol>
                                     </div>
                                     <div className="alert alert-warning">
-                                        Note: Please register your allele using a GRCh37 HGVS term. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
+                                        When registering your allele in the ClinGen Allele Registry, please use a GRCh37 HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
                                     </div>
                                 </div>
                                 <div className="row">

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -70,7 +70,7 @@ var SelectVariant = React.createClass({
                                             <li>If not found in ClinVar, search the <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> with a valid HGVS term for that variant.
                                             <ol type="a">
                                                 <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                                <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
+                                                <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID. Note: Please register your allele using a GRCh37 HGVS term. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 chromosomal HGVS</li>
                                             </ol>
                                             </li>
                                         </ol>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -76,7 +76,7 @@ var SelectVariant = React.createClass({
                                         </ol>
                                     </div>
                                     <div className="alert alert-warning">
-                                        When registering your allele in the ClinGen Allele Registry, please use a GRCh37 HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
+                                        When registering your allele in the ClinGen Allele Registry, please use a <strong>GRCh37</strong> HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
                                     </div>
                                 </div>
                                 <div className="row">

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -76,7 +76,7 @@ var SelectVariant = React.createClass({
                                         </ol>
                                     </div>
                                     <div className="alert alert-warning">
-                                        When registering your allele in the ClinGen Allele Registry, please use a <strong>GRCh37</strong> HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
+                                        When registering your allele in the ClinGen Allele Registry, please use a <strong>GRCh37</strong> HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href={external_url_map['mutalyzerSnpConverter']}>SNP Converter</a> functionality of <a href={external_url_map['mutalyzer']}>Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
                                     </div>
                                 </div>
                                 <div className="row">

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -70,10 +70,13 @@ var SelectVariant = React.createClass({
                                             <li>If not found in ClinVar, search the <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> with a valid HGVS term for that variant.
                                             <ol type="a">
                                                 <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                                <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID. Note: Please register your allele using a GRCh37 HGVS term. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 chromosomal HGVS</li>
+                                                <li>If <a href={external_url_map['CAR']}>ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
                                             </ol>
                                             </li>
                                         </ol>
+                                    </div>
+                                    <div className="alert alert-warning">
+                                        Note: Please register your allele using a GRCh37 HGVS term. For an rsID, you can us the <a href="https://mutalyzer.nl/snp-converter">SNP Converter</a> functionality of <a href="https://mutalyzer.nl/">Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
                                     </div>
                                 </div>
                                 <div className="row">

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -33,6 +33,11 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                         <CurationRecordGeneDisease data={variant} />
                         <CurationRecordCurator data={variant} interpretationUuid={interpretationUuid} session={session} />
                     </div>
+                    {variant && !variant.hgvsNames.GRCh37 ?
+                        <div className="alert alert-warning">
+                            <strong>Warning:</strong> You registered your allele in the ClinGen Allele Registry using a GRCh38 HGVS term. This will currently limit some of the population and predictive evidence that can be retrieved for this variant until an upcoming version of the ClinGen Allele Registry is available.
+                        </div>
+                    : null}
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -63,7 +63,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         //var refseq_data = {};
         var variant = this.props.data;
         var url = this.props.protocol + external_url_map['ClinVarEutils'];
-        if (variant) {
+        if (variant && variant.clinvarVariantId) {
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
             // Extract genomic substring from HGVS name whose assembly is GRCh37 or GRCh38
             // Both of "GRCh37" and "gRCh37" (same for GRCh38) instances are possibly present in the variant object
@@ -128,15 +128,17 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (variant) {
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
-            var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
-                this.setState({
-                    hasEnsemblData: true,
-                    ensembl_transcripts: response[0].transcript_consequences
+            var rsid = (variant.dbSNPIds && variant.dbSNPIds.length > 0) ? variant.dbSNPIds[0].match(numberPattern) : null;
+            if (rsid) {
+                this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
+                    this.setState({
+                        hasEnsemblData: true,
+                        ensembl_transcripts: response[0].transcript_consequences
+                    });
+                }).catch(function(e) {
+                    console.log('Ensembl Fetch Error=: %o', e);
                 });
-            }).catch(function(e) {
-                console.log('Ensembl Fetch Error=: %o', e);
-            });
+            }
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -52,7 +52,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             clinvar_id: null, // ClinVar ID
             car_id: null, // ClinGen Allele Registry ID
             interpretation: this.props.interpretation,
-            hgvs_GRCh37: null,
             ensembl_exac_allele: {},
             interpretationUuid: this.props.interpretationUuid,
             hasExacData: false, // flag to display ExAC table
@@ -129,16 +128,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             }).catch(function(e) {
                 console.log('VEP Allele Frequency Fetch Error=: %o', e);
             });
-            this.getRestData(url + variant_id).then(response => {
-                // Calling methods to update global object with ExAC & ESP population data
-                // FIXME: Need to create a new copy of the global object with new data
-                // while leaving the original object with pre-existing data
-                // for comparison of any potential changed values
-                this.parseExacData(response);
-                this.parseEspData(response);
-            }).catch(function(e) {
-                console.log('MyVariant Fetch Error=: %o', e);
-            });
+            if (hgvs_GRCh37) {
+                this.getRestData(url + variant_id).then(response => {
+                    // Calling methods to update global object with ExAC & ESP population data
+                    // FIXME: Need to create a new copy of the global object with new data
+                    // while leaving the original object with pre-existing data
+                    // for comparison of any potential changed values
+                    this.parseExacData(response);
+                    this.parseEspData(response);
+                }).catch(function(e) {
+                    console.log('MyVariant Fetch Error=: %o', e);
+                });
+            }
         }
     },
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1170,6 +1170,11 @@ div.react-tabs .ReactTabs__TabPanel--selected {
             padding: 0;
         }
     }
+
+    .alert {
+        margin-top: 20px;
+        margin-bottom: 0;
+    }
 }
 
 /* bootstrap callout component styles */


### PR DESCRIPTION
Select page:
![image](https://cloud.githubusercontent.com/assets/4326866/16668907/c20f1a5a-4447-11e6-955b-7505640df0ac.png)

Modal:
![image](https://cloud.githubusercontent.com/assets/4326866/16669412/483eeb62-444a-11e6-8223-fcef1448e059.png)

Hub:
![image](https://cloud.githubusercontent.com/assets/4326866/16668925/d3f76506-4447-11e6-8bfd-b0b865099168.png)

Testing:

1. Load select variant page. Confirm warning text.
2. Open CA ID modal. Confirm warning text in modal.
3. Add CA ID that does not have a grch37 info (ex: CA034913). Confirm warning text in hub.
4. Add CA ID/ClinVar ID that does have grch37 info. Confirm warning text does not exist in hub.