### PR TITLE
Connects to #737. Connects to #788. Calculate CI and standardize decimal places on pop tab

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -45,8 +45,11 @@ var VariantCurationHub = React.createClass({
         });
     },
 
-    updateInterpretationObj: function(interpretation) {
-        this.setState({interpretation: interpretation});
+    // method to update the interpretation object and send it down to child components on demand
+    updateInterpretationObj: function() {
+        this.getRestData('/interpretation/' + this.state.interpretationUuid).then(interpretation => {
+            this.setState({interpretation: interpretation});
+        });
     },
 
     render: function() {

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var _ = require('underscore');
 var globals = require('../globals');
 
 var queryKeyValue = globals.queryKeyValue;
@@ -46,8 +47,17 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     getInitialState: function() {
         return {
+            interpretation: this.props.interpretation,
             selectedTab: (this.props.href_url.href ? tabList.indexOf(queryKeyValue('tab', this.props.href_url.href)) : 0) // set selectedTab to whatever is defined in the address; default to first tab if not set
         };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        // this block is for handling props and states when props (external data) is updated after the initial load/rendering
+        // when props are updated, update the parent interpreatation object, if applicable
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
     },
 
     // set selectedTab to whichever tab the user switches to, and update the address accordingly
@@ -62,7 +72,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     render: function() {
         var variant = this.props.variantData;
-        var interpretation = this.props.interpretation;
+        var interpretation = this.state.interpretation;
 
         // The ordering of TabPanels are corresponding to that of tabs
         // Adding or deleting a tab also requires its corresponding TabPanel to be added/deleted

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -367,22 +367,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 }
             }
         });
-        // check against 1000g data
-        populationStatic.tGenomes._order.map(pop => {
-            let ref = populationObj.tGenomes._extra.ref,
-                alt = populationObj.tGenomes._extra.alt;
-            if (populationObj.tGenomes[pop].af && populationObj.tGenomes[pop].af[alt]) {
-                if (populationObj.tGenomes[pop].af[alt] > highestMAFObj.af) {
-                    highestMAFObj.pop = pop;
-                    highestMAFObj.popLabel = populationStatic.tGenomes._labels[pop];
-                    highestMAFObj.ac = populationObj.tGenomes[pop].ac[alt];
-                    highestMAFObj.ac_tot = populationObj.tGenomes[pop].ac[ref] + populationObj.tGenomes[pop].ac[alt];
-                    highestMAFObj.source = '1000 Genomes';
-                    highestMAFObj.af = populationObj.tGenomes[pop].af[alt];
-                }
-            }
-        });
-        // check against esp data
+        // check against esp data - done before 1000g's so that it takes precedence in case of tie
+        // due to 1000g also carrying esp data
         populationStatic.esp._order.map(pop => {
             let alt = populationObj.esp._extra.alt;
             if (populationObj.esp[pop].ac) {
@@ -397,6 +383,21 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     highestMAFObj.ac_tot = populationObj.esp[pop].ac[ref] + populationObj.esp[pop].ac[alt];
                     highestMAFObj.source = 'ESP';
                     highestMAFObj.af = tempMAF;
+                }
+            }
+        });
+        // check against 1000g data
+        populationStatic.tGenomes._order.map(pop => {
+            let ref = populationObj.tGenomes._extra.ref,
+                alt = populationObj.tGenomes._extra.alt;
+            if (populationObj.tGenomes[pop].af && populationObj.tGenomes[pop].af[alt]) {
+                if (populationObj.tGenomes[pop].af[alt] > highestMAFObj.af) {
+                    highestMAFObj.pop = pop;
+                    highestMAFObj.popLabel = populationStatic.tGenomes._labels[pop];
+                    highestMAFObj.ac = populationObj.tGenomes[pop].ac[alt];
+                    highestMAFObj.ac_tot = populationObj.tGenomes[pop].ac[ref] + populationObj.tGenomes[pop].ac[alt];
+                    highestMAFObj.source = '1000 Genomes';
+                    highestMAFObj.af = populationObj.tGenomes[pop].af[alt];
                 }
             }
         });
@@ -567,17 +568,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
         return (
             <div className="variant-interpretation population">
-                {(this.props.data && this.state.interpretation) ?
-                <div className="row">
-                    <div className="col-sm-12">
-                        <CurationInterpretationForm formTitle={"Population Criteria Evaluation"} renderedFormContent={criteriaGroup1}
-                            evidenceType={'population'} evidenceData={this.state.populationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
-                            formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BA1', 'PM2']} criteriaDisease={['BS1']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                    </div>
-                </div>
-                : null}
-
                 <div className="bs-callout bs-callout-info clearfix">
                     <h4>Highest Minor Allele Frequency</h4>
                     <div className="clearfix">
@@ -617,12 +607,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     : null}
                 </div>
 
-                {(this.state.interpretationUuid) ?
-                <ul className="section-criteria-evaluation clearfix">
-                    <li className="col-xs-12 gutter-exc">
-                        <CurationInterpretationForm />
-                    </li>
-                </ul>
+
+                {(this.props.data && this.state.interpretation) ?
+                <div className="row">
+                    <div className="col-sm-12">
+                        <CurationInterpretationForm formTitle={"Population Criteria Evaluation"} renderedFormContent={criteriaGroup1}
+                            evidenceType={'population'} evidenceData={this.state.populationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
+                            formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BA1', 'PM2']} criteriaDisease={['BS1']}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    </div>
+                </div>
                 : null}
 
                 {this.state.hasExacData ?

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -385,7 +385,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     highestMAFObj.popLabel = populationStatic.tGenomes._labels[pop];
                     highestMAFObj.ac = populationObj.tGenomes[pop].ac[alt];
                     highestMAFObj.ac_tot = populationObj.tGenomes[pop].ac[ref] + populationObj.tGenomes[pop].ac[alt];
-                    highestMAFObj.source = '1000 Genomes';
+                    highestMAFObj.source = (pop == 'espaa' || pop == 'espea') ? 'ESP (provided by 1000 Genomes)' : '1000 Genomes';
                     highestMAFObj.af = populationObj.tGenomes[pop].af[alt];
                 }
             }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -607,7 +607,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     : null}
                 </div>
 
-
                 {(this.props.data && this.state.interpretation) ?
                 <div className="row">
                     <div className="col-sm-12">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -58,6 +58,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             hasTGenomesData: false,
             hasEspData: false, // flag to display ESP table
             geneENSG: null,
+            CILow: null,
+            CIhigh: null,
             populationObj: {
                 highestMAF: null,
                 exac: {
@@ -164,14 +166,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
     },
 
+    parseFloatShort: function(float) {
+        return +parseFloat(float).toFixed(5);
+    },
+
     // Get ExAC allele frequency from Ensembl (VEP) directly
     // Because myvariant.info doesn't always return ExAC allele frequency data
     parseAlleleFrequencyData: function(response) {
         let populationObj = this.state.populationObj;
         populationStatic.exac._order.map(key => {
-            populationObj.exac[key].af = parseFloat(response[0].colocated_variants[0]['exac_' + key + '_maf']);
+            populationObj.exac[key].af = this.parseFloatShort(response[0].colocated_variants[0]['exac_' + key + '_maf']);
         });
-        populationObj.exac._tot.af = parseFloat(response[0].colocated_variants[0].exac_adj_maf);
+        populationObj.exac._tot.af = this.parseFloatShort(response[0].colocated_variants[0].exac_adj_maf);
 
         this.setState({populationObj: populationObj});
     },
@@ -241,25 +247,25 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... for specific populations =
                         populationObj.tGenomes[populationCode].ac[population.allele] = parseInt(population.allele_count);
-                        populationObj.tGenomes[populationCode].af[population.allele] = parseFloat(population.frequency);
+                        populationObj.tGenomes[populationCode].af[population.allele] = this.parseFloatShort(population.frequency);
                         updated1000GData = true;
                     } else if (population.population == '1000GENOMES:phase_3:ALL') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and totals
                         populationObj.tGenomes._tot.ac[population.allele] = parseInt(population.allele_count);
-                        populationObj.tGenomes._tot.af[population.allele] = parseFloat(population.frequency);
+                        populationObj.tGenomes._tot.af[population.allele] = this.parseFloatShort(population.frequency);
                         updated1000GData = true;
                     } else if (population.population == 'ESP6500:African_American') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and ESP AA
                         populationObj.tGenomes.espaa.ac[population.allele] = parseInt(population.allele_count);
-                        populationObj.tGenomes.espaa.af[population.allele] = parseFloat(population.frequency);
+                        populationObj.tGenomes.espaa.af[population.allele] = this.parseFloatShort(population.frequency);
                         updated1000GData = true;
                     } else if (population.population == 'ESP6500:European_American') {
                         this.parseTGenomesDataAltAllele(populationObj, population);
                         // ... and ESP EA
                         populationObj.tGenomes.espea.ac[population.allele] = parseInt(population.allele_count);
-                        populationObj.tGenomes.espea.af[population.allele] = parseFloat(population.frequency);
+                        populationObj.tGenomes.espea.af[population.allele] = this.parseFloatShort(population.frequency);
                         updated1000GData = true;
                     }
                 });
@@ -273,22 +279,22 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         populationStatic.tGenomes._order.indexOf(populationCode) > 0) {
                         // ... for specific populations
                         populationObj.tGenomes[populationCode].gc[population_genotype.genotype] = parseInt(population_genotype.count);
-                        populationObj.tGenomes[populationCode].gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        populationObj.tGenomes[populationCode].gf[population_genotype.genotype] = this.parseFloatShort(population_genotype.frequency);
                         updated1000GData = true;
                     } else if (population_genotype.population == '1000GENOMES:phase_3:ALL') {
                         // ... and totals
                         populationObj.tGenomes._tot.gc[population_genotype.genotype] = parseInt(population_genotype.count);
-                        populationObj.tGenomes._tot.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        populationObj.tGenomes._tot.gf[population_genotype.genotype] = this.parseFloatShort(population_genotype.frequency);
                         updated1000GData = true;
                     } else if (population_genotype.population == 'ESP6500:African_American') {
                         // ... and ESP AA
                         populationObj.tGenomes.espaa.gc[population_genotype.genotype] = parseInt(population_genotype.count);
-                        populationObj.tGenomes.espaa.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        populationObj.tGenomes.espaa.gf[population_genotype.genotype] = this.parseFloatShort(population_genotype.frequency);
                         updated1000GData = true;
                     } else if (population_genotype.population == 'ESP6500:European_American') {
                         // ... and ESP EA
                         populationObj.tGenomes.espea.gc[population_genotype.genotype] = parseInt(population_genotype.count);
-                        populationObj.tGenomes.espea.gf[population_genotype.genotype] = parseFloat(population_genotype.frequency);
+                        populationObj.tGenomes.espea.gf[population_genotype.genotype] = this.parseFloatShort(population_genotype.frequency);
                         updated1000GData = true;
                     }
                 });
@@ -377,7 +383,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 let ref = populationObj.esp._extra.ref,
                     alt = populationObj.esp._extra.alt;
                 // esp does not report back frequencies, so we have to calculate it off counts
-                let tempMAF = populationObj.esp[pop].ac[alt] / (populationObj.esp[pop].ac[ref] + populationObj.esp[pop].ac[alt]);
+                let tempMAF = this.parseFloatShort(populationObj.esp[pop].ac[alt] / (populationObj.esp[pop].ac[ref] + populationObj.esp[pop].ac[alt]));
                 if (tempMAF > highestMAFObj.af) {
                     highestMAFObj.pop = pop;
                     highestMAFObj.popLabel = populationStatic.esp._labels[pop];
@@ -454,28 +460,27 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         );
     },
 
+    // wrapper function to calculateCI on value change
     changeDesiredCI: function(ref, e) {
-        console.log(ref);
-        console.log(this.refs);
-        console.log(this.refs[ref].valueAsNumber);
-        this.calculateCI(this.refs[ref].valueAsNumber, this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
+        this.calculateCI(parseInt(this.refs.desiredCI.getValue()), this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
     },
 
     // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
     calculateCI: function(CIp, highestMAF) {
         //let CIp = this.refs[ref].getValue();
-        if (highestMAF && 0 <= CIp <= 100) {
-            let xp = highestMAF.ac,
-                np = highestMAF.ac_tot,
-                CIp = 95;
-            let zp = -this.normSInv((1 - CIp / 100) / 2),
-                pp = xp / np,
-                qp = 1 - pp;
-            let CILow = ((2 * np * pp) + (zp * zp) - zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp))),
-                CIHigh = ((2 * np * pp) + (zp * zp) + zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp)));
-            console.log(zp);
-            console.log(CILow);
-            console.log(CIHigh);
+        if (highestMAF) {
+            if (isNaN(CIp) || CIp < 0 || CIp > 100) {
+                this.setState({CILow: null, CIHigh: null});
+            } else {
+                let xp = highestMAF.ac,
+                    np = highestMAF.ac_tot;
+                let zp = -this.normSInv((1 - CIp / 100) / 2),
+                    pp = xp / np,
+                    qp = 1 - pp;
+                let CILow = this.parseFloatShort(((2 * np * pp) + (zp * zp) - zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp)))),
+                    CIHigh = this.parseFloatShort(((2 * np * pp) + (zp * zp) + zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp))));
+                this.setState({CILow: CILow, CIHigh: CIHigh});
+            }
         }
     },
 
@@ -548,11 +553,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                 <dt>Allele Frequency: </dt><dd>{highestMAF && highestMAF.af ? highestMAF.af : 'N/A'}</dd>
                                 {(this.state.interpretation && highestMAF) ?
                                     <span>
-                                        <dt>Desired CI:</dt><dd>
-                                        <input type="number" ref="desiredCI" defaultValue={"95"} onChange={this.changeDesiredCI} min="0" max="100" maxLength="2" />
-                                        </dd>
-                                        <dt>CI - lower: </dt><dd>XXXXXX</dd>
-                                        <dt>CI - upper: </dt><dd>XXXXXX</dd>
+                                        <dt className="dtFormLabel">Desired CI:</dt>
+                                        <dd className="ddFormInput"><Input type="number" ref="desiredCI" value="95" handleChange={this.changeDesiredCI} min="0" max="100" maxLength="2" /></dd>
+                                        <dt>CI - lower: </dt><dd>{this.state.CILow ? this.state.CILow : ''}</dd>
+                                        <dt>CI - upper: </dt><dd>{this.state.CIHigh ? this.state.CIHigh : ''}</dd>
                                     </span>
                                 : null}
                             </dl>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -38,7 +38,7 @@ var populationStatic = {
 
 // Display the population data of external sources
 var CurationInterpretationPopulation = module.exports.CurationInterpretationPopulation = React.createClass({
-    mixins: [RestMixin],
+    mixins: [RestMixin, FormMixin],
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
@@ -454,6 +454,61 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         );
     },
 
+    changeDesiredCI: function(ref, e) {
+        console.log(ref);
+        console.log(this.refs);
+        //this.calculateCI(CIp, highestMAF);
+    },
+
+    // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
+    calculateCI: function(CIp, highestMAF) {
+        //let CIp = this.refs[ref].getValue();
+        if (highestMAF && 0 <= CIp <= 100) {
+            let xp = highestMAF.ac,
+                np = highestMAF.ac_tot,
+                CIp = 95;
+            let zp = -this.normSInv((1 - CIp / 100) / 2),
+                pp = xp / np,
+                qp = 1 - pp;
+            let CILow = ((2 * np * pp) + (zp * zp) - zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp))),
+                CIHigh = ((2 * np * pp) + (zp * zp) + zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp)));
+            console.log(zp);
+            console.log(CILow);
+            console.log(CIHigh);
+        }
+    },
+
+    // NORMSINV implementation taken from http://stackoverflow.com/a/8843728
+    // used for CI calculation
+    normSInv: function (p) {
+        let a1 = -39.6968302866538, a2 = 220.946098424521, a3 = -275.928510446969;
+        let a4 = 138.357751867269, a5 = -30.6647980661472, a6 = 2.50662827745924;
+        let b1 = -54.4760987982241, b2 = 161.585836858041, b3 = -155.698979859887;
+        let b4 = 66.8013118877197, b5 = -13.2806815528857, c1 = -7.78489400243029E-03;
+        let c2 = -0.322396458041136, c3 = -2.40075827716184, c4 = -2.54973253934373;
+        let c5 = 4.37466414146497, c6 = 2.93816398269878, d1 = 7.78469570904146E-03;
+        let d2 = 0.32246712907004, d3 = 2.445134137143, d4 = 3.75440866190742;
+        let p_low = 0.02425, p_high = 1 - p_low;
+        let q, r;
+        let retVal;
+
+        if ((p < 0) || (p > 1)) {
+            alert("NormSInv: Argument out of range.");
+            retVal = 0;
+        } else if (p < p_low) {
+            q = Math.sqrt(-2 * Math.log(p));
+            retVal = (((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6) / ((((d1 * q + d2) * q + d3) * q + d4) * q + 1);
+        } else if (p <= p_high) {
+            q = p - 0.5;
+            r = q * q;
+            retVal = (((((a1 * r + a2) * r + a3) * r + a4) * r + a5) * r + a6) * q / (((((b1 * r + b2) * r + b3) * r + b4) * r + b5) * r + 1);
+        } else {
+            q = Math.sqrt(-2 * Math.log(1 - p));
+            retVal = -(((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6) / ((((d1 * q + d2) * q + d3) * q + d4) * q + 1);
+        }
+        return retVal;
+    },
+
     render: function() {
         var exacStatic = populationStatic.exac,
             tGenomesStatic = populationStatic.tGenomes,
@@ -494,8 +549,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <dl className="inline-dl clearfix">
                                 <dt>Source: </dt><dd>{highestMAF && highestMAF.source ? highestMAF.source : 'N/A'}</dd>
                                 <dt>Allele Frequency: </dt><dd>{highestMAF && highestMAF.af ? highestMAF.af : 'N/A'}</dd>
-                                {(this.state.interpretation) ?
+                                {(this.state.interpretation && highestMAF) ?
                                     <span>
+                                        <dt>Desired CI:</dt><dd>
+                                        <Form><input type="number" name="desiredCI" defaultValue={"95"} onChange={this.changeDesiredCI} maxLength="2" /></Form>
+                                        </dd>
                                         <dt>CI - lower: </dt><dd>XXXXXX</dd>
                                         <dt>CI - upper: </dt><dd>XXXXXX</dd>
                                     </span>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -38,7 +38,7 @@ var populationStatic = {
 
 // Display the population data of external sources
 var CurationInterpretationPopulation = module.exports.CurationInterpretationPopulation = React.createClass({
-    mixins: [RestMixin, FormMixin],
+    mixins: [RestMixin],
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
@@ -457,7 +457,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     changeDesiredCI: function(ref, e) {
         console.log(ref);
         console.log(this.refs);
-        //this.calculateCI(CIp, highestMAF);
+        console.log(this.refs[ref].valueAsNumber);
+        this.calculateCI(this.refs[ref].valueAsNumber, this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
     },
 
     // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
@@ -552,7 +553,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                 {(this.state.interpretation && highestMAF) ?
                                     <span>
                                         <dt>Desired CI:</dt><dd>
-                                        <Form><input type="number" name="desiredCI" defaultValue={"95"} onChange={this.changeDesiredCI} maxLength="2" /></Form>
+                                        <input type="number" ref="desiredCI" defaultValue={"95"} onChange={this.changeDesiredCI} min="0" max="100" maxLength="2" />
                                         </dd>
                                         <dt>CI - lower: </dt><dd>XXXXXX</dd>
                                         <dt>CI - upper: </dt><dd>XXXXXX</dd>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -35,6 +35,7 @@ var populationStatic = {
         _labels: {ea: 'EA Allele', aa: 'AA Allele'}
     }
 };
+var CI_DEFAULT = 95;
 
 // Display the population data of external sources
 var CurationInterpretationPopulation = module.exports.CurationInterpretationPopulation = React.createClass({
@@ -478,7 +479,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             }
         }
         if (!this.state.desiredCIDisplay) {
-            this.setState({desiredCIDisplay: 95});
+            this.setState({desiredCIDisplay: CI_DEFAULT});
         }
         this.changeDesiredCI();
     },
@@ -486,7 +487,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     // wrapper function to calculateCI on value change
     changeDesiredCI: function(forceDefault) {
         if (this.refs && this.refs.desiredCI) {
-            this.calculateCI(forceDefault ? 95 : parseInt(this.refs.desiredCI.getValue()), this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
+            this.calculateCI(forceDefault ? CI_DEFAULT : parseInt(this.refs.desiredCI.getValue()), this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
         }
     },
 
@@ -495,8 +496,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         let desiredCI = parseInt(this.refs.desiredCI.getValue());
         if (desiredCI == '' || isNaN(desiredCI)) {
             // display does not update; use 'placeholder' text as fallback
-            this.refs.desiredCI.setValue(95);
-            this.setState({desiredCIDisplay: 95});
+            this.refs.desiredCI.setValue(CI_DEFAULT);
+            this.setState({desiredCIDisplay: CI_DEFAULT});
             this.changeDesiredCI(true);
         }
     },
@@ -596,7 +597,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                         <dt className="dtFormLabel">Desired CI:</dt>
                                         <dd className="ddFormInput">
                                             <Input type="number" inputClassName="desired-ci-input" ref="desiredCI" value={desiredCIDisplay} handleChange={this.changeDesiredCI}
-                                                onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder="95" />
+                                                onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder={CI_DEFAULT} />
                                         </dd>
                                         <dt>CI - lower: </dt><dd>{this.state.CILow ? this.state.CILow : ''}</dd>
                                         <dt>CI - upper: </dt><dd>{this.state.CIHigh ? this.state.CIHigh : ''}</dd>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -484,18 +484,27 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // wrapper function to calculateCI on value change
-    changeDesiredCI: function() {
+    changeDesiredCI: function(forceDefault) {
         if (this.refs && this.refs.desiredCI) {
-            this.calculateCI(parseInt(this.refs.desiredCI.getValue()), this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
+            this.calculateCI(forceDefault ? 95 : parseInt(this.refs.desiredCI.getValue()), this.state.populationObj && this.state.populationObj.highestMAF ? this.state.populationObj.highestMAF : null);
+        }
+    },
+
+    // checking for empty text when clicking away from desired CI field
+    onBlurDesiredCI: function(event) {
+        let desiredCI = parseInt(this.refs.desiredCI.getValue());
+        if (desiredCI == '' || isNaN(desiredCI)) {
+            // display does not update; use 'placeholder' text as fallback
+            this.refs.desiredCI.setValue(95);
+            this.setState({desiredCIDisplay: 95});
+            this.changeDesiredCI(true);
         }
     },
 
     // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
     calculateCI: function(CIp, highestMAF) {
-        //let CIp = this.refs[ref].getValue();
         if (highestMAF) {
             if (isNaN(CIp) || CIp < 0 || CIp > 100) {
-                // make sure we have valid value
                 this.setState({CILow: null, CIHigh: null});
             } else {
                 // store user-input desired CI value
@@ -509,7 +518,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     qp = 1 - pp;
                 let CILow = this.parseFloatShort(((2 * np * pp) + (zp * zp) - zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp)))),
                     CIHigh = this.parseFloatShort(((2 * np * pp) + (zp * zp) + zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp))));
-                this.setState({populationObj: populationObj, CILow: CILow, CIHigh: CIHigh});
+                this.setState({populationObj: populationObj, desiredCIDisplay: CIp, CILow: CILow, CIHigh: CIHigh});
             }
         }
     },
@@ -585,7 +594,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                 {(this.state.interpretation && highestMAF) ?
                                     <span>
                                         <dt className="dtFormLabel">Desired CI:</dt>
-                                        <dd className="ddFormInput"><Input type="number" ref="desiredCI" value={desiredCIDisplay} handleChange={this.changeDesiredCI} min="0" max="100" maxLength="2" /></dd>
+                                        <dd className="ddFormInput">
+                                            <Input type="number" inputClassName="desired-ci-input" ref="desiredCI" value={desiredCIDisplay} handleChange={this.changeDesiredCI}
+                                                onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder="95" />
+                                        </dd>
                                         <dt>CI - lower: </dt><dd>{this.state.CILow ? this.state.CILow : ''}</dd>
                                         <dt>CI - upper: </dt><dd>{this.state.CIHigh ? this.state.CIHigh : ''}</dd>
                                     </span>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -90,12 +90,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     componentDidMount: function() {
-        this.setState({interpretation: this.props.interpretation});
         this.getPrevSetDesiredCI(this.props.interpretation);
     },
 
     componentWillReceiveProps: function(nextProps) {
-        this.setState({interpretation: nextProps.interpretation});
+        // this block is for handling props and states when props (external data) is updated after the initial load/rendering
+        // when props are updated, update the parent interpreatation object, if applicable
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
+
         this.getPrevSetDesiredCI(nextProps.interpretation);
         if (nextProps.data && this.props.data) {
             if (!this.state.hasExacData || !this.state.hasEspData) {
@@ -584,7 +588,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                         <dt className="dtFormLabel">Desired CI:</dt>
                                         <dd className="ddFormInput">
                                             <Input type="number" inputClassName="desired-ci-input" ref="desiredCI" value={desiredCIDisplay} handleChange={this.changeDesiredCI}
-                                                onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder={CI_DEFAULT} />
+                                                onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder={CI_DEFAULT.toString()} />
                                         </dd>
                                         <dt>CI - lower: </dt><dd>{this.state.CILow ? this.state.CILow : ''}</dd>
                                         <dt>CI - upper: </dt><dd>{this.state.CIHigh ? this.state.CIHigh : ''}</dd>
@@ -755,7 +759,7 @@ var criteriaGroup1 = function() {
             <Input type="checkbox" ref="PM2-value" label="PM2 met?:" handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['PM2-value'] ? this.state.checkboxes['PM2-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="textarea" ref="BA1-description" label="Explain criteria selection:" rows="5" placeholder="Explanation"
+            <Input type="textarea" ref="BA1-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <Input type="textarea" ref="PM2-description" label="Explain criteria selection (PM2):" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" handleChange={this.handleFormChange} />

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -38,7 +38,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
             submitBusy: false, // spinner for Save button
             submitDisabled: false, // disabled for now due to uncertain/non-universal logic
             evidenceData: null, // any extra data (external sources or otherwise) that will be passed into the evaluation evidence object
-            interpretation: null, // parent interpretation object
+            interpretation: this.props.interpretation, // parent interpretation object
             diseaseAssociated: false, // flag to define whether or not the interpretation has a disease associated with it
             checkboxes: {}, // store any checkbox values
             updateMsg: null // specifies what html to display next to button after press
@@ -49,7 +49,6 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
         // this block is for handling props and states on initial load/rendering
         // update the interpretation object when loaded
         if (this.props.interpretation) {
-            this.setState({interpretation: this.props.interpretation});
             // check to see if the interpretation has a disease associated with it
             if (this.props.interpretation.interpretation_disease && this.props.interpretation.interpretation_disease !== '') {
                 this.setState({diseaseAssociated: true});
@@ -68,7 +67,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
     componentWillReceiveProps: function(nextProps) {
         // this block is for handling props and states when props (external data) is updated after the initial load/rendering
         // when props are updated, update the parent interpreatation object, if applicable
-        if (typeof nextProps.interpretation !== undefined && _.isEqual(nextProps.interpretation, this.props.interpretation)) {
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
             this.setState({interpretation: nextProps.interpretation});
         }
         // when props are updated, update the form with new extra data, if applicable

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -221,6 +221,7 @@ var Input = module.exports.Input = React.createClass({
         submitHandler: React.PropTypes.func, // Called to handle submit button click
         cancelHandler: React.PropTypes.func, // Called to handle cancel button click
         submitBusy: React.PropTypes.bool, //
+        onBlur: React.PropTypes.func,
         minVal: React.PropTypes.number, // Minimum value for a number formatted input
         maxVal: React.PropTypes.number // Maximum value for a number formatted input
     },
@@ -255,7 +256,7 @@ var Input = module.exports.Input = React.createClass({
 
     // Set the value of an input
     setValue: function(val) {
-        if (this.props.type === 'text' || this.props.type === 'email' || this.props.type === 'textarea') {
+        if (this.props.type === 'text' || this.props.type === 'email' || this.props.type === 'textarea' || this.props.type === 'number') {
             ReactDOM.findDOMNode(this.refs.input).value = val;
             this.setState({value: val});
         } else if (this.props.type === 'select') {
@@ -338,7 +339,7 @@ var Input = module.exports.Input = React.createClass({
                 inputClasses = 'form-control' + (this.props.error ? ' error' : '') + (this.props.inputClassName ? ' ' + this.props.inputClassName : '');
                 var innerInput = (
                     <span>
-                        <input className={inputClasses} type={inputType} id={this.props.id} name={this.props.id} placeholder={this.props.placeholder} ref="input" value={this.state.value} onChange={this.handleChange.bind(null, this.props.id)} maxLength={this.props.maxLength} disabled={this.props.inputDisabled} />
+                        <input className={inputClasses} type={inputType} id={this.props.id} name={this.props.id} placeholder={this.props.placeholder} ref="input" value={this.state.value} onChange={this.handleChange.bind(null, this.props.id)} onBlur={this.props.onBlur} maxLength={this.props.maxLength} disabled={this.props.inputDisabled} />
                         <div className="form-error">{this.props.error ? <span>{this.props.error}</span> : <span>&nbsp;</span>}</div>
                     </span>
                 );

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1341,3 +1341,13 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     opacity: 1;
 }
+
+dl.inline-dl {
+    dt.dtFormLabel {
+        line-height: 4.5;
+    }
+
+    dd.ddFormInput {
+        margin-top: 15px;
+    }
+}

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -284,3 +284,9 @@ input[type=search] {
 .hidden {
     display: none;
 }
+
+// population tab - VCI
+.desired-ci-input {
+    display: inline-block;
+    width: 35%;
+}


### PR DESCRIPTION
Instance: http://737-mc-calculate-ci-2374fe1-minchoi.instance.clinicalgenome.org/

#### Connects to #737:

* CI fields only show up when interpretation is added
* CI lower and upper values update when desired CI is changed
* Clearing the the desired CI field or putting in bad characters will default the value to 95 on clicking away
* Desired CI values are saved on evaluation form saving, and is pre-filled with saved value on re-loading the interpretation

![image](https://cloud.githubusercontent.com/assets/4326866/16751326/60fdb886-478d-11e6-816f-e2d60dba3536.png)

*Testing:*

1. Get to VCI hub, populations tab
2. Add interpretation and confirm that the CI fields now show up, with 95 as default value
3. Change Desired CI to confirm that upper and lower values change correctly (check against Steven's Excel spreadsheet)
4. Put bad characters into field, confirm that value defaults to 95 when clicking away from text box
5. Save evaluation, confirm that the desired CI value is saved in `desiredCI` of the `populationData` object
6. Reload the interpretation, confirm that the correct desired CI value is pre-filled

#### Connects to #788:

* Truncate length of returned float values to 5 decimal places (with rounding)

![image](https://cloud.githubusercontent.com/assets/4326866/16747363/ad6e2d6e-4773-11e6-94d7-69c04ce75ef5.png)

*Testing:*

1. Load variant with population tab
2. Confirm that the values in population tab do not exceed 5 decimal places