### PR TITLE
Connects to #750. Connects to #767. Connects to #781. Connects to #783. Population tab changes

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -387,7 +387,7 @@ function clinvarRenderResourceResult() {
                         <span className="col-sm-5 col-md-3 control-label"><label>ClinVar Variant ID</label></span>
                         <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
                     </div>
-                    {this.state.tempResource.hgvsNames.others && this.state.tempResource.hgvsNames.others.length > 0 ?
+                    {this.state.tempResource.hgvsNames ?
                         <div className="row">
                             <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>
                             <span className="col-sm-7 col-md-9 text-no-input">
@@ -550,7 +550,7 @@ function carRenderResourceResult() {
                             <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
                         </div>
                     : null}
-                    {this.state.tempResource.hgvsNames.others && this.state.tempResource.hgvsNames.others.length > 0 ?
+                    {this.state.tempResource.hgvsNames ?
                         <div className="row">
                             <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>
                             <span className="col-sm-7 col-md-9 text-no-input">

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -189,6 +189,7 @@ module.exports.external_url_map = {
     'MyVariantInfo': '//myvariant.info/v1/variant/',
     'EXAC': '//exac.broadinstitute.org/variant/',
     'EXACHome': 'http://exac.broadinstitute.org/',
+    'ExACGene': 'http://exac.broadinstitute.org/gene/',
     'ESPHome': 'http://evs.gs.washington.edu/EVS/',
     '1000GenomesHome': 'http://browser.1000genomes.org/',
     'mutalyzer': 'https://mutalyzer.nl/',

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -186,7 +186,10 @@ module.exports.external_url_map = {
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',
-    'EXAC': '//exac.broadinstitute.org/variant/'
+    'EXAC': '//exac.broadinstitute.org/variant/',
+    'EXACHome': 'http://exac.broadinstitute.org/',
+    'ESPHome': 'http://evs.gs.washington.edu/EVS/',
+    '1000GenomesHome': 'http://www.1000genomes.org/'
 };
 
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -183,13 +183,14 @@ module.exports.external_url_map = {
     'CARallele-test': '//reg.test.genome.network/allele/',
     'EnsemblVEP': '//rest.ensembl.org/vep/human/id/',
     'EnsemblVariation': '//rest.ensembl.org/variation/human/',
+    'EnsemblPopulationPage': 'http://ensembl.org/Homo_sapiens/Variation/Population?db=core;v=',
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',
     'EXAC': '//exac.broadinstitute.org/variant/',
     'EXACHome': 'http://exac.broadinstitute.org/',
     'ESPHome': 'http://evs.gs.washington.edu/EVS/',
-    '1000GenomesHome': 'http://www.1000genomes.org/'
+    '1000GenomesHome': 'http://browser.1000genomes.org/'
 };
 
 

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -35,7 +35,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                     </div>
                     {variant && !variant.hgvsNames.GRCh37 ?
                         <div className="alert alert-warning">
-                            <strong>Warning:</strong> Your variant is not associated with a GRCh37 genomic representation. This will currently limit some of the population and predictive evidence retrieved for this variant
+                            <strong>Warning:</strong> Your variant is not associated with a GRCh37 genomic representation. This will currently limit some of the population and predictive evidence retrieved for this variant.
                         </div>
                     : null}
                 </div>

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -35,7 +35,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                     </div>
                     {variant && !variant.hgvsNames.GRCh37 ?
                         <div className="alert alert-warning">
-                            <strong>Warning:</strong> You registered your allele in the ClinGen Allele Registry using a GRCh38 HGVS term. This will currently limit some of the population and predictive evidence that can be retrieved for this variant until an upcoming version of the ClinGen Allele Registry is available.
+                            <strong>Warning:</strong> Your variant is not associated with a GRCh37 genomic representation. This will currently limit some of the population and predictive evidence retrieved for this variant
                         </div>
                     : null}
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -67,6 +67,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
             // Extract genomic substring from HGVS name whose assembly is GRCh37 or GRCh38
             // Both of "GRCh37" and "gRCh37" (same for GRCh38) instances are possibly present in the variant object
+            // FIXME: this GRCh vs gRCh needs to be reconciled in the data model and data import
             var hgvs_GRCh37 = (variant.hgvsNames.GRCh37) ? variant.hgvsNames.GRCh37 : variant.hgvsNames.gRCh37;
             var hgvs_GRCh38 = (variant.hgvsNames.GRCh38) ? variant.hgvsNames.GRCh38 : variant.hgvsNames.gRCh38;
             this.setState({

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -517,7 +517,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     <div className="panel panel-info datasource-ExAC">
                         <div className="panel-heading">
                             <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
-                                <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See ExAC data <i className="icon icon-external-link"></i></a>
+                                <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
                             </h3>
                         </div>
                         <table className="table">
@@ -556,7 +556,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">
                             <h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
-                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">See 1000G data <i className="icon icon-external-link"></i></a>
+                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
                             </h3>
                         </div>
                         <table className="table">
@@ -591,7 +591,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     <div className="panel panel-info datasource-ESP">
                         <div className="panel-heading">
                             <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}
-                                <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See ESP data <i className="icon icon-external-link"></i></a>
+                                <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
                             </h3>
                         </div>
                         <table className="table">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -500,7 +500,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                 {this.state.hasExacData ?
                     <div className="panel panel-info datasource-ExAC">
-                        <div className="panel-heading"><h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">(See ExAC data <i className="icon icon-external-link"></i>)</a></h3></div>
+                        <div className="panel-heading">
+                            <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
+                                <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See ExAC data <i className="icon icon-external-link"></i></a>
+                            </h3>
+                        </div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -535,7 +539,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 }
                 {this.state.hasTGenomesData ?
                     <div className="panel panel-info datasource-1000G">
-                        <div className="panel-heading"><h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class} <a href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">(See 1000G data <i className="icon icon-external-link"></i>)</a></h3></div>
+                        <div className="panel-heading">
+                            <h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
+                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">See 1000G data <i className="icon icon-external-link"></i></a>
+                            </h3>
+                        </div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -566,7 +574,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 }
                 {this.state.hasEspData ?
                     <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">(See ESP data <i className="icon icon-external-link"></i>)</a></h3></div>
+                        <div className="panel-heading">
+                            <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}
+                                <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See ESP data <i className="icon icon-external-link"></i></a>
+                            </h3>
+                        </div>
                         <table className="table">
                             <thead>
                                 <tr>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -200,6 +200,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         // not all variants are SNPs. Do nothing if variant is not a SNP
         if (response.var_class && response.var_class == 'SNP') {
             let populationObj = this.state.populationObj;
+            let updated1000GData = false;
             // get extra 1000Genome information
             populationObj.tGenomes._extra.name = response.name;
             populationObj.tGenomes._extra.var_class = response.var_class;
@@ -216,21 +217,25 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         // ... for specific populations =
                         populationObj.tGenomes[populationCode].ac[population.allele] = parseInt(population.allele_count);
                         populationObj.tGenomes[populationCode].af[population.allele] = parseFloat(population.frequency);
+                        updated1000GData = true;
                     } else if (population.population == '1000GENOMES:phase_3:ALL') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and totals
                         populationObj.tGenomes._tot.ac[population.allele] = parseInt(population.allele_count);
                         populationObj.tGenomes._tot.af[population.allele] = parseFloat(population.frequency);
+                        updated1000GData = true;
                     } else if (population.population == 'ESP6500:African_American') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and ESP AA
                         populationObj.tGenomes.espaa.ac[population.allele] = parseInt(population.allele_count);
                         populationObj.tGenomes.espaa.af[population.allele] = parseFloat(population.frequency);
+                        updated1000GData = true;
                     } else if (population.population == 'ESP6500:European_American') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and ESP EA
                         populationObj.tGenomes.espea.ac[population.allele] = parseInt(population.allele_count);
                         populationObj.tGenomes.espea.af[population.allele] = parseFloat(population.frequency);
+                        updated1000GData = true;
                     }
                 });
             }
@@ -244,23 +249,29 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         // ... for specific populations
                         populationObj.tGenomes[populationCode].gc[population_genotype.genotype] = parseInt(population_genotype.count);
                         populationObj.tGenomes[populationCode].gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        updated1000GData = true;
                     } else if (population_genotype.population == '1000GENOMES:phase_3:ALL') {
                         // ... and totals
                         populationObj.tGenomes._tot.gc[population_genotype.genotype] = parseInt(population_genotype.count);
                         populationObj.tGenomes._tot.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        updated1000GData = true;
                     } else if (population_genotype.population == 'ESP6500:African_American') {
                         // ... and ESP AA
                         populationObj.tGenomes.espaa.gc[population_genotype.genotype] = parseInt(population_genotype.count);
                         populationObj.tGenomes.espaa.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        updated1000GData = true;
                     } else if (population_genotype.population == 'ESP6500:European_American') {
                         // ... and ESP EA
                         populationObj.tGenomes.espea.gc[population_genotype.genotype] = parseInt(population_genotype.count);
                         populationObj.tGenomes.espea.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        updated1000GData = true;
                     }
                 });
             }
-            // update populationObj, and set flag indicating that we have 1000Genomes data
-            this.setState({hasTGenomesData: true, populationObj: populationObj});
+            if (updated1000GData) {
+                // update populationObj, and set flag indicating that we have 1000Genomes data
+                this.setState({hasTGenomesData: true, populationObj: populationObj});
+            }
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -506,13 +506,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found.</th>
+                                    <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']}>Search ExAC</a> for this variant.</th>
                                 </tr>
                             </thead>
                         </table>
                     </div>
-                    // FIXME: below URL is dependent on a response, but this block is executed on lack of a response
-                    //Please see <a href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">variant data</a> at ExAC.
                 }
                 {this.state.hasTGenomesData ?
                     <div className="panel panel-info datasource-1000G">
@@ -539,7 +537,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found.</th>
+                                    <th>No population data was found for this allele in 1000G. <a href={external_url_map['1000GenomesHome']}>Search 1000G</a> for this variant.</th>
                                 </tr>
                             </thead>
                         </table>
@@ -576,13 +574,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>Variant information could not be found.</th>
+                                    <th>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']}>Search ESP</a> for this variant.</th>
                                 </tr>
                             </thead>
                         </table>
                     </div>
-                    // FIXME: below URL is dependent on a response, but this block is executed on lack of a response
-                    // Please see <a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">variant data</a> at ESP.
                 }
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -565,7 +565,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">
                             <h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
-                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
+                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
                             </h3>
                         </div>
                         <table className="table">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -490,7 +490,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                 {this.state.hasExacData ?
                     <div className="panel panel-info datasource-ExAC">
-                        <div className="panel-heading"><h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">(See ExAC data)</a></h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">(See ExAC data <i className="icon icon-external-link"></i>)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -525,7 +525,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 }
                 {this.state.hasTGenomesData ?
                     <div className="panel panel-info datasource-1000G">
-                        <div className="panel-heading"><h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}</h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class} <a href={external_url_map['EnsemblPopulationPage'] + esp._extra.rsid} target="_blank">(See 1000G data <i className="icon icon-external-link"></i>)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
@@ -556,7 +556,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 }
                 {this.state.hasEspData ?
                     <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">(See ESP data)</a></h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">(See ESP data <i className="icon icon-external-link"></i>)</a></h3></div>
                         <table className="table">
                             <thead>
                                 <tr>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -365,7 +365,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     highestMAFObj.popLabel = populationStatic.tGenomes._labels[pop];
                     highestMAFObj.ac = populationObj.tGenomes[pop].ac[alt];
                     highestMAFObj.ac_tot = populationObj.tGenomes[pop].ac[ref] + populationObj.tGenomes[pop].ac[alt];
-                    highestMAFObj.source = '1000Genomes';
+                    highestMAFObj.source = '1000 Genomes';
                     highestMAFObj.af = populationObj.tGenomes[pop].af[alt];
                 }
             }
@@ -564,7 +564,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 {this.state.hasTGenomesData ?
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">
-                            <h3 className="panel-title">1000G: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
+                            <h3 className="panel-title">1000 Genomes: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
                                 <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
                             </h3>
                         </div>
@@ -586,11 +586,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </div>
                 :
                     <div className="panel panel-info datasource-1000G">
-                        <div className="panel-heading"><h3 className="panel-title">1000G</h3></div>
+                        <div className="panel-heading"><h3 className="panel-title">1000 Genomes</h3></div>
                         <table className="table">
                             <thead>
                                 <tr>
-                                    <th>No population data was found for this allele in 1000G. <a href={external_url_map['1000GenomesHome']}>Search 1000G</a> for this variant.</th>
+                                    <th>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']}>Search 1000 Genomes</a> for this variant.</th>
                                 </tr>
                             </thead>
                         </table>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -57,6 +57,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             hasExacData: false, // flag to display ExAC table
             hasTGenomesData: false,
             hasEspData: false, // flag to display ESP table
+            geneENSG: null,
             populationObj: {
                 highestMAF: null,
                 exac: {
@@ -144,6 +145,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(response => {
                         // Calling method to update global object with ExAC Allele Frequency data
                         this.parseAlleleFrequencyData(response);
+                        this.parseGeneConstraintScores(response);
                         this.calculateHighestMAF();
                     }).catch(function(e) {
                         console.log('VEP Allele Frequency Fetch Error=: %o', e);
@@ -172,6 +174,14 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         populationObj.exac._tot.af = parseFloat(response[0].colocated_variants[0].exac_adj_maf);
 
         this.setState({populationObj: populationObj});
+    },
+
+    // Get gene ENSG value to link out to Gene's page on ExAC, as temporary stop gap for displaying
+    // constraint scores (see #750)
+    parseGeneConstraintScores: function(response) {
+        if (response && response.length > 0 && response[0].transcript_consequences && response[0].transcript_consequences.length > 0) {
+            this.setState({geneENSG: response[0].transcript_consequences[0].gene_id});
+        }
     },
 
     // Method to assign ExAC population data to global population object

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -508,7 +508,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <br />
                             <h4>ExAC Constraint Score</h4>
                             <div className="clearfix">
-                                <div className="bs-callout-content-container"><a href={external_url_map['EXAC'] + this.state.geneENSG} target="_blank">View pLI in ExAC <i className="icon icon-external-link"></i></a></div>
+                                <div className="bs-callout-content-container"><a href={external_url_map['ExACGene'] + this.state.geneENSG} target="_blank">View pLI in ExAC <i className="icon icon-external-link"></i></a></div>
                             </div>
                         </div>
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -503,6 +503,15 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </dl>
                         </div>
                     </div>
+                    {this.state.geneENSG ?
+                        <div>
+                            <br />
+                            <h4>ExAC Constraint Score</h4>
+                            <div className="clearfix">
+                                <div className="bs-callout-content-container"><a href={external_url_map['EXAC'] + this.state.geneENSG} target="_blank">View pLI in ExAC <i className="icon icon-external-link"></i></a></div>
+                            </div>
+                        </div>
+                    : null}
                 </div>
 
                 {(this.state.interpretationUuid) ?

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1204,11 +1204,23 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     margin-top: -5px;
 }
 
-.panel.panel-info .panel-title {
-    font-weight: bold;
+.panel.panel-info {
+    .panel-title {
+        font-weight: bold;
 
-    a {
-        font-weight: normal;
-        margin-left: 20px;
+        a {
+            font-weight: normal;
+            margin-left: 20px;
+        }
+    }
+
+    .panel-subtitle {
+        a {
+            font-weight: normal;
+        }
+    }
+
+    .pull-right {
+        float: right;
     }
 }


### PR DESCRIPTION
Test instance: http://767-mc-population-linkouts-try2.instance.clinicalgenome.org/ - few commits behind, but most functionality is in.

#### Connects to #750:
Link out to ExAC's gene page for the Constraint Score section, if the gene info is available.

![image](https://cloud.githubusercontent.com/assets/4326866/16702231/94208b74-4519-11e6-9a5c-2a3b28f35ffd.png)

Testing:

1. Add variant w/ GRCh37 data, confirm that ExAC Constraint Score section is visible, and that link is correct
2. Add variant w/o GRCh37 data, confirm that the section does not appear

#### Connects to #767:
Update the link outs from the population tables. Different links out if it has data or not. Updated text and location of these linkouts.

With data:
![image](https://cloud.githubusercontent.com/assets/4326866/16702748/f56d704c-451c-11e6-9d8f-2fff4753cd02.png)

Without data:
![image](https://cloud.githubusercontent.com/assets/4326866/16702754/04d527a0-451d-11e6-8ad8-367eb1250aa0.png)

Testing:

1. Add variant w/ various population data availability (139214, 66756, 41231)
2. Confirm that linkouts are correct

#### Connects to #781:
The 1000 Genomes parser now grabs the ref and alt allele information from the NC value, with the NC from GRCh38 being preferred.

Testing:

1. Add variants w/ 1000G data, confirm that the displayed data in the 1000G table is correct
   * Variant 66756 was of interest because the `ancestral_allele` data was funky, but we're not using that variable at all anymore so this is irrelevant

#### Connects to #783:
We discovered that some ClinVar variants do not have GRCh37 data. Message was updated to account for this.

![image](https://cloud.githubusercontent.com/assets/4326866/16702473/0651ae0c-451b-11e6-8ee8-9ab3de9ad9cd.png)

1. Add CA ID and/or ClinVar ID with (139214, CA003323) and without (5555, CA501058) GRCh37 info; confirm that the banner display is correct

#### Additional minor bugfix:
![image](https://cloud.githubusercontent.com/assets/4326866/16704594/e5b000f0-452d-11e6-97f2-fb47e421fdaf.png)

Fix HGVS rendering code in modals so that the HGVS list displays even without the presence of non-NC HGVS values (aka remove old code logic)