### PR TITLE
Connects to #760 kl non clinvar title

### DIFF
--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -11,7 +11,7 @@ var Title = module.exports.Title = React.createClass({
         var variant = this.props.data;
         var variantTitle = (variant && variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : null;
         if (variant && !variantTitle && variant.hgvsNames && variant.hgvsNames != {}) {
-            variantTitle = variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38+' (GRCh38)': (variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37+' (GRCh37)' : variant.hgvsNames.others[0]);
+            variantTitle = variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38+' (GRCh38)': (variant.carId ? variant.carId : null);
         } else if (!variantTitle) {
             variantTitle = 'A preferred title is not available';
         }

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -9,14 +9,20 @@ var Title = module.exports.Title = React.createClass({
 
     render: function() {
         var variant = this.props.data;
+        var variantTitle = (variant && variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : null;
+        if (variant && !variantTitle && variant.hgvsNames && variant.hgvsNames != {}) {
+            variantTitle = variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38+' (GRCh38)': (variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37+' (GRCh37)' : variant.hgvsNames.others[0]);
+        } else if (!variantTitle) {
+            variantTitle = 'A preferred title is not available';
+        }
+
         if (variant) {
-            var clinVarTitle = (variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : 'A preferred title is not available';
             var associatedDisease = (variant.disease) ? variant.disease : 'Not yet associated with a disease';
         }
 
         return (
             <div>
-                <h1>{clinVarTitle}{this.props.children}</h1>
+                <h1>{variantTitle}{this.props.children}</h1>
                 <h2>{associatedDisease}</h2>
             </div>
         );


### PR DESCRIPTION
The final decision is set as following order:
* display ClinVar preferred title for any ClinVar variant,
* display NC_ genomic GRCh38 for any non-ClinVar variant if it has NC_ HGVS GRCh38,
* display CAR id, otherwise

**Test**
* In Select Variant page, select ClinGen Allele Registry ID, enter CA144043 (this is ClinVar varaint), Save. Expect to see
![screen shot 2016-07-11 at 11 57 00 am](https://cloud.githubusercontent.com/assets/9206696/16742871/9e237ae0-475e-11e6-8712-222fc40a54c9.png)
* Go back to Select Variant page, select ClinGen Allele Registry ID, enter  CA501058 (this variant has no ClinVar data but a NC_ HGVS), Save. Expect to see
![screen shot 2016-07-11 at 11 57 57 am](https://cloud.githubusercontent.com/assets/9206696/16742925/d157a7b0-475e-11e6-8f90-80da50416125.png)
* Go back to Select Variant page, select ClinGen Allele Registry ID, enter CA501064 (this one has neither ClinVar data no NC_ HGVS). Expect to see
![screen shot 2016-07-11 at 11 59 41 am](https://cloud.githubusercontent.com/assets/9206696/16742967/fb773290-475e-11e6-9c0d-391b38cc05b7.png)
**End Test** 