### PR TITLE
Connects to #789 kl stay on same tab

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -16,8 +16,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         variantData: React.PropTypes.object, // ClinVar data payload
         session: React.PropTypes.object,
         interpretationUuid: React.PropTypes.string,
-        editKey: React.PropTypes.bool,
-        href_url: React.PropTypes.object
+        editKey: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -41,11 +40,14 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         e.preventDefault(); e.stopPropagation();
         var variantObj = this.props.variantData;
         var newInterpretationObj;
+
+        // get tab from current window href. If get one, it will be added into the new url
         var tab = null;
         var page_url = window.location.href;
         if (page_url.indexOf('tab=') > -1 ) {
             tab = '&tab=' + page_url.split('tab=').pop();
         }
+
         if (variantObj) {
             this.setState({variantUuid: variantObj.uuid});
             // Put together a new interpretation object
@@ -55,9 +57,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         // the new interpretation UUID in the query string.
         this.postRestData('/interpretations/', newInterpretationObj).then(data => {
             var newInterpretationUuid = data['@graph'][0].uuid;
-            // this.setState({interpretationUuid: newInterpretationUuid});
-            //window.location.href = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
             var new_url = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
+            // add tab
             if (tab) {
                 new_url = new_url + tab;
             }

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -16,7 +16,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         variantData: React.PropTypes.object, // ClinVar data payload
         session: React.PropTypes.object,
         interpretationUuid: React.PropTypes.string,
-        editKey: React.PropTypes.bool
+        editKey: React.PropTypes.bool,
+        pageURL: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -63,6 +64,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         */
         return (
             <div>
+                <span>{this.props.pageURL}</span>
                 <div className="container curation-actions curation-variant">
                 {((this.props.interpretationUuid && this.props.interpretationUuid.length > 0) || (this.props.editKey && this.props.interpretationUuid.length > 0)) ?
                     <div className="interpretation-record clearfix">

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -17,7 +17,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         session: React.PropTypes.object,
         interpretationUuid: React.PropTypes.string,
         editKey: React.PropTypes.bool,
-        pageURL: React.PropTypes.string
+        href_url: React.PropTypes.object
     },
 
     getInitialState: function() {
@@ -41,6 +41,11 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         e.preventDefault(); e.stopPropagation();
         var variantObj = this.props.variantData;
         var newInterpretationObj;
+        var tab = null;
+        var page_url = window.location.href;
+        if (page_url.indexOf('tab=') > -1 ) {
+            tab = '&tab=' + page_url.split('tab=').pop();
+        }
         if (variantObj) {
             this.setState({variantUuid: variantObj.uuid});
             // Put together a new interpretation object
@@ -51,7 +56,12 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         this.postRestData('/interpretations/', newInterpretationObj).then(data => {
             var newInterpretationUuid = data['@graph'][0].uuid;
             // this.setState({interpretationUuid: newInterpretationUuid});
-            window.location.href = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
+            //window.location.href = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
+            var new_url = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
+            if (tab) {
+                new_url = new_url + tab;
+            }
+            window.location.href =  new_url;
         }).catch(e => {parseAndLogError.bind(undefined, 'postRequest')});
     },
 
@@ -64,7 +74,6 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         */
         return (
             <div>
-                <span>{this.props.pageURL}</span>
                 <div className="container curation-actions curation-variant">
                 {((this.props.interpretationUuid && this.props.interpretationUuid.length > 0) || (this.props.editKey && this.props.interpretationUuid.length > 0)) ?
                     <div className="interpretation-record clearfix">

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -21,7 +21,8 @@ var VariantCurationHub = React.createClass({
             interpretation: null,
             editKey: queryKeyValue('edit', this.props.href),
             variantObj: null,
-            isLoadingComplete: false
+            isLoadingComplete: false,
+            pageURL: this.props.href
         };
     },
 
@@ -60,7 +61,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
+                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} pageURL={this.state.pageURL} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -64,7 +64,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} pageURL={this.state.pageURL} />
+                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} href_url={this.props.href_url} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -21,8 +21,7 @@ var VariantCurationHub = React.createClass({
             interpretation: null,
             editKey: queryKeyValue('edit', this.props.href),
             variantObj: null,
-            isLoadingComplete: false,
-            pageURL: this.props.href
+            isLoadingComplete: false
         };
     },
 
@@ -64,7 +63,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} href_url={this.props.href_url} />
+                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>


### PR DESCRIPTION
It's required to stay at same tab after click "Start new interpretation" button.

**Changes**
Added codes in file `src/clincoded/static/components/variant_central/actions.js` to pass tab info to new page.

**Test**
* After select variant id type, enter variant id and get into initial variant-central page, select any tab and click "Start new interpretation" button. Expect to see new interpretation page stays at the same tab.