### PR TITLE
Connects to #777. MAF cutoff field in population tab

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -841,6 +841,7 @@ var criteriaGroup1Change = function(ref, e) {
         }
         this.refs[altCriteriaDescription].setValue(this.refs[ref].getValue());
     }
+    // if the MAF cutoff field is changed, update the populationObj payload with the updated value
     if (ref === 'maf-cutoff') {
         let tempEvidenceData = this.state.evidenceData;
         tempEvidenceData.mafCutoff = parseInt(this.refs[ref].getValue());
@@ -848,6 +849,7 @@ var criteriaGroup1Change = function(ref, e) {
     }
 };
 
+// special function to handle the MAF cutoff % field
 var mafCutoffBlur = function(event) {
     let mafCutoff = parseInt(this.refs['maf-cutoff'].getValue());
     if (mafCutoff == '' || isNaN(mafCutoff)) {

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -64,8 +64,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             desiredCIDisplay: null,
             populationObj: {
                 highestMAF: null,
-                desiredCI: null,
-                mafCutoff: null,
+                desiredCI: 95,
+                mafCutoff: 5,
                 exac: {
                     afr: {}, amr: {}, eas: {}, fin: {}, nfe: {}, oth: {}, sas: {}, _tot: {}, _extra: {}
                 },
@@ -761,7 +761,9 @@ var criteriaGroup1 = function() {
                 checked={this.state.checkboxes['PM2-value'] ? this.state.checkboxes['PM2-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="number" ref="maf-cutoff" label="MAF cutoff (%):" minVal={0} maxVal={100} maxLength="2" handleChange={this.handleFormChange}
+                value={this.state.evidenceData && this.state.evidenceData.mafCutoff ? this.state.evidenceData.mafCutoff : 5}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-1" groupClassName="form-group" onBlur={mafCutoffBlur.bind(this)} />
+            }
             <Input type="textarea" ref="BA1-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <Input type="textarea" ref="PM2-description" label="Explain criteria selection (PM2):" rows="5"

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -508,6 +508,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
     calculateCI: function(CIp, highestMAF) {
+        // store user-input desired CI value into population object
         let populationObj = this.state.populationObj;
         populationObj.desiredCI = CIp;
         if (highestMAF) {
@@ -517,8 +518,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 // automatically set value to default here
                 this.setState({populationObj: populationObj, CILow: null, CIHigh: null});
             } else if (highestMAF.ac && highestMAF.ac_tot) {
-                // store user-input desired CI value into population object
-
                 // calculate CI
                 let xp = highestMAF.ac,
                     np = highestMAF.ac_tot;

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -61,7 +61,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             geneENSG: null,
             CILow: null,
             CIhigh: null,
-            desiredCIDisplay: null,
             populationObj: {
                 highestMAF: null,
                 desiredCI: 95,
@@ -469,15 +468,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         if (interpretation && interpretation.evaluations && interpretation.evaluations.length > 0) {
             for (var i = 0; i < interpretation.evaluations.length; i++) {
                 if (interpretation.evaluations[i].criteria == 'BA1') {
-                    this.setState({desiredCIDisplay: interpretation.evaluations[i].population.populationData.desiredCI});
-                    //this.refs.desiredCI.setValue(this.state.interpretation.evaluations[i].population.populationData.desiredCI);
+                    let tempPopulationObj = this.state.populationObj;
+                    tempPopulationObj.desiredCI = interpretation.evaluations[i].population.populationData.desiredCI;
+                    this.setState({populationObj: tempPopulationObj});
                     break;
                 }
             }
         }
-        if (!this.state.desiredCIDisplay) {
+        if (!this.state.populationObj.desiredCI) {
             // previously saved value does not exist for some reason... set it to default value
-            this.setState({desiredCIDisplay: CI_DEFAULT});
+            let tempPopulationObj = this.state.populationObj;
+            tempPopulationObj.desiredCI = CI_DEFAULT;
+            this.setState({populationObj: tempPopulationObj});
         }
         // update CI low and high values
         this.changeDesiredCI();
@@ -496,24 +498,27 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         if (desiredCI == '' || isNaN(desiredCI)) {
             // if the user clicks away from the desired CI field, but it is blank/filled with
             // bad input, re-set it to the default value
+            let tempPopulationObj = this.state.populationObj;
             this.refs.desiredCI.setValue(CI_DEFAULT);
-            this.setState({desiredCIDisplay: CI_DEFAULT});
+            tempPopulationObj.desiredCI = CI_DEFAULT;
+            this.setState({populationObj: tempPopulationObj});
             this.changeDesiredCI();
         }
     },
 
     // function to calculate confidence intervals (CI). Formula taken from Steven's excel spreadsheet
     calculateCI: function(CIp, highestMAF) {
+        let populationObj = this.state.populationObj;
+        populationObj.desiredCI = CIp;
         if (highestMAF) {
             if (isNaN(CIp) || CIp < 0 || CIp > 100) {
                 // the field is blank... clear CI low and high values
                 // note that the user did not necessary navigate away from field just yet, so do not
                 // automatically set value to default here
-                this.setState({CILow: null, CIHigh: null});
-            } else {
+                this.setState({populationObj: populationObj, CILow: null, CIHigh: null});
+            } else if (highestMAF.ac && highestMAF.ac_tot) {
                 // store user-input desired CI value into population object
-                let populationObj = this.state.populationObj;
-                populationObj.desiredCI = CIp;
+
                 // calculate CI
                 let xp = highestMAF.ac,
                     np = highestMAF.ac_tot;
@@ -523,7 +528,11 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                 let CILow = this.parseFloatShort(((2 * np * pp) + (zp * zp) - zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp)))),
                     CIHigh = this.parseFloatShort(((2 * np * pp) + (zp * zp) + zp * Math.sqrt((zp * zp) + (4 * np * pp * qp))) / (2 * (np + (zp * zp))));
                 this.setState({populationObj: populationObj, CILow: CILow, CIHigh: CIHigh});
+            } else {
+                this.setState({populationObj: populationObj, CILow: 'N/A', CIHigh: 'N/A'});
             }
+        } else {
+            this.setState({populationObj: populationObj, CILow: 'N/A', CIHigh: 'N/A'});
         }
     },
 
@@ -566,7 +575,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             exac = this.state.populationObj && this.state.populationObj.exac ? this.state.populationObj.exac : null, // Get ExAC data from global population object
             tGenomes = this.state.populationObj && this.state.populationObj.tGenomes ? this.state.populationObj.tGenomes : null,
             esp = this.state.populationObj && this.state.populationObj.esp ? this.state.populationObj.esp : null; // Get ESP data from global population object
-        var desiredCIDisplay = this.state.desiredCIDisplay ? this.state.desiredCIDisplay : null;
+        var desiredCI = this.state.populationObj && this.state.populationObj.desiredCI ? this.state.populationObj.desiredCI : CI_DEFAULT;
 
         return (
             <div className="variant-interpretation population">
@@ -588,7 +597,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                     <span>
                                         <dt className="dtFormLabel">Desired CI:</dt>
                                         <dd className="ddFormInput">
-                                            <Input type="number" inputClassName="desired-ci-input" ref="desiredCI" value={desiredCIDisplay} handleChange={this.changeDesiredCI}
+                                            <Input type="number" inputClassName="desired-ci-input" ref="desiredCI" value={desiredCI} handleChange={this.changeDesiredCI}
                                                 onBlur={this.onBlurDesiredCI} minVal={0} maxVal={100} maxLength="2" placeholder={CI_DEFAULT.toString()} />
                                         </dd>
                                         <dt>CI - lower: </dt><dd>{this.state.CILow ? this.state.CILow : ''}</dd>
@@ -761,9 +770,8 @@ var criteriaGroup1 = function() {
                 checked={this.state.checkboxes['PM2-value'] ? this.state.checkboxes['PM2-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="number" ref="maf-cutoff" label="MAF cutoff (%):" minVal={0} maxVal={100} maxLength="2" handleChange={this.handleFormChange}
-                value={this.state.evidenceData && this.state.evidenceData.mafCutoff ? this.state.evidenceData.mafCutoff : 5}
+                value={this.state.evidenceData && this.state.evidenceData.mafCutoff ? this.state.evidenceData.mafCutoff : "5"}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-1" groupClassName="form-group" onBlur={mafCutoffBlur.bind(this)} />
-            }
             <Input type="textarea" ref="BA1-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <Input type="textarea" ref="PM2-description" label="Explain criteria selection (PM2):" rows="5"

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -65,6 +65,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             populationObj: {
                 highestMAF: null,
                 desiredCI: null,
+                mafCutoff: null,
                 exac: {
                     afr: {}, amr: {}, eas: {}, fin: {}, nfe: {}, oth: {}, sas: {}, _tot: {}, _extra: {}
                 },
@@ -759,6 +760,8 @@ var criteriaGroup1 = function() {
             <Input type="checkbox" ref="PM2-value" label="PM2 met?:" handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['PM2-value'] ? this.state.checkboxes['PM2-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="number" ref="maf-cutoff" label="MAF cutoff (%):" minVal={0} maxVal={100} maxLength="2" handleChange={this.handleFormChange}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-1" groupClassName="form-group" onBlur={mafCutoffBlur.bind(this)} />
             <Input type="textarea" ref="BA1-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <Input type="textarea" ref="PM2-description" label="Explain criteria selection (PM2):" rows="5"
@@ -788,6 +791,7 @@ var criteriaGroup1Update = function(nextProps) {
                     case 'BA1':
                         tempCheckboxes['BA1-value'] = evaluation.value === 'true';
                         this.refs['BA1-description'].setValue(evaluation.description);
+                        this.refs['maf-cutoff'].setValue(evaluation.population.populationData.mafCutoff);
                         break;
                     case 'PM2':
                         tempCheckboxes['PM2-value'] = evaluation.value === 'true';
@@ -829,5 +833,22 @@ var criteriaGroup1Change = function(ref, e) {
             altCriteriaDescription = 'BA1-description';
         }
         this.refs[altCriteriaDescription].setValue(this.refs[ref].getValue());
+    }
+    if (ref === 'maf-cutoff') {
+        let tempEvidenceData = this.state.evidenceData;
+        tempEvidenceData.mafCutoff = parseInt(this.refs[ref].getValue());
+        this.setState({evidenceData: tempEvidenceData});
+    }
+};
+
+var mafCutoffBlur = function(event) {
+    let mafCutoff = parseInt(this.refs['maf-cutoff'].getValue());
+    if (mafCutoff == '' || isNaN(mafCutoff)) {
+        let tempEvidenceData = this.state.evidenceData;
+        // if the user clicks away from the MAF cutoff field, but it is blank/filled with
+        // bad input, re-set it to the default value of 5
+        this.refs['maf-cutoff'].setValue(5);
+        tempEvidenceData.mafCutoff = 5;
+        this.setState({evidenceData: tempEvidenceData});
     }
 };

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -754,11 +754,9 @@ var criteriaGroup1 = function() {
         <div>
             <div className="col-sm-7 col-sm-offset-5 input-note-top">
                 <p className="alert alert-info">
-                    <strong>BA1 (Benign):</strong> &gt;0.1% with a 99% CI<br />
-                        CI – lower must be &gt;0.1%
+                    <strong>BA1:</strong> Allele frequence is > 5% in ExAC, 1000 Genomes, or ESP
                     <br /><br />
-                    <strong>PM2 (Rare Enough to be Absent):</strong> &lt;0.5% with a 95% CI<br />
-                        CI – lower must be ~0%; CI – upper must stay below (0.05%)
+                    <strong>PM2:</strong> Absent from controls (or at extremely low frequency if recessive) in ExAC, 1000 Genomes, or ESP
                 </p>
             </div>
             <Input type="checkbox" ref="BA1-value" label="BA1 met?:" handleChange={this.handleCheckboxChange}
@@ -777,7 +775,7 @@ var criteriaGroup1 = function() {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" handleChange={this.handleFormChange} />
             <div className="col-sm-7 col-sm-offset-5 input-note-top">
                 <p className="alert alert-info">
-                    <strong>BS1 (Benign):</strong> Allele frequency greater than expected due to disorder
+                    <strong>BS1:</strong> Allele frequency greater than expected due to disorder
                 </p>
             </div>
             <Input type="checkbox" ref="BS1-value" label={<span>BS1 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -212,7 +212,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
         }).then(interpretation => {
             // REST handling is done. Re-enable Save button, and send the interpretation object back to index.js
             this.setState({submitBusy: false, updateMsg: <span className="text-success">Evaluations for {submittedCriteria.join(', ')} saved successfully!</span>});
-            this.props.updateInterpretationObj(interpretation);
+            this.props.updateInterpretationObj();
         }).catch(error => {
             this.setState({submitBusy: false, updateMsg: <span className="text-danger">Evaluation could not be saved successfully!</span>});
             console.log(error);

--- a/src/clincoded/static/libs/bootstrap/form.js
+++ b/src/clincoded/static/libs/bootstrap/form.js
@@ -356,7 +356,7 @@ var Input = module.exports.Input = React.createClass({
                     <div className={this.props.groupClassName}>
                         {this.props.label ? <label htmlFor={this.props.id} className={this.props.labelClassName}><span>{this.props.label}{this.props.required ? ' *' : ''}</span></label> : null}
                         <div className={this.props.wrapperClassName}>
-                            <select className="form-control" ref="input" onChange={this.handleChange.bind(null, this.props.id)} defaultValue={this.props.hasOwnProperty('value') ? this.props.value : this.props.defaultValue} disabled={this.props.inputDisabled}>
+                            <select className="form-control" ref="input" onChange={this.handleChange.bind(null, this.props.id)} onBlur={this.props.onBlur} defaultValue={this.props.hasOwnProperty('value') ? this.props.value : this.props.defaultValue} disabled={this.props.inputDisabled}>
                                 {this.props.children}
                             </select>
                             <div className="form-error">{this.props.error ? <span>{this.props.error}</span> : <span>&nbsp;</span>}</div>
@@ -371,7 +371,7 @@ var Input = module.exports.Input = React.createClass({
                     <div className={this.props.groupClassName}>
                         {this.props.label ? <label htmlFor={this.props.id} className={this.props.labelClassName}><span>{this.props.label}{this.props.required ? ' *' : ''}</span></label> : null}
                         <div className={this.props.wrapperClassName}>
-                            <textarea className={inputClasses} id={this.props.id} name={this.props.id} ref="input" defaultValue={this.props.value} placeholder={this.props.placeholder} onChange={this.handleChange.bind(null, this.props.id)} disabled={this.props.inputDisabled} rows={this.props.rows} />
+                            <textarea className={inputClasses} id={this.props.id} name={this.props.id} ref="input" defaultValue={this.props.value} placeholder={this.props.placeholder} onChange={this.handleChange.bind(null, this.props.id)} onBlur={this.props.onBlur} disabled={this.props.inputDisabled} rows={this.props.rows} />
                             <div className="form-error">{this.props.error ? <span>{this.props.error}</span> : <span>&nbsp;</span>}</div>
                         </div>
                     </div>


### PR DESCRIPTION
* Default value is 5
* If user clicks away and there is invalid/blank value, it defaults to 5
* Value is saved into `populationObj`
* Value is loaded and pre-populated on evaluation load

![image](https://cloud.githubusercontent.com/assets/4326866/16822135/5767f042-490f-11e6-974c-289b2cba36e2.png)

Testing:

1. Get to VCI, population tab
2. Create interpretation
3. Confirm that MAF cutoff field is pre-populated with 5
4. Change MAF cutoff field, save evaluation. Confirm that the proper value is stored in interpretation's evaluation's population's populationData's mafCutoff field
5. Try changing MAF cutoff field (including blank and bad values), and confirm that the field is properly updated