### PR TITLE
Connects to #779, Connects to #746. ids and links in header

### DIFF
--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -30,7 +30,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : null;
             var carId = (variant.carId) ? variant.carId : null;
             var dbSNPId = (variant.dbSNPIds.length) ? variant.dbSNPIds[0] : null;
-            if (dbSNPId && !dbSNPId.indexOf('rs')) {
+            if (dbSNPId && dbSNPId.indexOf('rs') == -1) {
                 dbSNPId = 'rs' + dbSNPId;
             }
         }
@@ -43,17 +43,17 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                     {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
                             {clinVarId ?
-                                <dd><a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{'ClinVar ID: '+clinVarId}</a></dd>
+                                <dd>ClinVar ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
                                 :
                                 null
                             }
                             {carId ?
-                                <dd><a href={'http://reg.genome.network/allele/' + carId + '.html'} target="_blank" title={'GlinGen Allele Registry page for ' + carId + ' in a new window'}>{'ClinGen Allele Registry ID: '+carId}</a></dd>
+                                <dd>ClinGen Allele Registry ID:&nbsp;<a href={'http://reg.genome.network/allele/' + carId + '.html'} target="_blank" title={'GlinGen Allele Registry page for ' + carId + ' in a new window'}>{carId}</a></dd>
                                 :
                                 null
                             }
                             {dbSNPId ?
-                                <dd><a href={'http://www.ncbi.nlm.nih.gov/snp/?term=' + dbSNPId} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{'dbSNP ID: '+dbSNPId}</a></dd>
+                                <dd>dbSNP ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/snp/?term=' + dbSNPId} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{dbSNPId}</a></dd>
                                 :
                                 null
                             }

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -29,7 +29,10 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
         if (variant) {
             var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : null;
             var carId = (variant.carId) ? variant.carId : null;
-            var dbSNPId = (variant.dbSNPIds.length) ? 'rs'+variant.dbSNPIds[0] : null;
+            var dbSNPId = (variant.dbSNPIds.length) ? variant.dbSNPIds[0] : null;
+            if (dbSNPId && !dbSNPId.indexOf('rs')) {
+                dbSNPId = 'rs' + dbSNPId;
+            }
         }
         var addEdit = this.props.interpretationTranscript ? 'Edit' : 'Add';
 

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -53,7 +53,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                                 null
                             }
                             {dbSNPId ?
-                                <dd>dbSNP ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/snp/?term=' + dbSNPId} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{dbSNPId}</a></dd>
+                                <dd>dbSNP ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=' + dbSNPId.replace('rs', '')} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{dbSNPId}</a></dd>
                                 :
                                 null
                             }

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -43,7 +43,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                     {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
                             {clinVarId ?
-                                <dd>ClinVar Variation ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
+                                <dd>ClinVar VariationID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
                                 :
                                 null
                             }

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -43,7 +43,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                     {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
                             {clinVarId ?
-                                <dd>ClinVar ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
+                                <dd>ClinVar Variation ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
                                 :
                                 null
                             }

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -27,9 +27,9 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
         var variant = this.props.data;
         var recordHeader = this.props.recordHeader;
         if (variant) {
-            var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : 'Unknown';
-            var carId = (variant.carId) ? variant.carId : 'Unknown';
-            var dbSNPId = (variant.dbSNPIds.length) ? variant.dbSNPIds[0] : 'Unknown';
+            var clinVarId = (variant.clinvarVariantId) ? variant.clinvarVariantId : null;
+            var carId = (variant.carId) ? variant.carId : null;
+            var dbSNPId = (variant.dbSNPIds.length) ? 'rs'+variant.dbSNPIds[0] : null;
         }
         var addEdit = this.props.interpretationTranscript ? 'Edit' : 'Add';
 
@@ -37,11 +37,23 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
             <div className="col-xs-12 col-sm-3 gutter-exc">
                 <div className="curation-data-gene">
                     <h4>{recordHeader}</h4>
-                    {variant ?
+                    {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
-                            <dd><a href={external_url_map['ClinVar'] + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>ClinVar</a></dd>
-                            <dd><a href={'http://reg.genome.network/allele/' + carId + '.html'} target="_blank" title={'GlinGen Allele Registry page for ' + carId + ' in a new window'}>ClinGen Allele Registry</a></dd>
-                            <dd><a href={external_url_map['dbSNP'] + dbSNPId.slice(2)} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>dbSNP</a></dd>
+                            {clinVarId ?
+                                <dd><a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{'ClinVar ID: '+clinVarId}</a></dd>
+                                :
+                                null
+                            }
+                            {carId ?
+                                <dd><a href={'http://reg.genome.network/allele/' + carId + '.html'} target="_blank" title={'GlinGen Allele Registry page for ' + carId + ' in a new window'}>{'ClinGen Allele Registry ID: '+carId}</a></dd>
+                                :
+                                null
+                            }
+                            {dbSNPId ?
+                                <dd><a href={'http://www.ncbi.nlm.nih.gov/snp/?term=' + dbSNPId} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{'dbSNP ID: '+dbSNPId}</a></dd>
+                                :
+                                null
+                            }
                         </dl>
                     : null}
                 </div>

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -1,7 +1,7 @@
 [
     {
         "uuid": "c71fc085-2683-11e5-b9fe-60f81dc5b05a",
-        "dbSNPIds": ["386833448"],
+        "dbSNPIds": ["rs386833448"],
         "clinvarVariantId": "55966",
         "clinVarRCVs": ["RCV000049375"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1306C>T (p.Gln436Ter)",
@@ -32,7 +32,7 @@
     },
     {
         "uuid": "3080772e-2685-11e5-ad92-60f81dc5b05a",
-        "dbSNPIds": ["386833446"],
+        "dbSNPIds": ["rs386833446"],
         "clinvarVariantId": "55964",
         "clinVarRCVs": ["RCV000049373"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1136G>C (p.Gly379Ala)",
@@ -63,7 +63,7 @@
     },
     {
         "uuid": "35eedfdc-2685-11e5-b6a0-60f81dc5b05a",
-        "dbSNPIds": ["386833444"],
+        "dbSNPIds": ["rs386833444"],
         "clinvarVariantId": "55962",
         "clinVarRCVs": ["RCV000049371"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1028G>A (p.Cys343Tyr)",
@@ -94,7 +94,7 @@
     },
     {
         "uuid": "3b3af7f0-2685-11e5-bc56-60f81dc5b05a",
-        "dbSNPIds": ["387907373"],
+        "dbSNPIds": ["rs387907373"],
         "clinvarVariantId": "55874",
         "clinVarRCVs": ["RCV000049288"],
         "clinvarVariantTitle": "NM_000475.4(NR0B1):c.1274G>T (p.Arg425Ile)",
@@ -122,7 +122,7 @@
     },
     {
         "uuid": "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a",
-        "dbSNPIds": ["147674680"],
+        "dbSNPIds": ["rs147674680"],
         "clinvarVariantId": "55847",
         "clinVarRCVs": [
             "RCV000049262",
@@ -152,7 +152,7 @@
     },
     {
         "uuid": "e496545c-2685-11e5-a4b3-60f81dc5b05a",
-        "dbSNPIds": ["76262710"],
+        "dbSNPIds": ["rs76262710"],
         "clinvarVariantId": "38601",
         "clinVarRCVs": [
             "RCV000032040",
@@ -189,7 +189,7 @@
     },
     {
         "uuid": "df8135d4-2685-11e5-af19-60f81dc5b05a",
-        "dbSNPIds": ["2298771"],
+        "dbSNPIds": ["rs2298771"],
         "clinvarVariantId": "36753",
         "clinVarRCVs": [
             "RCV000030432",
@@ -226,7 +226,7 @@
     },
     {
         "uuid": "d9717187-2685-11e5-9eac-60f81dc5b05a",
-        "dbSNPIds": ["193922686"],
+        "dbSNPIds": ["rs193922686"],
         "clinvarVariantId": "36485",
         "clinVarRCVs": ["RCV000030157"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.677T>C (p.Ile226Thr)",
@@ -253,7 +253,7 @@
     },
     {
         "uuid": "d439f000-2685-11e5-9792-60f81dc5b05a",
-        "dbSNPIds": ["138281308"],
+        "dbSNPIds": ["rs138281308"],
         "clinvarVariantId": "36484",
         "clinVarRCVs": ["RCV000030156"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.606C>A (p.Phe202Leu)",
@@ -280,7 +280,7 @@
     },
     {
         "uuid": "95d62ca5-d344-4c0f-8509-488b2e043969",
-        "dbSNPIds": ["386833478"],
+        "dbSNPIds": ["rs386833478"],
         "clinvarVariantId": "55996",
         "clinVarRCVs": ["RCV000049405"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.344delT (p.Ile115Thrfs)",

--- a/src/clincoded/tests/data/inserts/variant.json
+++ b/src/clincoded/tests/data/inserts/variant.json
@@ -1,7 +1,7 @@
 [
     {
         "uuid": "c71fc085-2683-11e5-b9fe-60f81dc5b05a",
-        "dbSNPIds": ["rs386833448"],
+        "dbSNPIds": ["386833448"],
         "clinvarVariantId": "55966",
         "clinVarRCVs": ["RCV000049375"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1306C>T (p.Gln436Ter)",
@@ -32,7 +32,7 @@
     },
     {
         "uuid": "3080772e-2685-11e5-ad92-60f81dc5b05a",
-        "dbSNPIds": ["rs386833446"],
+        "dbSNPIds": ["386833446"],
         "clinvarVariantId": "55964",
         "clinVarRCVs": ["RCV000049373"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1136G>C (p.Gly379Ala)",
@@ -63,7 +63,7 @@
     },
     {
         "uuid": "35eedfdc-2685-11e5-b6a0-60f81dc5b05a",
-        "dbSNPIds": ["rs386833444"],
+        "dbSNPIds": ["386833444"],
         "clinvarVariantId": "55962",
         "clinVarRCVs": ["RCV000049371"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.1028G>A (p.Cys343Tyr)",
@@ -94,7 +94,7 @@
     },
     {
         "uuid": "3b3af7f0-2685-11e5-bc56-60f81dc5b05a",
-        "dbSNPIds": ["rs387907373"],
+        "dbSNPIds": ["387907373"],
         "clinvarVariantId": "55874",
         "clinVarRCVs": ["RCV000049288"],
         "clinvarVariantTitle": "NM_000475.4(NR0B1):c.1274G>T (p.Arg425Ile)",
@@ -122,7 +122,7 @@
     },
     {
         "uuid": "e9f9a6d7-2685-11e5-8e9c-60f81dc5b05a",
-        "dbSNPIds": ["rs147674680"],
+        "dbSNPIds": ["147674680"],
         "clinvarVariantId": "55847",
         "clinVarRCVs": [
             "RCV000049262",
@@ -152,7 +152,7 @@
     },
     {
         "uuid": "e496545c-2685-11e5-a4b3-60f81dc5b05a",
-        "dbSNPIds": ["rs76262710"],
+        "dbSNPIds": ["76262710"],
         "clinvarVariantId": "38601",
         "clinVarRCVs": [
             "RCV000032040",
@@ -189,7 +189,7 @@
     },
     {
         "uuid": "df8135d4-2685-11e5-af19-60f81dc5b05a",
-        "dbSNPIds": ["rs2298771"],
+        "dbSNPIds": ["2298771"],
         "clinvarVariantId": "36753",
         "clinVarRCVs": [
             "RCV000030432",
@@ -226,7 +226,7 @@
     },
     {
         "uuid": "d9717187-2685-11e5-9eac-60f81dc5b05a",
-        "dbSNPIds": ["rs193922686"],
+        "dbSNPIds": ["193922686"],
         "clinvarVariantId": "36485",
         "clinVarRCVs": ["RCV000030157"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.677T>C (p.Ile226Thr)",
@@ -253,7 +253,7 @@
     },
     {
         "uuid": "d439f000-2685-11e5-9792-60f81dc5b05a",
-        "dbSNPIds": ["rs138281308"],
+        "dbSNPIds": ["138281308"],
         "clinvarVariantId": "36484",
         "clinVarRCVs": ["RCV000030156"],
         "clinvarVariantTitle": "NM_005912.2(MC4R):c.606C>A (p.Phe202Leu)",
@@ -280,7 +280,7 @@
     },
     {
         "uuid": "95d62ca5-d344-4c0f-8509-488b2e043969",
-        "dbSNPIds": ["rs386833478"],
+        "dbSNPIds": ["386833478"],
         "clinvarVariantId": "55996",
         "clinVarRCVs": ["RCV000049405"],
         "clinvarVariantTitle": "NM_000111.2(SLC26A3):c.344delT (p.Ile115Thrfs)",


### PR DESCRIPTION
This PR is for tickets #746 and #779 about displaying ClinVar variation id, CAR id, dbSNP id and their links to specific pages in external sources.

**Test**
* In Select Variant page, select ClinVar Variation ID and enter 55966, retrieve data and Save. Expect to see:
![screen shot 2016-07-08 at 4 37 02 pm](https://cloud.githubusercontent.com/assets/9206696/16704295/451f0224-452a-11e6-9dd2-bb70db0dcc1f.png)
* Click link at 55966, expect to go to http://www.ncbi.nlm.nih.gov/clinvar/variation/55966/
* Click link at CA144043, expect to go to http://reg.genome.network/allele/CA144043.html
* Click link at rs386833448, expect to go to http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=386833448

* Back to dashboard and go to Select Variant page
* Select ClinVar Variation ID and enter 139214, retrieve data and Save. Expect to see:
![screen shot 2016-07-08 at 4 43 22 pm](https://cloud.githubusercontent.com/assets/9206696/16704376/251f7b24-452b-11e6-9c94-0b225b2b4bcd.png)

* Back to dashboard and go to Select Variant page
* Select ClinGen Allele Registry ID and enter CA501064, retrieve data and Save. Expect to see:
![screen shot 2016-07-08 at 4 45 55 pm](https://cloud.githubusercontent.com/assets/9206696/16704400/7c313e8e-452b-11e6-9dc6-a63f8770ba05.png)

**End of Test**