### PR TITLE
Connects to #718. Connects to #776. VCI Computation tab.

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -167,6 +167,7 @@ module.exports.external_url_map = {
     'ClinVar': 'http://www.ncbi.nlm.nih.gov/clinvar/',
     'ClinVarSearch': 'http://www.ncbi.nlm.nih.gov/clinvar/variation/',
     'ClinVarEutils': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=',
+    'ClinVarEsearch': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?',
     'HPO': 'http://compbio.charite.de/hpoweb/showterm?id=',
     'HPOBrowser': 'http://compbio.charite.de/hpoweb/showterm?id=HP:0000118',
     'Uberon': 'http://uberon.github.io/',

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -138,7 +138,11 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             var item = molecular_consequence.find((x) => x.HGVS === result.HGVS);
             // 'SO_terms' is defined via requiring external mapping file
             var found = SO_terms.find((entry) => entry.SO_id === item.SOid);
-            SO_id_term = found.SO_term + ' ' + found.SO_id;
+            if (found) {
+                SO_id_term = found.SO_term + ' ' + found.SO_id;
+            } else {
+                SO_id_term = '--';
+            }
             // FIXME: temporarily use protein_change[0] due to lack of mapping
             // associated with nucleotide transcript in ClinVar data
             var protein_hgvs = (typeof protein_change !== 'undefined' && protein_change.length) ? protein_change[0].HGVS : '--';

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -4,7 +4,13 @@ var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
+var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
 var CurationInterpretationForm = require('./shared/form').CurationInterpretationForm;
+var parseAndLogError = require('../../mixins').parseAndLogError;
+var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
+
+var external_url_map = globals.external_url_map;
+var dbxref_prefix_map = globals.dbxref_prefix_map;
 
 var form = require('../../../libs/bootstrap/form');
 
@@ -12,6 +18,31 @@ var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
 var InputMixin = form.InputMixin;
+
+var computationStatic = {
+    conservation: {
+        _order: ['phylop7way', 'phylop20way', 'phastconsp7way', 'phastconsp20way', 'gerp', 'siphy'],
+        _labels: {'phylop7way': 'phyloP7way', 'phylop20way': 'phyloP20way', 'phastconsp7way': 'phastCons7way', 'phastconsp20way': 'phastCons20way', 'gerp': 'GERP++', 'siphy': 'SiPhy'}
+    },
+    other_predictors: {
+        _order: ['sift', 'polyphen2_hdiv', 'polyphen2_hvar', 'lrt', 'mutationtaster', 'mutationassessor', 'fathmm', 'provean', 'metasvm', 'metalr', 'cadd', 'fathmm_mkl', 'fitcons'],
+        _labels: {
+            'sift': 'SIFT',
+            'polyphen2_hdiv': 'PolyPhen2-HDIV',
+            'polyphen2_hvar': 'PolyPhen2-HVAR',
+            'lrt': 'LRT',
+            'mutationtaster': 'MutationTaster',
+            'mutationassessor': 'MutationAssessor',
+            'fathmm': 'FATHMM',
+            'provean': 'PROVEAN',
+            'metasvm': 'MetaSVM',
+            'metalr': 'MetaLR',
+            'cadd': 'CADD',
+            'fathmm_mkl': 'FATHMM-MKL',
+            'fitcons': 'fitCons',
+        }
+    }
+};
 
 // Display the curator data of the curation data
 var CurationInterpretationComputational = module.exports.CurationInterpretationComputational = React.createClass({
@@ -27,15 +58,227 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     getInitialState: function() {
         return {
             clinvar_id: null,
-            interpretation: this.props.interpretation
+            interpretation: this.props.interpretation,
+            hasConservationData: false,
+            hasOtherPredData: false,
+            hasClinVarData: false,
+            codonObj: {},
+            computationObj: {
+                conservation: {
+                    phylop7way: null, phylop20way: null, phastconsp7way: null, phastconsp20way: null, gerp: null, siphy: null
+                },
+                other_predictors: {
+                    sift: {score_range: '--', score: null, prediction: null},
+                    polyphen2_hdiv: {score_range: '--', score: null, prediction: null},
+                    polyphen2_hvar: {score_range: '0 to 1', score: null, prediction: null},
+                    lrt: {score_range: '0 to 1', score: null, prediction: null},
+                    mutationtaster: {score_range: '0 to 1', score: null, prediction: null},
+                    mutationassessor: {score_range: '-0.5135 to 6.49', score: null, prediction: null},
+                    fathmm: {score_range: '-16.13 to 10.64', score: null, prediction: null},
+                    provean: {score_range: '-14 to +14', score: null, prediction: null},
+                    metasvm: {score_range: '-2 to +3', score: null, prediction: null},
+                    metalr: {score_range: '0 to 1', score: null, prediction: null},
+                    cadd: {score_range: '-7.535 to 35.789', score: null, prediction: null},
+                    fathmm_mkl: {score_range: '--', score: null, prediction: null},
+                    fitcons: {score_range: '0 to 1', score: null, prediction: null}
+                }
+            }
         };
     },
 
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretation: nextProps.interpretation});
+        if (nextProps.data && this.props.data) {
+            if (!this.state.hasConservationData || !this.state.hasOtherPredData) {
+                this.fetchExternalData('myVariantInfo');
+            }
+            if (!this.state.hasClinVarData) {
+                this.fetchExternalData('clinvar');
+            }
+        }
+    },
+
+    componentWillUnmount: function() {
+        this.setState({
+            hasConservationData: false,
+            hasOtherPredData: false,
+            hasClinVarData: false
+        });
+    },
+
+    // Retrieve predictors data from myvariant.info
+    fetchExternalData: function(source) {
+        var variant = this.props.data;
+        var url = this.props.protocol + external_url_map['MyVariantInfo'];
+        if (variant) {
+            // Extract only the number portion of the dbSNP id
+            var numberPattern = /\d+/g;
+            var rsid = (variant.dbSNPIds && variant.dbSNPIds.length > 0) ? variant.dbSNPIds[0].match(numberPattern) : null;
+            // Extract genomic substring from HGVS name whose assembly is GRCh37
+            // Both of "GRCh37" and "gRCh37" instances are possibly present in the variant object
+            var hgvs_GRCh37 = (variant.hgvsNames.GRCh37) ? variant.hgvsNames.GRCh37 : variant.hgvsNames.gRCh37;
+            var NC_genomic = hgvs_GRCh37 ? hgvs_GRCh37.substr(0, hgvs_GRCh37.indexOf(':')) : null;
+            // 'genomic_chr_mapping' is defined via requiring external mapping file
+            var found = genomic_chr_mapping.GRCh37.find((entry) => entry.GenomicRefSeq === NC_genomic);
+            // Format variant_id for use of myvariant.info REST API
+            var variant_id = (hgvs_GRCh37 && found) ? found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':')) : null;
+            if (variant_id && variant_id.indexOf('del') > 0) {
+                variant_id = variant_id.substring(0, variant_id.indexOf('del') + 3);
+            }
+            if (source === 'myVariantInfo') {
+                if (variant_id) {
+                    this.getRestData(url + variant_id).then(response => {
+                        // Calling methods to update global object with predictors data
+                        // FIXME: Need to create a new copy of the global object with new data
+                        // while leaving the original object with pre-existing data
+                        // for comparison of any potential changed values
+                        this.parseOtherPredData(response);
+                        this.parseConservationData(response);
+                    }).catch(function(e) {
+                        console.log('MyVariant Fetch Error=: %o', e);
+                    });
+                }
+            } else if (source === 'clinvar') {
+                if (variant.clinvarVariantId) {
+                    // Get ClinVar data via the parseClinvar method defined in parse-resources.js
+                    this.getRestDataXml(this.props.protocol + external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
+                        // Passing 'true' option to invoke 'mixin' function
+                        // To extract more ClinVar data for codon data
+                        var variantData = parseClinvar(xml, true);
+                        var clinVarObj = {};
+                        clinVarObj.protein_change = variantData.allele.ProteinChange;
+                        clinVarObj.gene_symbol = variantData.gene.symbol;
+                        if (clinVarObj) {
+                            return Promise.resolve(clinVarObj);
+                        }
+                    }).then(clinvar => {
+                        var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
+                        var symbol = clinvar.gene_symbol;
+                        this.getRestData(this.props.protocol + '//eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+                            var codonObj = {};
+                            codonObj.count = result.esearchresult.count;
+                            codonObj.term = term;
+                            codonObj.symbol = symbol;
+                            this.setState({hasClinVarData: true, codonObj: codonObj});
+                        })
+                    }).catch(function(e) {
+                        console.log('ClinVar Fetch Error=: %o', e);
+                    });
+                }
+            }
+        }
+    },
+
+    // Method to assign other predictors data to global computation object
+    parseOtherPredData: function(response) {
+        let computationObj = this.state.computationObj;
+        // Not all variants return the dbnsfp{...} object from myvariant.info
+        if (response.dbnsfp) {
+            let dbnsfp = response.dbnsfp;
+            // get scores from dbnsfp
+            computationObj.other_predictors.sift.score = parseFloat(dbnsfp.sift.converted_rankscore);
+            computationObj.other_predictors.sift.prediction = dbnsfp.sift.pred[0];
+            computationObj.other_predictors.polyphen2_hdiv.score = parseFloat(dbnsfp.polyphen2.hdiv.rankscore);
+            computationObj.other_predictors.polyphen2_hdiv.prediction = dbnsfp.polyphen2.hdiv.pred;
+            computationObj.other_predictors.polyphen2_hvar.score = parseFloat(dbnsfp.polyphen2.hvar.rankscore);
+            computationObj.other_predictors.polyphen2_hvar.prediction = dbnsfp.polyphen2.hvar.pred;
+            computationObj.other_predictors.lrt.score = parseFloat(dbnsfp.lrt.converted_rankscore);
+            computationObj.other_predictors.lrt.prediction = dbnsfp.lrt.pred;
+            computationObj.other_predictors.mutationtaster.score = parseFloat(dbnsfp.mutationtaster.converted_rankscore);
+            computationObj.other_predictors.mutationtaster.prediction = dbnsfp.mutationtaster.pred[0];
+            computationObj.other_predictors.mutationassessor.score = parseFloat(dbnsfp.mutationassessor.rankscore);
+            computationObj.other_predictors.mutationassessor.prediction = dbnsfp.mutationassessor.pred;
+            computationObj.other_predictors.fathmm.score = parseFloat(dbnsfp.fathmm.rankscore);
+            computationObj.other_predictors.fathmm.prediction = dbnsfp.fathmm.pred[0];
+            computationObj.other_predictors.provean.score = parseFloat(dbnsfp.provean.rankscore);
+            computationObj.other_predictors.provean.prediction = dbnsfp.provean.pred[0];
+            computationObj.other_predictors.metasvm.score = parseFloat(dbnsfp.metasvm.rankscore);
+            computationObj.other_predictors.metasvm.prediction = dbnsfp.metasvm.pred;
+            computationObj.other_predictors.metalr.score = parseFloat(dbnsfp.metalr.rankscore);
+            computationObj.other_predictors.metalr.prediction = dbnsfp.metalr.pred;
+            computationObj.other_predictors.fathmm_mkl.score = parseFloat(dbnsfp['fathmm-mkl'].coding_rankscore);
+            computationObj.other_predictors.fathmm_mkl.prediction = dbnsfp['fathmm-mkl'].coding_pred;
+            // update computationObj, and set flag indicating that we have other predictors data
+            this.setState({hasOtherPredData: true, computationObj: computationObj});
+        }
+        if (response.cadd) {
+            let cadd = response.cadd;
+            computationObj.other_predictors.cadd.score = parseFloat(cadd.consscore);
+            //computationObj.other_predictors.cadd.prediction = cadd.pred;
+            computationObj.other_predictors.fitcons.score = parseFloat(cadd.fitcons);
+            //computationObj.other_predictors.fitcons.prediction = cadd.fitcons.pred;
+            // update computationObj, and set flag indicating that we have other predictors data
+            this.setState({hasOtherPredData: true, computationObj: computationObj});
+        }
+    },
+
+    // Method to assign conservation scores data to global computation object
+    parseConservationData: function(response) {
+        // Not all variants return the dbnsfp{...} object from myvariant.info
+        if (response.dbnsfp) {
+            let computationObj = this.state.computationObj;
+            let dbnsfp = response.dbnsfp;
+            // get scores from dbnsfp
+            computationObj.conservation.phylop7way = parseFloat(dbnsfp.phylo.p7way.vertebrate_rankscore);
+            computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian_rankscore);
+            computationObj.conservation.phastconsp7way = parseFloat(dbnsfp.phastcons['7way'].vertebrate_rankscore);
+            computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian_rankscore);
+            computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs_rankscore);
+            computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds_rankscore);
+            // update computationObj, and set flag indicating that we have conservation analysis data
+            this.setState({hasConservationData: true, computationObj: computationObj});
+        }
+    },
+
+    // method to render a row of data for the other predictors table
+    renderOtherPredRow: function(key, otherPred, otherPredStatic) {
+        let rowName = otherPredStatic._labels[key];
+        // Both 'source name' and 'score range' have static values
+        return (
+            <tr key={key}>
+                <td>{rowName}</td>
+                <td>{otherPred[key].score_range}</td>
+                <td>{otherPred[key].score ? otherPred[key].score : '--'}</td>
+                <td>{otherPred[key].prediction ? this.mapPredictionName(otherPred[key].prediction) : '--'}</td>
+            </tr>
+        );
+    },
+
+    // Method to map prediction names to their letter codes
+    mapPredictionName: function(pred) {
+        var name = '';
+        let predictionNames = {
+            'B': 'B(enign)',
+            'D': 'D(amaging)',
+            'N': 'N(eutral)',
+            'T': 'T(olerated)'
+        };
+        for (let key in predictionNames) {
+            if (key === pred) {
+                name = predictionNames[key];
+            }
+        }
+        return name;
+    },
+
+    // method to render a row of data for the conservation analysis table
+    renderConservationRow: function(key, conservation, conservationStatic) {
+        let rowName = conservationStatic._labels[key];
+        // 'source name' has static values
+        return (
+            <tr key={key}>
+                <td>{rowName}</td>
+                <td>{conservation[key] ? conservation[key] : '--'}</td>
+            </tr>
+        );
     },
 
     render: function() {
+        var conservationStatic = computationStatic.conservation, otherPredStatic = computationStatic.other_predictors;
+        var conservation = (this.state.computationObj && this.state.computationObj.conservation) ? this.state.computationObj.conservation : null;
+        var otherPred = (this.state.computationObj && this.state.computationObj.other_predictors) ? this.state.computationObj.other_predictors : null;
+        var codon = (this.state.codonObj) ? this.state.codonObj : null;
+
         return (
             <div className="variant-interpretation computational">
                 {(this.state.interpretation) ?
@@ -49,14 +292,267 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </div>
                 : null}
 
-                <ul className="section-calculator clearfix">
-                    <li className="col-xs-12 gutter-exc">
-                        <div>
-                            <h4>Pathogenicity Calculator</h4>
-                            <div>Calculator placeholder</div>
+                <div>
+                    <h2 className="page-header">Computational Tools</h2>
+                    {this.props.data ?
+                        <div className="panel panel-info datasource-clingen">
+                            <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th>Score Range</th>
+                                        <th>Score</th>
+                                        <th>Prediction</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><a href="https://sites.google.com/site/revelgenomics/home" target="_blank">REVEL meta-predictor</a></td>
+                                        <td>0 to 1</td>
+                                        <td>0.7</td>
+                                        <td>higher score = higher pathogenicity</td>
+                                    </tr>
+                                    <tr>
+                                        <td>CFTR</td>
+                                        <td>--</td>
+                                        <td>--</td>
+                                        <td>--</td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
-                    </li>
-                </ul>
+                    :
+                        <div className="panel panel-info datasource-clingen">
+                            <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <td>No predictors were found for this allele.</td>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+
+                    {this.state.hasOtherPredData ?
+                        <div className="panel panel-info datasource-other">
+                            <div className="panel-heading"><h3 className="panel-title">Other Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th>Score Range</th>
+                                        <th>Score</th>
+                                        <th>Prediction</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {otherPredStatic._order.map(key => {
+                                        return (this.renderOtherPredRow(key, otherPred, otherPredStatic));
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    :
+                        <div className="panel panel-info datasource-other">
+                            <div className="panel-heading"><h3 className="panel-title">Other Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <td>No predictors were found for this allele.</td>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+
+                    {this.state.hasConservationData ?
+                        <div className="panel panel-info datasource-conservation">
+                            <div className="panel-heading"><h3 className="panel-title">Conservation Analysis</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th>Score</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {conservationStatic._order.map(key => {
+                                        return (this.renderConservationRow(key, conservation, conservationStatic));
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    :
+                        <div className="panel panel-info datasource-conservation">
+                            <div className="panel-heading"><h3 className="panel-title">Conservation Analysis</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <td>No predictors were found for this allele.</td>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+
+                    {this.state.hasConservationData ?
+                        <div className="panel panel-info datasource-splice">
+                            <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th>5' or 3'</th>
+                                        <th>Score Range</th>
+                                        <th>Score</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td colSpan="4">WT Sequence</td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="2" className="row-span">5'</td>
+                                        <td>[0-12]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="2" className="row-span">3'</td>
+                                        <td>[0-16]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td colSpan="4">Variant Sequence</td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="2" className="row-span">5'</td>
+                                        <td>[0-12]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="2" className="row-span">3'</td>
+                                        <td>[0-16]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                </tbody>
+                                <tfoot>
+                                    <tr>
+                                        <td colSpan="4">Average Change to Nearest Splice Site: <span className="splice-avg-change wip">IN PROGRESS</span></td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    :
+                        <div className="panel panel-info datasource-splice">
+                            <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <td>No predictions were found for this allele.</td>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+
+                    {this.state.hasConservationData ?
+                        <div className="panel panel-info datasource-additional">
+                            <div className="panel-heading"><h3 className="panel-title">Additional Information</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Distance to nearest splice site</th>
+                                        <th><span className="wip">IN PROGRESS</span></th>
+                                    </tr>
+                                    <tr>
+                                        <th>Exon location</th>
+                                        <th><span className="wip">IN PROGRESS</span></th>
+                                    </tr>
+                                    <tr>
+                                        <th>Distance of truncation mutation from end of last exon</th>
+                                        <th><span className="wip">IN PROGRESS</span></th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    :
+                        <div className="panel panel-info datasource-additional">
+                            <div className="panel-heading"><h3 className="panel-title">Additional Information</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <td>No additional information was found for this allele.</td>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+
+                </div>
+
+                <div>
+                    <h2 className="page-header">Other Variants in Codon</h2>
+                    <div className="panel panel-info datasource-clinvar">
+                        <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
+                        <div className="panel-body">
+                            {this.state.hasClinVarData && codon ?
+                                <dl className="inline-dl clearfix">
+                                    <dt>Number of variants at codon: <span className="condon-variant-count">{codon.count}</span></dt>
+                                    <dd>[ <a href={this.props.protocol + '//www.ncbi.nlm.nih.gov/clinvar/?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar</a> ]</dd>
+                                </dl>
+                            :
+                                <dl className="inline-dl clearfix">
+                                    <dd>No ClinVar data was found for this variant.</dd>
+                                </dl>
+                            }
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <h2 className="page-header">Repetitive Region</h2>
+                    {this.props.data ?
+                        <div className="panel panel-info">
+                            <div className="panel-heading"><h3 className="panel-title">External resources for this variant</h3></div>
+                            <div className="panel-body">
+                                <dl className="inline-dl clearfix">
+                                    <dd><a href="#" target="_blank">View Variant in UCSC Browser</a></dd>
+
+                                    <dd><a href="#" target="_blank">View Variant in Variation Viewer</a></dd>
+
+                                    <dd><a href="#" target="_blank">View genomic location in ExAC</a></dd>
+                                </dl>
+                            </div>
+                        </div>
+                    : null}
+                </div>
+
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -337,6 +337,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                         <th>Prediction</th>
                                     </tr>
                                 </thead>
+                                {/* FIXME: Need real data */}
                                 <tbody>
                                     <tr>
                                         <td><a href="https://sites.google.com/site/revelgenomics/about" target="_blank">REVEL</a> (meta-predictor)</td>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -176,37 +176,35 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (response.dbnsfp) {
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.other_predictors.sift.score = this.handleScoreObj(dbnsfp.sift.score);
-            computationObj.other_predictors.sift.prediction = this.handlePredObj(dbnsfp.sift.pred);
-            computationObj.other_predictors.polyphen2_hdiv.score = this.handleScoreObj(dbnsfp.polyphen2.hdiv.score);
-            computationObj.other_predictors.polyphen2_hdiv.prediction = this.handlePredObj(dbnsfp.polyphen2.hdiv.pred);
-            computationObj.other_predictors.polyphen2_hvar.score = this.handleScoreObj(dbnsfp.polyphen2.hvar.score);
-            computationObj.other_predictors.polyphen2_hvar.prediction = this.handlePredObj(dbnsfp.polyphen2.hvar.pred);
-            computationObj.other_predictors.lrt.score = this.handleScoreObj(dbnsfp.lrt.score);
-            computationObj.other_predictors.lrt.prediction = this.handlePredObj(dbnsfp.lrt.pred);
-            computationObj.other_predictors.mutationtaster.score = this.handleScoreObj(dbnsfp.mutationtaster.score);
-            computationObj.other_predictors.mutationtaster.prediction = this.handlePredObj(dbnsfp.mutationtaster.pred);
-            computationObj.other_predictors.mutationassessor.score = this.handleScoreObj(dbnsfp.mutationassessor.score);
-            computationObj.other_predictors.mutationassessor.prediction = this.handlePredObj(dbnsfp.mutationassessor.pred);
-            computationObj.other_predictors.fathmm.score = this.handleScoreObj(dbnsfp.fathmm.score);
-            computationObj.other_predictors.fathmm.prediction = this.handlePredObj(dbnsfp.fathmm.pred);
-            computationObj.other_predictors.provean.score = this.handleScoreObj(dbnsfp.provean.score);
-            computationObj.other_predictors.provean.prediction = this.handlePredObj(dbnsfp.provean.pred);
-            computationObj.other_predictors.metasvm.score = this.handleScoreObj(dbnsfp.metasvm.score);
-            computationObj.other_predictors.metasvm.prediction = this.handlePredObj(dbnsfp.metasvm.pred);
-            computationObj.other_predictors.metalr.score = this.handleScoreObj(dbnsfp.metalr.score);
-            computationObj.other_predictors.metalr.prediction = this.handlePredObj(dbnsfp.metalr.pred);
-            computationObj.other_predictors.fathmm_mkl.score = this.handleScoreObj(dbnsfp['fathmm-mkl'].coding_score);
-            computationObj.other_predictors.fathmm_mkl.prediction = this.handlePredObj(dbnsfp['fathmm-mkl'].coding_pred);
+            computationObj.other_predictors.sift.score = (dbnsfp.sift && dbnsfp.sift.score) ? this.handleScoreObj(dbnsfp.sift.score) : null;
+            computationObj.other_predictors.sift.prediction = (dbnsfp.sift && dbnsfp.sift.pred) ? this.handlePredObj(dbnsfp.sift.pred) : null;
+            computationObj.other_predictors.polyphen2_hdiv.score = (dbnsfp.polyphen2 && dbnsfp.polyphen2.hdiv.score) ? this.handleScoreObj(dbnsfp.polyphen2.hdiv.score) : null;
+            computationObj.other_predictors.polyphen2_hdiv.prediction = (dbnsfp.polyphen2 && dbnsfp.polyphen2.hdiv.pred) ? this.handlePredObj(dbnsfp.polyphen2.hdiv.pred) : null;
+            computationObj.other_predictors.polyphen2_hvar.score = (dbnsfp.polyphen2 && dbnsfp.polyphen2.hvar.score) ? this.handleScoreObj(dbnsfp.polyphen2.hvar.score) : null;
+            computationObj.other_predictors.polyphen2_hvar.prediction = (dbnsfp.polyphen2 && dbnsfp.polyphen2.hvar.pred) ? this.handlePredObj(dbnsfp.polyphen2.hvar.pred) : null;
+            computationObj.other_predictors.lrt.score = (dbnsfp.lrt && dbnsfp.lrt.score) ? this.handleScoreObj(dbnsfp.lrt.score) : null;
+            computationObj.other_predictors.lrt.prediction = (dbnsfp.lrt && dbnsfp.lrt.pred) ? this.handlePredObj(dbnsfp.lrt.pred) : null;
+            computationObj.other_predictors.mutationtaster.score = (dbnsfp.mutationtaster && dbnsfp.mutationtaster.score) ? this.handleScoreObj(dbnsfp.mutationtaster.score) : null;
+            computationObj.other_predictors.mutationtaster.prediction = (dbnsfp.mutationtaster && dbnsfp.mutationtaster.pred) ? this.handlePredObj(dbnsfp.mutationtaster.pred) : null;
+            computationObj.other_predictors.mutationassessor.score = (dbnsfp.mutationassessor && dbnsfp.mutationassessor.score) ? this.handleScoreObj(dbnsfp.mutationassessor.score) : null;
+            computationObj.other_predictors.mutationassessor.prediction = (dbnsfp.mutationassessor && dbnsfp.mutationassessor.pred) ? this.handlePredObj(dbnsfp.mutationassessor.pred) : null;
+            computationObj.other_predictors.fathmm.score = (dbnsfp.fathmm && dbnsfp.fathmm.score) ? this.handleScoreObj(dbnsfp.fathmm.score) : null;
+            computationObj.other_predictors.fathmm.prediction = (dbnsfp.fathmm && dbnsfp.fathmm.pred) ? this.handlePredObj(dbnsfp.fathmm.pred) : null;
+            computationObj.other_predictors.provean.score = (dbnsfp.provean && dbnsfp.provean.score) ? this.handleScoreObj(dbnsfp.provean.score) : null;
+            computationObj.other_predictors.provean.prediction = (dbnsfp.provean && dbnsfp.provean.pred) ? this.handlePredObj(dbnsfp.provean.pred) : null;
+            computationObj.other_predictors.metasvm.score = (dbnsfp.metasvm && dbnsfp.metasvm.score) ? this.handleScoreObj(dbnsfp.metasvm.score) : null;
+            computationObj.other_predictors.metasvm.prediction = (dbnsfp.metasvm && dbnsfp.metasvm.pred) ? this.handlePredObj(dbnsfp.metasvm.pred) : null;
+            computationObj.other_predictors.metalr.score = (dbnsfp.metalr && dbnsfp.metalr.score) ? this.handleScoreObj(dbnsfp.metalr.score) : null;
+            computationObj.other_predictors.metalr.prediction = (dbnsfp.metalr && dbnsfp.metalr.pred) ? this.handlePredObj(dbnsfp.metalr.pred) : null;
+            computationObj.other_predictors.fathmm_mkl.score = (dbnsfp['fathmm-mkl'] && dbnsfp['fathmm-mkl'].coding_score) ? this.handleScoreObj(dbnsfp['fathmm-mkl'].coding_score) : null;
+            computationObj.other_predictors.fathmm_mkl.prediction = (dbnsfp['fathmm-mkl'] && dbnsfp['fathmm-mkl'].coding_pred) ? this.handlePredObj(dbnsfp['fathmm-mkl'].coding_pred) : null;
+            computationObj.other_predictors.fitcons.score = (dbnsfp.integrated && dbnsfp.integrated.fitcons_score) ? this.handleScoreObj(dbnsfp.integrated.fitcons_score) : null;
             // update computationObj, and set flag indicating that we have other predictors data
             this.setState({hasOtherPredData: true, computationObj: computationObj});
         }
         if (response.cadd) {
             let cadd = response.cadd;
-            computationObj.other_predictors.cadd.score = parseFloat(cadd.consscore);
-            //computationObj.other_predictors.cadd.prediction = cadd.pred;
-            computationObj.other_predictors.fitcons.score = parseFloat(cadd.fitcons);
-            //computationObj.other_predictors.fitcons.prediction = cadd.fitcons.pred;
+            computationObj.other_predictors.cadd.score = parseFloat(cadd.rawscore);
             // update computationObj, and set flag indicating that we have other predictors data
             this.setState({hasOtherPredData: true, computationObj: computationObj});
         }
@@ -341,7 +339,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <td><a href="https://sites.google.com/site/revelgenomics/home" target="_blank">REVEL (meta-predictor)</a></td>
+                                        <td><a href="https://sites.google.com/site/revelgenomics/about" target="_blank">REVEL</a> (meta-predictor)</td>
                                         <td>0 to 1</td>
                                         <td>0.7</td>
                                         <td>higher score = higher pathogenicity</td>
@@ -565,7 +563,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             {this.state.hasClinVarData && codon ?
                                 <dl className="inline-dl clearfix">
                                     <dt>Number of variants at codon: <span className="condon-variant-count">{codon.count}</span></dt>
-                                    <dd className="pull-right"><a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a></dd>
+                                    <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
                                 </dl>
                             :
                                 <dl className="inline-dl clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -35,9 +35,9 @@ var computationStatic = {
             'mutationassessor': 'MutationAssessor',
             'fathmm': 'FATHMM',
             'provean': 'PROVEAN',
-            'metasvm': 'MetaSVM',
-            'metalr': 'MetaLR',
-            'cadd': 'CADD',
+            'metasvm': 'MetaSVM (meta-predictor)',
+            'metalr': 'MetaLR (meta-predictor)',
+            'cadd': 'CADD (meta-predictor)',
             'fathmm_mkl': 'FATHMM-MKL',
             'fitcons': 'fitCons',
         }
@@ -308,7 +308,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <td><a href="https://sites.google.com/site/revelgenomics/home" target="_blank">REVEL meta-predictor</a></td>
+                                        <td><a href="https://sites.google.com/site/revelgenomics/home" target="_blank">REVEL (meta-predictor)</a></td>
                                         <td>0 to 1</td>
                                         <td>0.7</td>
                                         <td>higher score = higher pathogenicity</td>
@@ -545,20 +545,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                 <div>
                     <h2 className="page-header">Repetitive Region</h2>
-                    {this.props.data ?
-                        <div className="panel panel-info">
-                            <div className="panel-heading"><h3 className="panel-title">External resources for this variant</h3></div>
-                            <div className="panel-body">
-                                <dl className="inline-dl clearfix">
-                                    <dd><a href="#" target="_blank">View Variant in UCSC Browser</a></dd>
-
-                                    <dd><a href="#" target="_blank">View Variant in Variation Viewer</a></dd>
-
-                                    <dd><a href="#" target="_blank">View genomic location in ExAC</a></dd>
-                                </dl>
-                            </div>
-                        </div>
-                    : null}
                 </div>
 
             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -39,7 +39,7 @@ var computationStatic = {
             'metalr': 'MetaLR (meta-predictor)',
             'cadd': 'CADD (meta-predictor)',
             'fathmm_mkl': 'FATHMM-MKL',
-            'fitcons': 'fitCons',
+            'fitcons': 'fitCons'
         }
     }
 };
@@ -160,7 +160,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             codonObj.term = term;
                             codonObj.symbol = symbol;
                             this.setState({hasClinVarData: true, codonObj: codonObj});
-                        })
+                        });
                     }).catch(function(e) {
                         console.log('ClinVar Fetch Error=: %o', e);
                     });
@@ -235,7 +235,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 if (!isNaN(value) && value !== null) {
                     newArr.push(value);
                 }
-            };
+            }
             newStr = newArr.join(', ');
         } else {
             newStr = obj;
@@ -451,7 +451,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <td colSpan="4">WT Sequence</td>
+                                        <th colSpan="4">WT Sequence</th>
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
@@ -476,7 +476,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
                                     <tr>
-                                        <td colSpan="4">Variant Sequence</td>
+                                        <th colSpan="4">Variant Sequence</th>
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
@@ -557,13 +557,13 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </div>
 
                 <div>
-                    <h2 className="page-header">Other Variants in Codon</h2>
+                    <h2 className="page-header">Variants in Same Codon</h2>
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
                             {this.state.hasClinVarData && codon ?
                                 <dl className="inline-dl clearfix">
-                                    <dt>Number of variants at codon: <span className="condon-variant-count">{codon.count}</span></dt>
+                                    <dt>Number of variants in codon: <span className="condon-variant-count">{codon.count}</span></dt>
                                     <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
                                 </dl>
                             :

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -176,28 +176,28 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (response.dbnsfp) {
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.other_predictors.sift.score = parseFloat(dbnsfp.sift.converted_rankscore);
-            computationObj.other_predictors.sift.prediction = dbnsfp.sift.pred[0];
-            computationObj.other_predictors.polyphen2_hdiv.score = parseFloat(dbnsfp.polyphen2.hdiv.rankscore);
-            computationObj.other_predictors.polyphen2_hdiv.prediction = dbnsfp.polyphen2.hdiv.pred;
-            computationObj.other_predictors.polyphen2_hvar.score = parseFloat(dbnsfp.polyphen2.hvar.rankscore);
-            computationObj.other_predictors.polyphen2_hvar.prediction = dbnsfp.polyphen2.hvar.pred;
-            computationObj.other_predictors.lrt.score = parseFloat(dbnsfp.lrt.converted_rankscore);
-            computationObj.other_predictors.lrt.prediction = dbnsfp.lrt.pred;
-            computationObj.other_predictors.mutationtaster.score = parseFloat(dbnsfp.mutationtaster.converted_rankscore);
-            computationObj.other_predictors.mutationtaster.prediction = dbnsfp.mutationtaster.pred[0];
-            computationObj.other_predictors.mutationassessor.score = parseFloat(dbnsfp.mutationassessor.rankscore);
-            computationObj.other_predictors.mutationassessor.prediction = dbnsfp.mutationassessor.pred;
-            computationObj.other_predictors.fathmm.score = parseFloat(dbnsfp.fathmm.rankscore);
-            computationObj.other_predictors.fathmm.prediction = dbnsfp.fathmm.pred[0];
-            computationObj.other_predictors.provean.score = parseFloat(dbnsfp.provean.rankscore);
-            computationObj.other_predictors.provean.prediction = dbnsfp.provean.pred[0];
-            computationObj.other_predictors.metasvm.score = parseFloat(dbnsfp.metasvm.rankscore);
-            computationObj.other_predictors.metasvm.prediction = dbnsfp.metasvm.pred;
-            computationObj.other_predictors.metalr.score = parseFloat(dbnsfp.metalr.rankscore);
-            computationObj.other_predictors.metalr.prediction = dbnsfp.metalr.pred;
-            computationObj.other_predictors.fathmm_mkl.score = parseFloat(dbnsfp['fathmm-mkl'].coding_rankscore);
-            computationObj.other_predictors.fathmm_mkl.prediction = dbnsfp['fathmm-mkl'].coding_pred;
+            computationObj.other_predictors.sift.score = this.handleScoreObj(dbnsfp.sift.score);
+            computationObj.other_predictors.sift.prediction = this.handlePredObj(dbnsfp.sift.pred);
+            computationObj.other_predictors.polyphen2_hdiv.score = this.handleScoreObj(dbnsfp.polyphen2.hdiv.score);
+            computationObj.other_predictors.polyphen2_hdiv.prediction = this.handlePredObj(dbnsfp.polyphen2.hdiv.pred);
+            computationObj.other_predictors.polyphen2_hvar.score = this.handleScoreObj(dbnsfp.polyphen2.hvar.score);
+            computationObj.other_predictors.polyphen2_hvar.prediction = this.handlePredObj(dbnsfp.polyphen2.hvar.pred);
+            computationObj.other_predictors.lrt.score = this.handleScoreObj(dbnsfp.lrt.score);
+            computationObj.other_predictors.lrt.prediction = this.handlePredObj(dbnsfp.lrt.pred);
+            computationObj.other_predictors.mutationtaster.score = this.handleScoreObj(dbnsfp.mutationtaster.score);
+            computationObj.other_predictors.mutationtaster.prediction = this.handlePredObj(dbnsfp.mutationtaster.pred);
+            computationObj.other_predictors.mutationassessor.score = this.handleScoreObj(dbnsfp.mutationassessor.score);
+            computationObj.other_predictors.mutationassessor.prediction = this.handlePredObj(dbnsfp.mutationassessor.pred);
+            computationObj.other_predictors.fathmm.score = this.handleScoreObj(dbnsfp.fathmm.score);
+            computationObj.other_predictors.fathmm.prediction = this.handlePredObj(dbnsfp.fathmm.pred);
+            computationObj.other_predictors.provean.score = this.handleScoreObj(dbnsfp.provean.score);
+            computationObj.other_predictors.provean.prediction = this.handlePredObj(dbnsfp.provean.pred);
+            computationObj.other_predictors.metasvm.score = this.handleScoreObj(dbnsfp.metasvm.score);
+            computationObj.other_predictors.metasvm.prediction = this.handlePredObj(dbnsfp.metasvm.pred);
+            computationObj.other_predictors.metalr.score = this.handleScoreObj(dbnsfp.metalr.score);
+            computationObj.other_predictors.metalr.prediction = this.handlePredObj(dbnsfp.metalr.pred);
+            computationObj.other_predictors.fathmm_mkl.score = this.handleScoreObj(dbnsfp['fathmm-mkl'].coding_score);
+            computationObj.other_predictors.fathmm_mkl.prediction = this.handlePredObj(dbnsfp['fathmm-mkl'].coding_pred);
             // update computationObj, and set flag indicating that we have other predictors data
             this.setState({hasOtherPredData: true, computationObj: computationObj});
         }
@@ -212,6 +212,39 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         }
     },
 
+    // Method to convert prediction array to string
+    handlePredObj: function(obj) {
+        var newArr = [], newStr = '';
+        if (Array.isArray(obj)) {
+            for (let value of obj.values()) {
+                var letterPattern = /^[a-z]+$/i;
+                if (value.match(letterPattern)) {
+                    newArr.push(value);
+                }
+            };
+            newStr = newArr.join(', ');
+        } else {
+            newStr = obj;
+        }
+        return newStr;
+    },
+
+    // Method to convert score array to string
+    handleScoreObj: function(obj) {
+        var newArr = [], newStr = '';
+        if (Array.isArray(obj)) {
+            for (let value of obj.values()) {
+                if (!isNaN(value) && value !== null) {
+                    newArr.push(value);
+                }
+            };
+            newStr = newArr.join(', ');
+        } else {
+            newStr = obj;
+        }
+        return newStr;
+    },
+
     // Method to assign conservation scores data to global computation object
     parseConservationData: function(response) {
         // Not all variants return the dbnsfp{...} object from myvariant.info
@@ -219,12 +252,12 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             let computationObj = this.state.computationObj;
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.conservation.phylop7way = parseFloat(dbnsfp.phylo.p7way.vertebrate_rankscore);
-            computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian_rankscore);
-            computationObj.conservation.phastconsp7way = parseFloat(dbnsfp.phastcons['7way'].vertebrate_rankscore);
-            computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian_rankscore);
-            computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs_rankscore);
-            computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds_rankscore);
+            computationObj.conservation.phylop7way = parseFloat(dbnsfp.phylo.p7way.vertebrate);
+            computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian);
+            computationObj.conservation.phastconsp7way = parseFloat(dbnsfp.phastcons['7way'].vertebrate);
+            computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian);
+            computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs);
+            computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds);
             // update computationObj, and set flag indicating that we have conservation analysis data
             this.setState({hasConservationData: true, computationObj: computationObj});
         }
@@ -239,7 +272,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 <td>{rowName}</td>
                 <td>{otherPred[key].score_range}</td>
                 <td>{otherPred[key].score ? otherPred[key].score : '--'}</td>
-                <td>{otherPred[key].prediction ? this.mapPredictionName(otherPred[key].prediction) : '--'}</td>
+                <td>{otherPred[key].prediction ? otherPred[key].prediction : '--'}</td>
             </tr>
         );
     },

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -154,7 +154,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     }).then(clinvar => {
                         var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
                         var symbol = clinvar.gene_symbol;
-                        this.getRestData(this.props.protocol + '//eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+                        this.getRestData(this.props.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
                             var codonObj = {};
                             codonObj.count = result.esearchresult.count;
                             codonObj.term = term;
@@ -400,6 +400,14 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     {this.state.hasConservationData ?
                         <div className="panel panel-info datasource-splice">
                             <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
+                            <div className="panel-body">
+                                <span className="pull-right">
+                                    <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">See data in MaxEntScan <i className="icon icon-external-link"></i></a>
+                                    <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">See data in NNSPLICE <i className="icon icon-external-link"></i></a>
+                                    <a href="http://www.cbcb.umd.edu/software/GeneSplicer/gene_spl.shtml" target="_blank">See data in GeneSplicer <i className="icon icon-external-link"></i></a>
+                                    <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">See data in HumanSplicingFinder <i className="icon icon-external-link"></i></a>
+                                </span>
+                            </div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -524,7 +532,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             {this.state.hasClinVarData && codon ?
                                 <dl className="inline-dl clearfix">
                                     <dt>Number of variants at codon: <span className="condon-variant-count">{codon.count}</span></dt>
-                                    <dd>[ <a href={this.props.protocol + '//www.ncbi.nlm.nih.gov/clinvar/?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar</a> ]</dd>
+                                    <dd className="pull-right"><a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a></dd>
                                 </dl>
                             :
                                 <dl className="inline-dl clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -615,8 +615,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </tbody>
                             <tfoot>
                                 <tr className="count">
-                                    <td>Average Sample Read Depth</td>
-                                    <td colSpan="5">{esp._extra.avg_sample_read}</td>
+                                    <td colSpan="6">Average Sample Read Depth: {esp._extra.avg_sample_read}</td>
                                 </tr>
                             </tfoot>
                         </table>

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -58,6 +58,7 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.gene = {};
     variant.allele = {};
     variant.allele.SequenceLocation = [];
+    variant.allele.ProteinChange = '';
     // Group transcripts by RefSeq nucleotide change, molecular consequence, and protein change
     variant.RefSeqTranscripts.NucleotideChangeList = [];
     variant.RefSeqTranscripts.MolecularConsequenceList = [];
@@ -102,6 +103,8 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     var geneNode = geneList.getElementsByTagName('Gene')[0];
     variant.gene.symbol = geneNode.getAttribute('Symbol');
     variant.gene.full_name = geneNode.getAttribute('FullName');
+    var protein_change = allele.getElementsByTagName('ProteinChange')[0];
+    variant.allele.ProteinChange = protein_change.textContent;
     // Parse <SequenceLocation> nodes
     var SequenceLocationNodes = allele.getElementsByTagName('SequenceLocation');
     for(let y of SequenceLocationNodes) {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1101,6 +1101,41 @@ div.react-tabs .ReactTabs__TabPanel--selected {
         .population .datasource-ESP .table tfoot td {
             width: 16.66%;
         }
+
+        .computational .datasource-clingen .table th,
+        .computational .datasource-clingen .table td,
+        .computational .datasource-other .table th,
+        .computational .datasource-other .table td,
+        .computational .datasource-splice .table th,
+        .computational .datasource-splice .table td {
+            width: 25%;
+        }
+
+        .computational .datasource-conservation .table th,
+        .computational .datasource-conservation .table td,
+        .computational .datasource-additional .table th {
+            width: 50%;
+        }
+
+        .computational .datasource-clinvar dt {
+            margin-right: 15px;
+        }
+
+        .computational .page-header:first-child {
+            margin-top: 20px;
+        }
+
+        .computational .datasource-splice .table {
+            .row-span {
+                border-left: 1px solid #ddd;
+                border-right: 1px solid #ddd;
+                font-weight: bold;
+            }
+
+            tfoot td {
+                font-weight: bold;
+            }
+        }
     }
 }
 
@@ -1340,4 +1375,15 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     opacity: 1;
+}
+
+/* FIXME: placeholder style. Will be removed. */
+.wip {
+    background-color: #ccc;
+    border-radius: 4px;
+    color: white;
+    display: inline-block;
+    font-size: 10px;
+    font-weight: normal;
+    padding: 3px 8px;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1073,6 +1073,10 @@ div.react-tabs .ReactTabs__TabPanel--selected {
 
             dd {
                 margin-right: 20px;
+
+                &.pull-right {
+                    margin-right: 0;
+                }
             }
         }
 
@@ -1255,6 +1259,7 @@ div.react-tabs .ReactTabs__TabPanel--selected {
         font-weight: bold;
 
         a {
+            font-size: 85%;
             font-weight: normal;
             margin-left: 20px;
         }
@@ -1268,6 +1273,14 @@ div.react-tabs .ReactTabs__TabPanel--selected {
 
     .pull-right {
         float: right;
+    }
+
+    .panel-body {
+        padding-bottom: 12px;
+
+        .pull-right a {
+            margin-left: 20px;
+        }
     }
 }
 


### PR DESCRIPTION
This PR consists of changes pertinent to the UI of computational tab.

**Known issues:**
1. The data in the "ClinGen Predictors" table is static at the moment. Will add logic to call the API (e.g. https://predictvar.bustamante-lab.net) after today.
2. Removed the placeholder external links in the "Repetitive Region" section for future implementation as they are low-priority. But the header of "Repetitive Region" is left in the code in case @mrmin123 needs it in the process of implementing the form. He can choose it to remove it or hide it together with the form.
3. Just discovered that not all ClinVar IDs (e.g. 139214) returns the <ProteinChange> node in its Eutils API response. Currently there is no logic to bypass it and thus rendering bails out due to error. Will add logic to fix this and the respective codon API call.

**Steps to test:**
1. Login and enter ClinVar ID 55847 on the variant selection page.
2. Navigate to the "Predictors" tab and expect to see real data being displayed in the "Other Predictors" and "Conservation Analysis" tables.
3. Click on various external links in the "Predictors" tab and expect to see the intended external pages.