### PR TITLE
Connects to #782. VCI Basic Info tab updated changes.

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -182,6 +182,7 @@ module.exports.external_url_map = {
     'CAR-test': 'http://reg.test.genome.network/site/registry',
     'CARallele-test': '//reg.test.genome.network/allele/',
     'EnsemblVEP': '//rest.ensembl.org/vep/human/id/',
+    'EnsemblHgvsVEP': '//rest.ensembl.org/vep/human/hgvs/',
     'EnsemblVariation': '//rest.ensembl.org/variation/human/',
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
     'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -334,7 +334,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 </div>
 
                 <div className="panel panel-info">
-                    <div className="panel-heading"><h3 className="panel-title">RefSeq Transcripts</h3></div>
+                    <div className="panel-heading"><h3 className="panel-title">ClinVar Transcripts</h3></div>
                     {(clinvar_id && clinvar_hgvs_names) ?
                         <table className="table">
                             <tbody>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -329,7 +329,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </tbody>
                         </table>
                         :
-                        <table className="table"><tbody><tr><td>Not known in ClinVar</td></tr></tbody></table>
+                        <table className="table"><tbody><tr><td>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
                     }
                 </div>
 
@@ -350,7 +350,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </tbody>
                         </table>
                         :
-                        <table className="table"><tbody><tr><td>Not known in ClinVar</td></tr></tbody></table>
+                        <table className="table"><tbody><tr><td>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
                     }
                 </div>
 
@@ -372,7 +372,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </tbody>
                         </table>
                         :
-                         <table className="table"><tbody><tr><td>Unable to find transcripts</td></tr></tbody></table>
+                         <table className="table"><tbody><tr><td>No data was found for this allele in Ensembl. <a href="http://www.ensembl.org/Homo_sapiens/Info/Index" target="_blank">Search Ensembl</a> for this variant.</td></tr></tbody></table>
                     }
                 </div>
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -5,8 +5,8 @@ var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
-//var LocalStorageMixin = require('react-localstorage');
 var SO_terms = require('./mapping/SO_term.json');
+var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
 
 var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
@@ -24,6 +24,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         return {
             clinvar_id: null, // ClinVar ID
             car_id: null, // ClinGen Allele Registry ID
+            clinvar_hgvs_names: [],
             dbSNP_id: null,
             nucleotide_change: [],
             molecular_consequence: [],
@@ -83,6 +84,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 var variantData = parseClinvar(xml, true);
                 this.setState({
                     hasRefseqData: true,
+                    clinvar_hgvs_names: this.parseHgvsNames(variantData.hgvsNames),
                     nucleotide_change: variantData.RefSeqTranscripts.NucleotideChangeList,
                     protein_change: variantData.RefSeqTranscripts.ProteinChangeList,
                     molecular_consequence: variantData.RefSeqTranscripts.MolecularConsequenceList,
@@ -98,6 +100,25 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 console.log('RefSeq Fetch Error=: %o', e);
             });
         }
+    },
+
+    // Return all RefSeq hgvsNames in an array
+    parseHgvsNames: function(hgvsNames) {
+        var hgvs_names = [], NC_terms = [];
+        if (hgvsNames) {
+            if (hgvsNames.GRCh38) {
+                NC_terms.push(hgvsNames.GRCh38);
+            }
+            if (hgvsNames.GRCh37) {
+                NC_terms.push(hgvsNames.GRCh37);
+            }
+            if (hgvsNames.others) {
+                hgvs_names = NC_terms.concat(hgvsNames.others);
+            } else {
+                hgvs_names = NC_terms;
+            }
+        }
+        return hgvs_names;
     },
 
     // Create primary transcript object
@@ -126,10 +147,21 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     fetchEnsemblData: function() {
         var variant = this.props.data;
         if (variant) {
-            // Extract only the number portion of the dbSNP id
-            var numberPattern = /\d+/g;
-            var rsid = (variant.dbSNPIds) ? variant.dbSNPIds[0].match(numberPattern) : '';
-            this.getRestData(this.props.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
+            // Due to GRCh38 HGVS notations being used at Ensembl for their VEP API
+            // We are extracting genomic substring from HGVS name whose assembly is GRCh38
+            // Both of "GRCh38" and "gRCh38" instances are possibly present in the variant object
+            var hgvs_GRCh38 = (variant.hgvsNames.GRCh38) ? variant.hgvsNames.GRCh38 : variant.hgvsNames.gRCh38;
+            var NC_genomic = hgvs_GRCh38.substr(0, hgvs_GRCh38.indexOf(':'));
+            // 'genomic_chr_mapping' is defined via requiring external mapping file
+            var found = genomic_chr_mapping.GRCh38.find((entry) => entry.GenomicRefSeq === NC_genomic);
+            // Can't simply filter alpha letters due to the presence of 'chrX' and 'chrY'
+            var chrosome = (found.ChrFormat) ? found.ChrFormat.substr(3) : '';
+            // Format hgvs_notation for vep/:species/hgvs/:hgvs_notation api
+            var hgvs_notation = chrosome + hgvs_GRCh38.slice(hgvs_GRCh38.indexOf(':'));
+            if (hgvs_notation.indexOf('del') > 0) {
+                hgvs_notation = hgvs_notation.substring(0, hgvs_notation.indexOf('del') + 3);
+            }
+            this.getRestData(this.props.protocol + external_url_map['EnsemblHgvsVEP'] + hgvs_notation + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
                 this.setState({
                     hasEnsemblData: true,
                     ensembl_transcripts: response[0].transcript_consequences
@@ -137,6 +169,22 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             }).catch(function(e) {
                 console.log('Ensembl Fetch Error=: %o', e);
             });
+        }
+    },
+
+    //Render Ensembl transcripts table rows
+    renderEnsemblData: function(item, key) {
+        // Only if nucleotide transcripts exist
+        if (item.hgvsc) {
+            return (
+                <tr key={key}>
+                    <td>{item.hgvsc}</td>
+                    <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
+                    <td>
+                        {(item.consequence_terms) ? this.handleSOTerms(item.consequence_terms) : '--'}
+                    </td>
+                </tr>
+            );
         }
     },
 
@@ -229,58 +277,76 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var GRCh37 = this.state.hgvs_GRCh37;
         var GRCh38 = this.state.hgvs_GRCh38;
         var primary_transcript = this.state.primary_transcript;
+        var clinvar_hgvs_names = this.state.clinvar_hgvs_names;
         var self = this;
 
         return (
             <div className="variant-interpretation basic-info">
-                <div className="bs-callout bs-callout-info clearfix">
-                    <div className="bs-callout-content-container">
-                        <h4>IDs</h4>
-                        <ul>
-                            {(clinvar_id) ? <li><span>ClinVar Variation ID: {clinvar_id}</span></li> : null}
-                            {(car_id) ? <li><span>ClinGen Allele ID: {car_id}</span></li> : null}
-                            {(dbSNP_id) ? <li><span>dbSNP ID: {dbSNP_id}</span></li> : null}
-                        </ul>
+                {(GRCh37 || GRCh38) ?
+                    <div className="bs-callout bs-callout-info clearfix">
+                        <div className="bs-callout-content-container">
+                            <h4>Genomic</h4>
+                            <ul>
+                                {(GRCh38) ? <li><span>{GRCh38 + ' (GRCh38)'}</span></li> : null}
+                                {(GRCh37) ? <li><span>{GRCh37 + ' (GRCh37)'}</span></li> : null}
+                            </ul>
+                        </div>
                     </div>
-                    {(GRCh37 || GRCh38) ?
-                    <div className="bs-callout-content-container">
-                        <h4>Genomic</h4>
-                        <ul>
-                            {(GRCh38) ? <li><span>{GRCh38 + ' (GRCh38)'}</span></li> : null}
-                            {(GRCh37) ? <li><span>{GRCh37 + ' (GRCh37)'}</span></li> : null}
-                        </ul>
-                    </div>
-                    : null}
+                : null}
+
+                <div className="panel panel-info">
+                    <div className="panel-heading"><h3 className="panel-title">ClinVar Primary Transcript</h3></div>
+                    {(primary_transcript) ?
+                        <table className="table">
+                            <thead>
+                                <tr>
+                                    <th>Nucleotide Change</th>
+                                    <th>Protein Change</th>
+                                    <th>Molecular Consequence</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        {(primary_transcript) ? primary_transcript.nucleotide : '--'}
+                                    </td>
+                                    <td>
+                                        {(primary_transcript) ? primary_transcript.protein : '--'}
+                                    </td>
+                                    <td>
+                                        {(primary_transcript) ? primary_transcript.molecular : '--'}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        :
+                        <table className="table"><tbody><tr><td>Not known in ClinVar</td></tr></tbody></table>
+                    }
                 </div>
 
                 <div className="panel panel-info">
-                    <div className="panel-heading"><h3 className="panel-title">Primary Transcript</h3></div>
-                    <table className="table">
-                        <thead>
-                            <tr>
-                                <th>Nucleotide Change</th>
-                                <th>Protein Change</th>
-                                <th>Molecular Consequence</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    {(primary_transcript) ? primary_transcript.nucleotide : '--'}
-                                </td>
-                                <td>
-                                    {(primary_transcript) ? primary_transcript.protein : '--'}
-                                </td>
-                                <td>
-                                    {(primary_transcript) ? primary_transcript.molecular : '--'}
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <div className="panel-heading"><h3 className="panel-title">RefSeq Transcripts</h3></div>
+                    {(clinvar_hgvs_names) ?
+                        <table className="table">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <ul>
+                                            {clinvar_hgvs_names.map(function(name, index) {
+                                                return <li key={index}>{name}</li>;
+                                            })}
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        :
+                        <table className="table"><tbody><tr><td>Not known in ClinVar</td></tr></tbody></table>
+                    }
                 </div>
 
                 <div className="panel panel-info">
-                    <div className="panel-heading"><h3 className="panel-title">All Transcripts</h3></div>
+                    <div className="panel-heading"><h3 className="panel-title">Ensembl Transcripts</h3></div>
                     <table className="table">
                         <thead>
                             <tr>
@@ -291,15 +357,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                         </thead>
                         <tbody>
                             {ensembl_data.map(function(item, i) {
-                                return (
-                                    <tr key={i}>
-                                        <td>{item.hgvsc}</td>
-                                        <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
-                                        <td>
-                                            {(item.consequence_terms) ? self.handleSOTerms(item.consequence_terms) : '--'}
-                                        </td>
-                                    </tr>
-                                );
+                                return (self.renderEnsemblData(item, i));
                             })}
                         </tbody>
                     </table>
@@ -312,7 +370,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <dd>Variation Viewer [<a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh38')} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> - <a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh37')} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a>]</dd>
                             <dd>Ensembl Browser [<a href={dbxref_prefix_map['ENSEMBL'] + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>GRCh38</a>]</dd>
                             <dd>UCSC [<a href={this.ucscViewerURL(sequence_location, 'hg38', 'GRCh38')} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> - <a href={this.ucscViewerURL(sequence_location, 'hg19', 'GRCh37')} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a>]</dd>
-                            <dd><a href={dbxref_prefix_map['UniProtKB'] + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd>
+                            { /* <dd><a href={dbxref_prefix_map['UniProtKB'] + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd> */ }
                         </dl>
                     </div>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -102,20 +102,12 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
     },
 
-    // Return all RefSeq hgvsNames in an array
+    // Return all non NC_ genomic hgvsNames in an array
     parseHgvsNames: function(hgvsNames) {
-        var hgvs_names = [], NC_terms = [];
+        var hgvs_names = [];
         if (hgvsNames) {
-            if (hgvsNames.GRCh38) {
-                NC_terms.push(hgvsNames.GRCh38);
-            }
-            if (hgvsNames.GRCh37) {
-                NC_terms.push(hgvsNames.GRCh37);
-            }
             if (hgvsNames.others) {
-                hgvs_names = NC_terms.concat(hgvsNames.others);
-            } else {
-                hgvs_names = NC_terms;
+                hgvs_names = hgvsNames.others;
             }
         }
         return hgvs_names;

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/NC_genomic_chr_format.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/NC_genomic_chr_format.json
@@ -1,98 +1,198 @@
-[
-  {
-    "GenomicRefSeq": "NC_000001.10",
-    "ChrFormat": "chr1"
-  },
-  {
-    "GenomicRefSeq": "NC_000002.11",
-    "ChrFormat": "chr2"
-  },
-  {
-    "GenomicRefSeq": "NC_000003.11",
-    "ChrFormat": "chr3"
-  },
-  {
-    "GenomicRefSeq": "NC_000004.11",
-    "ChrFormat": "chr4"
-  },
-  {
-    "GenomicRefSeq": "NC_000005.9",
-    "ChrFormat": "chr5"
-  },
-  {
-    "GenomicRefSeq": "NC_000006.11",
-    "ChrFormat": "chr6"
-  },
-  {
-    "GenomicRefSeq": "NC_000007.13",
-    "ChrFormat": "chr7"
-  },
-  {
-    "GenomicRefSeq": "NC_000008.10",
-    "ChrFormat": "chr8"
-  },
-  {
-    "GenomicRefSeq": "NC_000009.11",
-    "ChrFormat": "chr9"
-  },
-  {
-    "GenomicRefSeq": "NC_000010.10",
-    "ChrFormat": "chr10"
-  },
-  {
-    "GenomicRefSeq": "NC_000011.9",
-    "ChrFormat": "chr11"
-  },
-  {
-    "GenomicRefSeq": "NC_000012.11",
-    "ChrFormat": "chr12"
-  },
-  {
-    "GenomicRefSeq": "NC_000013.10",
-    "ChrFormat": "chr13"
-  },
-  {
-    "GenomicRefSeq": "NC_000014.8",
-    "ChrFormat": "chr14"
-  },
-  {
-    "GenomicRefSeq": "NC_000015.9",
-    "ChrFormat": "chr15"
-  },
-  {
-    "GenomicRefSeq": "NC_000016.9",
-    "ChrFormat": "chr16"
-  },
-  {
-    "GenomicRefSeq": "NC_000017.10",
-    "ChrFormat": "chr17"
-  },
-  {
-    "GenomicRefSeq": "NC_000018.9",
-    "ChrFormat": "chr18"
-  },
-  {
-    "GenomicRefSeq": "NC_000019.9",
-    "ChrFormat": "chr19"
-  },
-  {
-    "GenomicRefSeq": "NC_000020.10",
-    "ChrFormat": "chr20"
-  },
-  {
-    "GenomicRefSeq": "NC_000021.8",
-    "ChrFormat": "chr21"
-  },
-  {
-    "GenomicRefSeq": "NC_000022.10",
-    "ChrFormat": "chr22"
-  },
-  {
-    "GenomicRefSeq": "NC_000023.10",
-    "ChrFormat": "chrX"
-  },
-  {
-    "GenomicRefSeq": "NC_000024.9",
-    "ChrFormat": "chrY"
-  }
-]
+{
+  "GRCh37": [
+    {
+      "GenomicRefSeq": "NC_000001.10",
+      "ChrFormat": "chr1"
+    },
+    {
+      "GenomicRefSeq": "NC_000002.11",
+      "ChrFormat": "chr2"
+    },
+    {
+      "GenomicRefSeq": "NC_000003.11",
+      "ChrFormat": "chr3"
+    },
+    {
+      "GenomicRefSeq": "NC_000004.11",
+      "ChrFormat": "chr4"
+    },
+    {
+      "GenomicRefSeq": "NC_000005.9",
+      "ChrFormat": "chr5"
+    },
+    {
+      "GenomicRefSeq": "NC_000006.11",
+      "ChrFormat": "chr6"
+    },
+    {
+      "GenomicRefSeq": "NC_000007.13",
+      "ChrFormat": "chr7"
+    },
+    {
+      "GenomicRefSeq": "NC_000008.10",
+      "ChrFormat": "chr8"
+    },
+    {
+      "GenomicRefSeq": "NC_000009.11",
+      "ChrFormat": "chr9"
+    },
+    {
+      "GenomicRefSeq": "NC_000010.10",
+      "ChrFormat": "chr10"
+    },
+    {
+      "GenomicRefSeq": "NC_000011.9",
+      "ChrFormat": "chr11"
+    },
+    {
+      "GenomicRefSeq": "NC_000012.11",
+      "ChrFormat": "chr12"
+    },
+    {
+      "GenomicRefSeq": "NC_000013.10",
+      "ChrFormat": "chr13"
+    },
+    {
+      "GenomicRefSeq": "NC_000014.8",
+      "ChrFormat": "chr14"
+    },
+    {
+      "GenomicRefSeq": "NC_000015.9",
+      "ChrFormat": "chr15"
+    },
+    {
+      "GenomicRefSeq": "NC_000016.9",
+      "ChrFormat": "chr16"
+    },
+    {
+      "GenomicRefSeq": "NC_000017.10",
+      "ChrFormat": "chr17"
+    },
+    {
+      "GenomicRefSeq": "NC_000018.9",
+      "ChrFormat": "chr18"
+    },
+    {
+      "GenomicRefSeq": "NC_000019.9",
+      "ChrFormat": "chr19"
+    },
+    {
+      "GenomicRefSeq": "NC_000020.10",
+      "ChrFormat": "chr20"
+    },
+    {
+      "GenomicRefSeq": "NC_000021.8",
+      "ChrFormat": "chr21"
+    },
+    {
+      "GenomicRefSeq": "NC_000022.10",
+      "ChrFormat": "chr22"
+    },
+    {
+      "GenomicRefSeq": "NC_000023.10",
+      "ChrFormat": "chrX"
+    },
+    {
+      "GenomicRefSeq": "NC_000024.9",
+      "ChrFormat": "chrY"
+    }
+  ],
+  "GRCh38": [
+    {
+      "GenomicRefSeq": "NC_000001.11",
+      "ChrFormat": "chr1"
+    },
+    {
+      "GenomicRefSeq": "NC_000002.12",
+      "ChrFormat": "chr2"
+    },
+    {
+      "GenomicRefSeq": "NC_000003.12",
+      "ChrFormat": "chr3"
+    },
+    {
+      "GenomicRefSeq": "NC_000004.12",
+      "ChrFormat": "chr4"
+    },
+    {
+      "GenomicRefSeq": "NC_000005.10",
+      "ChrFormat": "chr5"
+    },
+    {
+      "GenomicRefSeq": "NC_000006.12",
+      "ChrFormat": "chr6"
+    },
+    {
+      "GenomicRefSeq": "NC_000007.14",
+      "ChrFormat": "chr7"
+    },
+    {
+      "GenomicRefSeq": "NC_000008.11",
+      "ChrFormat": "chr8"
+    },
+    {
+      "GenomicRefSeq": "NC_000009.12",
+      "ChrFormat": "chr9"
+    },
+    {
+      "GenomicRefSeq": "NC_000010.11",
+      "ChrFormat": "chr10"
+    },
+    {
+      "GenomicRefSeq": "NC_000011.10",
+      "ChrFormat": "chr11"
+    },
+    {
+      "GenomicRefSeq": "NC_000012.12",
+      "ChrFormat": "chr12"
+    },
+    {
+      "GenomicRefSeq": "NC_000013.11",
+      "ChrFormat": "chr13"
+    },
+    {
+      "GenomicRefSeq": "NC_000014.9",
+      "ChrFormat": "chr14"
+    },
+    {
+      "GenomicRefSeq": "NC_000015.10",
+      "ChrFormat": "chr15"
+    },
+    {
+      "GenomicRefSeq": "NC_000016.10",
+      "ChrFormat": "chr16"
+    },
+    {
+      "GenomicRefSeq": "NC_000017.11",
+      "ChrFormat": "chr17"
+    },
+    {
+      "GenomicRefSeq": "NC_000018.10",
+      "ChrFormat": "chr18"
+    },
+    {
+      "GenomicRefSeq": "NC_000019.10",
+      "ChrFormat": "chr19"
+    },
+    {
+      "GenomicRefSeq": "NC_000020.11",
+      "ChrFormat": "chr20"
+    },
+    {
+      "GenomicRefSeq": "NC_000021.9",
+      "ChrFormat": "chr21"
+    },
+    {
+      "GenomicRefSeq": "NC_000022.11",
+      "ChrFormat": "chr22"
+    },
+    {
+      "GenomicRefSeq": "NC_000023.11",
+      "ChrFormat": "chrX"
+    },
+    {
+      "GenomicRefSeq": "NC_000024.10",
+      "ChrFormat": "chrY"
+    }
+  ]
+}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -121,7 +121,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             var hgvs_GRCh37 = (variant.hgvsNames.GRCh37) ? variant.hgvsNames.GRCh37 : variant.hgvsNames.gRCh37;
             var NC_genomic = hgvs_GRCh37.substr(0, hgvs_GRCh37.indexOf(':'));
             // 'genomic_chr_mapping' is defined via requiring external mapping file
-            var found = genomic_chr_mapping.find((entry) => entry.GenomicRefSeq === NC_genomic);
+            var found = genomic_chr_mapping.GRCh37.find((entry) => entry.GenomicRefSeq === NC_genomic);
             // Format variant_id for use of myvariant.info REST API
             var variant_id = found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':'));
             if (variant_id.indexOf('del') > 0) {


### PR DESCRIPTION
This PR consists of changes pertinent to the Basic Info tab in addressing the following:
* Remove IDs (e.g. ClinVar Variation ID, dbSNP ID) from top of basic information tab since they are already displayed in the static header.
* Change the title of the first table from "Primary Transcript" to "ClinVar Primary Transcript".
* If a variant is not in ClinVar then put "No data was found for this allele in ClinVar. Search ClinVar for this variant." in this table.
* For now, add a table with a list of non NC_ hgvs names obtained from RefSeq if the variant is in ClinVar.
* Comment out "non-functional" Uniprot ID at the bottom of the tab temporarily.
* In the Ensembl transcript table, use the GRCh38 hgvs notation in the API call instead of the rsID to only obtain the relevant allele transcripts.
* Suppress the display of respective LinkOut links at the bottom of tab if either a variant is not in Clinvar or no data can be retrieved from Ensembl.

**Known issues:**
* When using Ensembl VEP api, only GRCh38 hgvs notation can return results.
* Tab's bottom LinkOut links are dependent on various pieces of obtained data from APIs to construct the URLs.
* When starting with a CA ID in the variant selection, choosing certain CD ID (e.g. "CA501068") does not return the expected GRCh38 hgvs name, although the GRCh37 hgvs name is in the response. As a result, there won't be any data displayed in the Ensembl table.

**Technical details:**
* Added mappings of GRCh38's NC_ genomic to chromosome to the mapping JSON file.
* Updated code to account for the absence of variant in ClinVar.

**Steps to test this PR:**
1. Login and proceed to the variant selection interface.
2. Expect the "pertinent" changes described above to be verifiable.
3. Try the following CA IDs to observe the different display of data: CA016023, CA501068, CA501058.
* CA016023 - returns both GRCh37 and GRCh38 and thus all 3 tables are expected to have data displayed.
* CA501068 - returns only GRCh37 and the variant does not exist in ClinVar. Thus none of the tables are expected to have data displayed.
* CA501058 - returns only GRCh38 and the variant does not exist in ClinVar. Thus only the "Ensembl Transcripts" table is expected to have data displayed.