### PR TITLE
Connects to #765  Calculate Pathogenicity temp button and Feature in Dev UI

### DIFF
--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -24,7 +24,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
             <div>
                 <div className="curation-data-title">
                     <div className="container">
-                        <Title data={variant} />
+                        <Title data={variant} interpretationUuid={interpretationUuid} />
                     </div>
                 </div>
                 <div className="container curation-data curation-variant">

--- a/src/clincoded/static/components/variant_central/interpretation/criteria.js
+++ b/src/clincoded/static/components/variant_central/interpretation/criteria.js
@@ -8,7 +8,7 @@ var editQueryValue = globals.editQueryValue;
 
 // Display met criteria
 var CurationInterpretationCriteria = module.exports.CurationInterpretationCriteria = React.createClass({
-	propTypes: {
+    propTypes: {
         interpretation: React.PropTypes.object
     },
 
@@ -19,51 +19,59 @@ var CurationInterpretationCriteria = module.exports.CurationInterpretationCriter
     },
 
     componentWillReceiveProps: function(nextProps) {
-    	if (nextProps.interpretation && this.props.interpretation) {
-    		this.setState({interpretation: nextProps.interpretation});
-    	}
+        if (nextProps.interpretation && this.props.interpretation) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
     },
 
     // FIXME: fake data attribute to flag criteria that can be evaluated but not yet evaluated
     // after associating a disease with interpretation.
     // Shall be removed when actual functionality is implemented.
     handleCriteria: function(criteria_code) {
-		var status;
-		var evaluated = ["BS1", "BS2", "BP1", "BP3", "BP7", "PP3", "PM2", "PM4", "PM5", "PS1", "PS4"];
-		var not_evaluated = ["BS3", "BS4", "BP2", "BP4", "PP1", "PP2", "PM1", "PS3"];
-		for (let x of evaluated) {
-			if (x === criteria_code) {
-				status = "evaluated";
-			}
-		}
-		for (let y of not_evaluated) {
-			if (y === criteria_code) {
-				status = "not_evaluated";
-			}
-		}
-		return status;
+        var status;
+        var evaluated = ["BS1", "BS2", "BP1", "BP3", "BP7", "PP3", "PM2", "PM4", "PM5", "PS1", "PS4"];
+        var not_evaluated = ["BS3", "BS4", "BP2", "BP4", "PP1", "PP2", "PM1", "PS3"];
+        for (let x of evaluated) {
+            if (x === criteria_code) {
+                status = "evaluated";
+            }
+        }
+        for (let y of not_evaluated) {
+            if (y === criteria_code) {
+                status = "not_evaluated";
+            }
+        }
+        return status;
     },
 
-	render: function() {
-		var self =this;
+    render: function() {
+        var self =this;
 
         return (
             <div className="curation-criteria curation-variant">
-            	{(this.state.interpretation) ?
-            		<div className="criteria-bar btn-toolbar" role="toolbar" aria-label="Criteria bar with code buttons">
-            			<div className="criteria-group btn-group btn-group-sm" role="group" aria-label="Criteria code button group">
-							{/* FIXME: Remove 'data-status' attribute when actual functionality is implemented to handle 'met' criteria */}
-            				{evidenceCodes.map(function(evidence, i) {
-            					return (
-                                    <button type="button" className={'btn btn-default ' + evidence.class} key={i} data-status={self.handleCriteria(evidence.code)}
-                                    	data-toggle="tooltip" data-placement="top" data-tooltip={evidence.definition}>
-                                        <span>{evidence.code}</span>
-                                    </button>
-                                );
-            				})}
-            			</div>
-            		</div>
-            	: null}
+                {(this.state.interpretation) ?
+                    <div className="criteria-bar btn-toolbar" role="toolbar" aria-label="Criteria bar with code buttons">
+                        <div className="criteria-group btn-group btn-group-sm" role="group" aria-label="Criteria code button group">
+                            
+                            <div className="feature-in-development"> {/* FIXME div for temp yellow UI display */}
+
+                                {/* FIXME: Remove 'data-status' attribute when actual functionality is implemented to handle 'met' criteria */}
+                                {evidenceCodes.map(function(evidence, i) {
+                                    return (
+                                        <button type="button" className={'btn btn-default ' + evidence.class} key={i} data-status={self.handleCriteria(evidence.code)}
+                                            data-toggle="tooltip" data-placement="top" data-tooltip={evidence.definition}>
+                                            <span>{evidence.code}</span>
+                                        </button>
+                                    );
+                                })}
+
+                               
+                            </div> {/* /FIXME div for temp yellow UI display */}
+
+                        </div>                       
+                    </div>
+                    : null
+                }
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -24,7 +24,7 @@ var Title = module.exports.Title = React.createClass({
         if (this.props.interpretationUuid) {
             calculatePatho_button = true;
         }
-
+        
         return (
             <div>
                 <h1>{variantTitle}{this.props.children}</h1>
@@ -32,9 +32,13 @@ var Title = module.exports.Title = React.createClass({
                 {variant && calculatePatho_button ?
                     <div className="btn-vertical-space">
                         <div className="interpretation-record clearfix">
-                            <button type="button-button" className="btn btn-primary pull-right non-function">
-                                Calculate Pathogenicity
-                            </button>
+                            <div className="feature-in-development pull-right"> {/* FIXME div for temp yellow UI display */}
+
+                                <button type="button-button" className="btn btn-primary pull-right">
+                                    Calculate Pathogenicity
+                                </button>
+
+                            </div> {/* /FIXME div for temp yellow UI display */}
                         </div>
                     </div>
                     :

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -26,7 +26,7 @@ var Title = module.exports.Title = React.createClass({
                 {variant && calculatePatho_button ?
                     <div className="btn-vertical-space">
                         <div className="interpretation-record clearfix">
-                            <button type="button-button" className="btn btn-primary pull-right" disabled="disabled">
+                            <button type="button-button" className="btn btn-primary pull-right non-function">
                                 Calculate Pathogenicity
                             </button>
                         </div>

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -4,7 +4,8 @@ var React = require('react');
 // General purpose title rendering
 var Title = module.exports.Title = React.createClass({
     propTypes: {
-        data: React.PropTypes.object // ClinVar data payload
+        data: React.PropTypes.object, // ClinVar data payload
+        interpretationUuid: React.PropTypes.string
     },
 
     render: function() {
@@ -13,11 +14,26 @@ var Title = module.exports.Title = React.createClass({
             var clinVarTitle = (variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : 'A preferred title is not available';
             var associatedDisease = (variant.disease) ? variant.disease : 'Not yet associated with a disease';
         }
+        var calculatePatho_button = false;
+        if (this.props.interpretationUuid) {
+            calculatePatho_button = true;
+        }
 
         return (
             <div>
                 <h1>{clinVarTitle}{this.props.children}</h1>
                 <h2>{associatedDisease}</h2>
+                {variant && calculatePatho_button ?
+                    <div className="btn-vertical-space">
+                        <div className="interpretation-record clearfix">
+                            <button type="button-button" className="btn btn-primary pull-right" disabled="disabled">
+                                Calculate Pathogenicity
+                            </button>
+                        </div>
+                    </div>
+                    :
+                    null
+                }
             </div>
         );
     }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1351,8 +1351,9 @@ div.react-tabs .ReactTabs__TabPanel--selected {
 
 /* Non-function button */
 .non-function {
-    border-left: solid 10px #fed84d;
-    border-top: none;
-    border-right: none;
-    border-bottom: none;
+    border-left: solid 5px #fed84d;
+    border-top: solid 1px #c0c0c0;
+    border-right: solid 1px #c0c0c0;
+    border-bottom: solid 1px #c0c0c0;
+
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1324,3 +1324,9 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     opacity: 1;
 }
+
+/* set up vertical padding for div */
+.btn-vertical-space {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1337,8 +1337,14 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     opacity: 1;
 }
 
-/* set up vertical padding for div */
+/* Vertical padding for div */
 .btn-vertical-space {
     padding-top: 10px;
     padding-bottom: 10px;
+}
+
+
+/* Non-function */
+.non-function {
+    border-left: solid 10px #fed84d;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1349,7 +1349,10 @@ div.react-tabs .ReactTabs__TabPanel--selected {
 }
 
 
-/* Non-function */
+/* Non-function button */
 .non-function {
     border-left: solid 10px #fed84d;
+    border-top: none;
+    border-right: none;
+    border-bottom: none;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1348,12 +1348,14 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     padding-bottom: 10px;
 }
 
+.feature-in-development {
+    border: none;
+    border-left: 5px solid #fed84d;
+    border-radius: 2px;
+}
 
-/* Non-function button */
-.non-function {
-    border-left: solid 5px #fed84d;
-    border-top: solid 1px #c0c0c0;
-    border-right: solid 1px #c0c0c0;
-    border-bottom: solid 1px #c0c0c0;
-
+.feature-in-development:hover {
+    border: none;
+    border-left: 5px solid #fed84d;
+    border-radius: 2px;
 }


### PR DESCRIPTION
**Changes:**

- Extended off of 765_kl_CalculatePatho_button branch to fix some UI components.

- Adds temporary/non-functional "Calculate Pathogenicity" after VCI Interpretation mode has started

- Add visual cues to Features in Development (yellow border on left)

- Fixed some eslint errors in `/src/clincoded/static/components/variant_central/interpretation/criteria.js`

***
**To Test:**

VCI
- +  "Select Variant" -> choose CAR or CA ID pathway
- +  "Start new interpretation"
- Check UI changes
 - "Calculate Pathogenicity" should appear in the header and have a yellow UI border on the left
 - Bar of criteria codes should have yellow UI border on the left


![image](https://cloud.githubusercontent.com/assets/1878194/16793236/37694434-4884-11e6-9483-fdcb590d5049.png)

***
**Re-usable UI implementation:**
Note: This ticket will include the addition of a generalize-able UI designation to denote a 
`Feature-In-Development`

Enclose the affected JSX UI element in the following tags:

**opening div + comment to find again easily:**
`<div className="feature-in-development"> {/* FIXME div for temp yellow UI display */}`

**closing div + comment to find again easily:**
`</div> {/* /FIXME div for temp yellow UI display */}`

NOTE: `pull-right` or other class names may be need to be added above depending on the UI element being wrapped.
