### PR TITLE
Connects to #769. Computational eval forms. Collapsible groups.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -12,8 +12,11 @@ var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
 var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 
+var panel = require('../../../libs/bootstrap/panel');
 var form = require('../../../libs/bootstrap/form');
 
+var PanelGroup = panel.PanelGroup;
+var Panel = panel.Panel;
 var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
@@ -312,12 +315,11 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
         return (
             <div className="variant-interpretation computational">
-                <div>
-                    <h2 className="page-header">Computational Tools</h2>
+                <PanelGroup accordion><Panel title="Functional, Conservation, and Splicing Predictors" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
-                            <CurationInterpretationForm formTitle={"Functional, Conservation, and Splicing Predictors"} renderedFormContent={criteriaGroup1}
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup1}
                                 evidenceType={'computational'} evidenceData={this.state.computationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
                                 formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BP4', 'PP3', 'BP7']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
@@ -552,15 +554,13 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </table>
                         </div>
                     }
+                </Panel></PanelGroup>
 
-                </div>
-
-                <div>
-                    <h2 className="page-header">Variants in Same Codon</h2>
+                <PanelGroup accordion><Panel title="Variants in Same Codon" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
-                            <CurationInterpretationForm formTitle={"Alternate Changes in Codon"} renderedFormContent={criteriaGroup2}
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup2}
                                 evidenceType={'computational'} evidenceDataUpdated={true}
                                 formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
@@ -582,34 +582,33 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             }
                         </div>
                     </div>
-                </div>
+                </Panel></PanelGroup>
 
-                <div>
+                <PanelGroup accordion><Panel title="Molecular Consequence: Missense" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
-                            <CurationInterpretationForm formTitle={"Molecular Consequence: Missense"} renderedFormContent={criteriaGroup3}
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup3}
                                 evidenceType={'computational'} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
                                 formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </div>
                     : null}
-                </div>
+                </Panel></PanelGroup>
 
-                <div>
-                    <h2 className="page-header">Repetitive Region</h2>
+                <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
-                            <CurationInterpretationForm formTitle={"Molecular Consequence: Inframe indel"} renderedFormContent={criteriaGroup4}
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup4}
                                 evidenceType={'computational'} evidenceDataUpdated={true}
                                 formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
                     </div>
                     : null}
-                </div>
+                </Panel></PanelGroup>
 
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -219,7 +219,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 if (value.match(letterPattern)) {
                     newArr.push(value);
                 }
-            };
+            }
             newStr = newArr.join(', ');
         } else {
             newStr = obj;
@@ -312,31 +312,18 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
         return (
             <div className="variant-interpretation computational">
-                {(this.state.interpretation) ?
-                <div className="row">
-                    <div className="col-sm-12">
-                        <CurationInterpretationForm formTitle={"Functional, Conservation, and Splicing Predictors"} renderedFormContent={criteriaGroup1}
-                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
-                            formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BP4', 'PP3', 'BP7']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        <CurationInterpretationForm formTitle={"Alternate Changes in Codon"} renderedFormContent={criteriaGroup2}
-                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
-                            formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        <CurationInterpretationForm formTitle={"Molecular Consequence: Missense"} renderedFormContent={criteriaGroup3}
-                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
-                            formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        <CurationInterpretationForm formTitle={"Molecular Consequence: Inframe indel"} renderedFormContent={criteriaGroup4}
-                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
-                            formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                    </div>
-                </div>
-                : null}
-
                 <div>
                     <h2 className="page-header">Computational Tools</h2>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm formTitle={"Functional, Conservation, and Splicing Predictors"} renderedFormContent={criteriaGroup1}
+                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
+                                formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BP4', 'PP3', 'BP7']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
+                    </div>
+                    : null}
                     {this.props.data ?
                         <div className="panel panel-info datasource-clingen">
                             <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
@@ -570,6 +557,16 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                 <div>
                     <h2 className="page-header">Variants in Same Codon</h2>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm formTitle={"Alternate Changes in Codon"} renderedFormContent={criteriaGroup2}
+                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                                formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
+                    </div>
+                    : null}
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
@@ -588,91 +585,36 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </div>
 
                 <div>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm formTitle={"Molecular Consequence: Missense"} renderedFormContent={criteriaGroup3}
+                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
+                                formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
+                    </div>
+                    : null}
+                </div>
+
+                <div>
                     <h2 className="page-header">Repetitive Region</h2>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm formTitle={"Molecular Consequence: Inframe indel"} renderedFormContent={criteriaGroup4}
+                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                                formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
+                    </div>
+                    : null}
                 </div>
 
             </div>
         );
     }
 });
-
-// FIXME: all functions below here are examples; references to these in above render() should also be removed
-var comp_crit_1 = function() {
-    return (
-        <div>
-            <Input type="checkbox" ref="xbox1-value" label="Predictors Demo Criteria 1?:" handleChange={this.handleCheckboxChange}
-                checked={this.state.checkboxes['xbox1-value'] ? this.state.checkboxes['xbox1-value'] : false}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="checkbox" ref="xbox2-value" label="Predictors Demo Criteria 2?:" handleChange={this.handleCheckboxChange}
-                checked={this.state.checkboxes['xbox2-value'] ? this.state.checkboxes['xbox1-value'] : false}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-        </div>
-    );
-};
-
-var comp_crit_1_update = function(nextProps) {
-    if (nextProps.interpretation) {
-        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
-            nextProps.interpretation.evaluations.map(evaluation => {
-                if (evaluation.criteria == 'xbox1') {
-                    let tempCheckboxes = this.state.checkboxes;
-                    tempCheckboxes['xbox1-value'] = evaluation.value === 'true';
-                    this.setState({checkboxes: tempCheckboxes});
-                }
-                if (evaluation.criteria == 'xbox2') {
-                    let tempCheckboxes = this.state.checkboxes;
-                    tempCheckboxes['xbox2-value'] = evaluation.value === 'true';
-                    this.setState({checkboxes: tempCheckboxes});
-                }
-            });
-        }
-    }
-};
-
-var pop_crit_2 = function() {
-    return (
-        <div>
-            <Input type="select" ref="ps4-value" label="Population Demo Criteria 2?" defaultValue="No Selection"
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
-                <option value="No Selection">No Selection</option>
-                <option value="Yes">Yes</option>
-                <option value="No">No</option>
-                <option value="In Progress">In Progress</option>
-            </Input>
-            <Input type="text" ref="ps4-description" label="Population Demo Criteria 2 Description:" rows="5" placeholder="e.g. free text" inputDisabled={true}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="select" ref="ps5-value" label="Population Demo Criteria 3?" defaultValue="No Selection"
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
-                <option value="No Selection">No Selection</option>
-                <option value="Yes">Yes</option>
-                <option value="No">No</option>
-                <option value="In Progress">In Progress</option>
-            </Input>
-        </div>
-    );
-};
-
-var pop_crit_2_update = function(nextProps) {
-    if (nextProps.interpretation) {
-        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
-            nextProps.interpretation.evaluations.map(evaluation => {
-                switch(evaluation.criteria) {
-                    case 'ps4':
-                        this.refs['ps4-value'].setValue(evaluation.value);
-                        this.setState({submitDisabled: false});
-                        break;
-                    case 'ps5':
-                        this.refs['ps5-value'].setValue(evaluation.value);
-                        this.setState({submitDisabled: false});
-                        break;
-                }
-            });
-        }
-    }
-    if (nextProps.extraData) {
-        this.refs['ps4-description'].setValue(nextProps.extraData.test2);
-    }
-};
 
 // code for rendering of computational tab interpretation forms, first group:
 // functional, conservation, and splicing predictors
@@ -682,7 +624,6 @@ var criteriaGroup1 = function() {
             <div className="col-sm-7 col-sm-offset-5 input-note-top">
                 <p className="alert alert-info">
                     <strong>BP4:</strong> Multiple lines of computational evidence suggest no impact on gene or gene product (conservation, evolutionary, splicing impact, etc.)
-
                     <br /><br />
                     <strong>PP3:</strong> Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc.)
                 </p>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -387,9 +387,9 @@ var criteriaGroup4 = function() {
                 </p>
             </div>
             <Input type="checkbox" ref="BP3-value" label="BP3 met?:" handleChange={this.handleCheckboxChange}
-                checked={this.state.checkboxes['BP3-value'] ? this.state.checkboxes['BP3-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                checked={this.state.checkboxes['BP3-value'] ? this.state.checkboxes['BP3-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="textarea" ref="BP3-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+            <Input type="textarea" ref="BP3-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <div className="col-sm-7 col-sm-offset-5 input-note-top">
                 <p className="alert alert-info">
@@ -397,9 +397,9 @@ var criteriaGroup4 = function() {
                 </p>
             </div>
             <Input type="checkbox" ref="PM4-value" label="PM4 met?:" handleChange={this.handleCheckboxChange}
-                checked={this.state.checkboxes['PM4-value'] ? this.state.checkboxes['PM4-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                checked={this.state.checkboxes['PM4-value'] ? this.state.checkboxes['PM4-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="textarea" ref="PM4-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+            <Input type="textarea" ref="PM4-description" label="Explain criteria selection:" rows="5"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
         </div>
     );

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -41,9 +41,21 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 {(this.state.interpretation) ?
                 <div className="row">
                     <div className="col-sm-12">
-                        <CurationInterpretationForm formTitle={"Predictors Demo Criteria"} renderedFormContent={comp_crit_1}
+                        <CurationInterpretationForm formTitle={"Functional, Conservation, and Splicing Predictors"} renderedFormContent={criteriaGroup1}
+                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
+                            formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BP4', 'PP3', 'BP7']}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        <CurationInterpretationForm formTitle={"Alternate Changes in Codon"} renderedFormContent={criteriaGroup2}
                             evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
-                            formDataUpdater={comp_crit_1_update} variantUuid={this.props.data['@id']} criteria={['xbox1', 'xbox2']}
+                            formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        <CurationInterpretationForm formTitle={"Missense Variant"} renderedFormContent={criteriaGroup3}
+                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
+                            formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        <CurationInterpretationForm formTitle={"Repetetive Regions"} renderedFormContent={criteriaGroup4}
+                            evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                            formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     </div>
                 </div>
@@ -137,5 +149,281 @@ var pop_crit_2_update = function(nextProps) {
     }
     if (nextProps.extraData) {
         this.refs['ps4-description'].setValue(nextProps.extraData.test2);
+    }
+};
+
+// code for rendering of computational tab interpretation forms, first group:
+// functional, conservation, and splicing predictors
+var criteriaGroup1 = function() {
+    return (
+        <div>
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>BP4:</strong> Multiple lines of computational evidence suggest no impact on gene or gene product (conservation, evolutionary, splicing impact, etc.)
+
+                    <br /><br />
+                    <strong>PP3:</strong> Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc.)
+                </p>
+            </div>
+            <Input type="checkbox" ref="BP4-value" label="BP4 met?:" handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['BP4-value'] ? this.state.checkboxes['BP4-value'] : false}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <p className="col-sm-8 col-sm-offset-4 input-note-below-no-bottom">- or -</p>
+            <Input type="checkbox" ref="PP3-value" label="PP3 met?:" handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['PP3-value'] ? this.state.checkboxes['PP3-value'] : false}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="BP4-description" label="Explain criteria selection:" rows="5"
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+            <Input type="textarea" ref="PP3-description" label="Explain criteria selection (PP3):" rows="5"
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" handleChange={this.handleFormChange} />
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>BP7:</strong> A synonymous (silent) variant for which splicing prediction algorithms predict no impact to the splice site consensus sequence nor the creation of a new splice site AND the nucleotide is not highly conserved
+                </p>
+            </div>
+            <Input type="checkbox" ref="BP7-value" label={<span>BP7 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['BP7-value'] ? this.state.checkboxes['BP7-value'] : false}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="BP7-description" label="Explain criteria selection:" rows="5"
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+        </div>
+    );
+};
+
+// code for updating the form values of computational tab interpretation forms upon receiving
+// existing interpretations and evaluations
+var criteriaGroup1Update = function(nextProps) {
+    if (nextProps.interpretation) {
+        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
+            nextProps.interpretation.evaluations.map(evaluation => {
+                var tempCheckboxes = this.state.checkboxes;
+                switch(evaluation.criteria) {
+                    case 'BP4':
+                        tempCheckboxes['BP4-value'] = evaluation.value === 'true';
+                        this.refs['BP4-description'].setValue(evaluation.description);
+                        break;
+                    case 'PP3':
+                        tempCheckboxes['PP3-value'] = evaluation.value === 'true';
+                        this.refs['PP3-description'].setValue(evaluation.description);
+                        break;
+                    case 'BP7':
+                        tempCheckboxes['BP7-value'] = evaluation.value === 'true';
+                        this.refs['BP7-description'].setValue(evaluation.description);
+                        break;
+                }
+                this.setState({checkboxes: tempCheckboxes, submitDisabled: false});
+            });
+        }
+    }
+};
+
+// code for handling logic within the form
+var criteriaGroup1Change = function(ref, e) {
+    // BP4 and PP3 are exclusive. The following is to ensure that if one of the checkboxes
+    // are checked, the other is un-checked
+    if (ref === 'BP4-value' || ref === 'PP3-value') {
+        let tempCheckboxes = this.state.checkboxes,
+            altCriteriaValue = 'PP3-value';
+        if (ref === 'PP3-value') {
+            altCriteriaValue = 'BP4-value';
+        }
+        if (this.state.checkboxes[ref]) {
+            tempCheckboxes[altCriteriaValue] = false;
+            this.setState({checkboxes: tempCheckboxes});
+        }
+    }
+    // Since BP4 and PP3 'share' the same description box, and the user only sees the BP4 box,
+    // the following is to update the value in the PP3 box to contain the same data on
+    // saving of the evaluation. Handles changes going the other way, too, just in case (although
+    // this should never happen)
+    if (ref === 'BP4-description' || ref === 'PP3-description') {
+        let altCriteriaDescription = 'PP3-description';
+        if (ref === 'PP3-description') {
+            altCriteriaDescription = 'BP4-description';
+        }
+        this.refs[altCriteriaDescription].setValue(this.refs[ref].getValue());
+    }
+};
+
+// code for rendering of computational tab interpretation forms, second group:
+// alternate changes in codon
+var criteriaGroup2 = function() {
+    return (
+        <div>
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>PM5:</strong> Novel missense change at an amino acid residue where a different missense change determined to be pathogenic has not been seen before
+                </p>
+            </div>
+            <Input type="checkbox" ref="PM5-value" label={<span>PM5 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['PM5-value'] ? this.state.checkboxes['PM5-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="PM5-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>PS1:</strong> Same amino acid change as a previously established pathogenic variant regardless of nucleotide change
+                </p>
+            </div>
+            <Input type="checkbox" ref="PS1-value" label={<span>PS1 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['PS1-value'] ? this.state.checkboxes['PS1-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="PS1-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+        </div>
+    );
+};
+
+// code for updating the form values of computational tab interpretation forms upon receiving
+// existing interpretations and evaluations
+var criteriaGroup2Update = function(nextProps) {
+    if (nextProps.interpretation) {
+        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
+            nextProps.interpretation.evaluations.map(evaluation => {
+                var tempCheckboxes = this.state.checkboxes;
+                switch(evaluation.criteria) {
+                    case 'PM5':
+                        tempCheckboxes['PM5-value'] = evaluation.value === 'true';
+                        this.refs['PM5-description'].setValue(evaluation.description);
+                        break;
+                    case 'PS1':
+                        tempCheckboxes['PS1-value'] = evaluation.value === 'true';
+                        this.refs['PS1-description'].setValue(evaluation.description);
+                        break;
+                }
+                this.setState({checkboxes: tempCheckboxes, submitDisabled: false});
+            });
+        }
+    }
+};
+
+// code for rendering of computational tab interpretation forms, third group:
+// missense variants
+var criteriaGroup3 = function() {
+    return (
+        <div>
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>BP1:</strong> Missense variant in a gene for which primarily truncating variants are known to cause disease
+
+                    <br /><br />
+                    <strong>PP2:</strong> Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease
+                </p>
+            </div>
+            <Input type="checkbox" ref="BP1-value" label="BP1 met?:" handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['BP1-value'] ? this.state.checkboxes['BP1-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <p className="col-sm-8 col-sm-offset-4 input-note-below-no-bottom">- or -</p>
+            <Input type="checkbox" ref="PP2-value" label="PP2 met?:" handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['PP2-value'] ? this.state.checkboxes['PP2-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="BP1-description" label="Explain criteria selection:" rows="5" placeholder="Explanation" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+            <Input type="textarea" ref="PP2-description" label="Explain criteria selection (PP2):" rows="5" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" handleChange={this.handleFormChange} />
+        </div>
+    );
+};
+
+// code for updating the form values of computational tab interpretation forms upon receiving
+// existing interpretations and evaluations
+var criteriaGroup3Update = function(nextProps) {
+    if (nextProps.interpretation) {
+        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
+            nextProps.interpretation.evaluations.map(evaluation => {
+                var tempCheckboxes = this.state.checkboxes;
+                switch(evaluation.criteria) {
+                    case 'BP1':
+                        tempCheckboxes['BP1-value'] = evaluation.value === 'true';
+                        this.refs['BP1-description'].setValue(evaluation.description);
+                        break;
+                    case 'PP2':
+                        tempCheckboxes['PP2-value'] = evaluation.value === 'true';
+                        this.refs['PP2-description'].setValue(evaluation.description);
+                        break;
+                }
+                this.setState({checkboxes: tempCheckboxes, submitDisabled: false});
+            });
+        }
+    }
+};
+
+// code for handling logic within the form
+var criteriaGroup3Change = function(ref, e) {
+    // BP1 and PP2 are exclusive. The following is to ensure that if one of the checkboxes
+    // are checked, the other is un-checked
+    if (ref === 'BP1-value' || ref === 'PP2-value') {
+        let tempCheckboxes = this.state.checkboxes,
+            altCriteriaValue = 'PP2-value';
+        if (ref === 'PP2-value') {
+            altCriteriaValue = 'BP1-value';
+        }
+        if (this.state.checkboxes[ref]) {
+            tempCheckboxes[altCriteriaValue] = false;
+            this.setState({checkboxes: tempCheckboxes});
+        }
+    }
+    // Since BP1 and PP2 'share' the same description box, and the user only sees the BP4 box,
+    // the following is to update the value in the PP2 box to contain the same data on
+    // saving of the evaluation. Handles changes going the other way, too, just in case (although
+    // this should never happen)
+    if (ref === 'BP1-description' || ref === 'PP2-description') {
+        let altCriteriaDescription = 'PP2-description';
+        if (ref === 'PP2-description') {
+            altCriteriaDescription = 'BP1-description';
+        }
+        this.refs[altCriteriaDescription].setValue(this.refs[ref].getValue());
+    }
+};
+
+// code for rendering of computational tab interpretation forms, third group:
+// repetetive regions
+var criteriaGroup4 = function() {
+    return (
+        <div>
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>BP3:</strong> In-frame deletions/insertions in a repetitive region without a known function
+                </p>
+            </div>
+            <Input type="checkbox" ref="BP3-value" label={<span>BP3 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['BP3-value'] ? this.state.checkboxes['BP3-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="BP3-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+            <div className="col-sm-7 col-sm-offset-5 input-note-top">
+                <p className="alert alert-info">
+                    <strong>PM4:</strong> Protein length changes as a result of in-frame deletions/insertions in a nonrepeat region or stop-loss variant
+                </p>
+            </div>
+            <Input type="checkbox" ref="PM4-value" label={<span>PM4 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+                checked={this.state.checkboxes['PM4-value'] ? this.state.checkboxes['PM4-value'] : false} inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            <Input type="textarea" ref="PM4-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
+        </div>
+    );
+};
+
+// code for updating the form values of computational tab interpretation forms upon receiving
+// existing interpretations and evaluations
+var criteriaGroup4Update = function(nextProps) {
+    if (nextProps.interpretation) {
+        if (nextProps.interpretation.evaluations && nextProps.interpretation.evaluations.length > 0) {
+            nextProps.interpretation.evaluations.map(evaluation => {
+                var tempCheckboxes = this.state.checkboxes;
+                switch(evaluation.criteria) {
+                    case 'BP3':
+                        tempCheckboxes['BP3-value'] = evaluation.value === 'true';
+                        this.refs['BP3-description'].setValue(evaluation.description);
+                        break;
+                    case 'PM4':
+                        tempCheckboxes['PM4-value'] = evaluation.value === 'true';
+                        this.refs['PM4-description'].setValue(evaluation.description);
+                        break;
+                }
+                this.setState({checkboxes: tempCheckboxes, submitDisabled: false});
+            });
+        }
     }
 };

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -317,7 +317,7 @@ var criteriaGroup3 = function() {
             <Input type="checkbox" ref="PP2-value" label="PP2 met?:" handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['PP2-value'] ? this.state.checkboxes['PP2-value'] : false} inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
-            <Input type="textarea" ref="BP1-description" label="Explain criteria selection:" rows="5" placeholder="Explanation" inputDisabled={!this.state.diseaseAssociated}
+            <Input type="textarea" ref="BP1-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleFormChange} />
             <Input type="textarea" ref="PP2-description" label="Explain criteria selection (PP2):" rows="5" inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" handleChange={this.handleFormChange} />

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -181,7 +181,7 @@ var criteriaGroup1 = function() {
                     <strong>BP7:</strong> A synonymous (silent) variant for which splicing prediction algorithms predict no impact to the splice site consensus sequence nor the creation of a new splice site AND the nucleotide is not highly conserved
                 </p>
             </div>
-            <Input type="checkbox" ref="BP7-value" label={<span>BP7 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+            <Input type="checkbox" ref="BP7-value" label={<span>BP7 met?:</span>} handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['BP7-value'] ? this.state.checkboxes['BP7-value'] : false}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="textarea" ref="BP7-description" label="Explain criteria selection:" rows="5"
@@ -310,11 +310,11 @@ var criteriaGroup3 = function() {
                     <strong>PP2:</strong> Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease
                 </p>
             </div>
-            <Input type="checkbox" ref="BP1-value" label="BP1 met?:" handleChange={this.handleCheckboxChange}
+            <Input type="checkbox" ref="BP1-value" label={<span>BP1 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['BP1-value'] ? this.state.checkboxes['BP1-value'] : false} inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-8 col-sm-offset-4 input-note-below-no-bottom">- or -</p>
-            <Input type="checkbox" ref="PP2-value" label="PP2 met?:" handleChange={this.handleCheckboxChange}
+            <Input type="checkbox" ref="PP2-value" label={<span>PP2 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['PP2-value'] ? this.state.checkboxes['PP2-value'] : false} inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="textarea" ref="BP1-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
@@ -386,7 +386,7 @@ var criteriaGroup4 = function() {
                     <strong>BP3:</strong> In-frame deletions/insertions in a repetitive region without a known function
                 </p>
             </div>
-            <Input type="checkbox" ref="BP3-value" label={<span>BP3 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+            <Input type="checkbox" ref="BP3-value" label="BP3 met?:" handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['BP3-value'] ? this.state.checkboxes['BP3-value'] : false} inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="textarea" ref="BP3-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}
@@ -396,7 +396,7 @@ var criteriaGroup4 = function() {
                     <strong>PM4:</strong> Protein length changes as a result of in-frame deletions/insertions in a nonrepeat region or stop-loss variant
                 </p>
             </div>
-            <Input type="checkbox" ref="PM4-value" label={<span>PM4 met?:<br />(Disease dependent)</span>} handleChange={this.handleCheckboxChange}
+            <Input type="checkbox" ref="PM4-value" label="PM4 met?:" handleChange={this.handleCheckboxChange}
                 checked={this.state.checkboxes['PM4-value'] ? this.state.checkboxes['PM4-value'] : false} inputDisabled={!this.state.diseaseAssociated}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="textarea" ref="PM4-description" label="Explain criteria selection:" rows="5" inputDisabled={!this.state.diseaseAssociated}

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -315,7 +315,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
         return (
             <div className="variant-interpretation computational">
-                <PanelGroup accordion><Panel title="Functional, Conservation, and Splicing Predictors" open>
+                <PanelGroup accordion><Panel title="Functional, Conservation, and Splicing Predictors" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
@@ -556,7 +556,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     }
                 </Panel></PanelGroup>
 
-                <PanelGroup accordion><Panel title="Variants in Same Codon" open>
+                <PanelGroup accordion><Panel title="Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
@@ -584,7 +584,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </div>
                 </Panel></PanelGroup>
 
-                <PanelGroup accordion><Panel title="Molecular Consequence: Missense" open>
+                <PanelGroup accordion><Panel title="Molecular Consequence: Missense" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">
@@ -597,7 +597,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     : null}
                 </Panel></PanelGroup>
 
-                <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" open>
+                <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -49,11 +49,11 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
                             formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        <CurationInterpretationForm formTitle={"Missense Variant"} renderedFormContent={criteriaGroup3}
+                        <CurationInterpretationForm formTitle={"Molecular Consequence: Missense"} renderedFormContent={criteriaGroup3}
                             evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
                             formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        <CurationInterpretationForm formTitle={"Repetetive Regions"} renderedFormContent={criteriaGroup4}
+                        <CurationInterpretationForm formTitle={"Molecular Consequence: Inframe indel"} renderedFormContent={criteriaGroup4}
                             evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
                             formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -318,7 +318,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="row">
                         <div className="col-sm-12">
                             <CurationInterpretationForm formTitle={"Functional, Conservation, and Splicing Predictors"} renderedFormContent={criteriaGroup1}
-                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
+                                evidenceType={'computational'} evidenceData={this.state.computationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
                                 formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BP4', 'PP3', 'BP7']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
@@ -561,7 +561,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="row">
                         <div className="col-sm-12">
                             <CurationInterpretationForm formTitle={"Alternate Changes in Codon"} renderedFormContent={criteriaGroup2}
-                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                                evidenceType={'computational'} evidenceDataUpdated={true}
                                 formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
@@ -589,7 +589,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="row">
                         <div className="col-sm-12">
                             <CurationInterpretationForm formTitle={"Molecular Consequence: Missense"} renderedFormContent={criteriaGroup3}
-                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
+                                evidenceType={'computational'} evidenceDataUpdated={true} formChangeHandler={criteriaGroup3Change}
                                 formDataUpdater={criteriaGroup3Update} variantUuid={this.props.data['@id']} criteriaDisease={['BP1', 'PP2']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>
@@ -603,7 +603,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="row">
                         <div className="col-sm-12">
                             <CurationInterpretationForm formTitle={"Molecular Consequence: Inframe indel"} renderedFormContent={criteriaGroup4}
-                                evidenceType={'computational'} evidenceData={this.state.data} evidenceDataUpdated={true}
+                                evidenceType={'computational'} evidenceDataUpdated={true}
                                 formDataUpdater={criteriaGroup4Update} variantUuid={this.props.data['@id']} criteria={['BP3', 'PM4']}
                                 interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -14,8 +14,11 @@ var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 var queryKeyValue = globals.queryKeyValue;
 
+var panel = require('../../../libs/bootstrap/panel');
 var form = require('../../../libs/bootstrap/form');
 
+var PanelGroup = panel.PanelGroup;
+var Panel = panel.Panel;
 var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
@@ -617,131 +620,133 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     : null}
                 </div>
 
-                {(this.props.data && this.state.interpretation) ?
-                <div className="row">
-                    <div className="col-sm-12">
-                        <CurationInterpretationForm formTitle={"Population Criteria Evaluation"} renderedFormContent={criteriaGroup1}
-                            evidenceType={'population'} evidenceData={this.state.populationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
-                            formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BA1', 'PM2']} criteriaDisease={['BS1']}
-                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                <PanelGroup accordion><Panel title="Population Criteria Evaluation" open>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup1}
+                                evidenceType={'population'} evidenceData={this.state.populationObj} evidenceDataUpdated={true} formChangeHandler={criteriaGroup1Change}
+                                formDataUpdater={criteriaGroup1Update} variantUuid={this.props.data['@id']} criteria={['BA1', 'PM2']} criteriaDisease={['BS1']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
                     </div>
-                </div>
-                : null}
+                    : null}
 
-                {this.state.hasExacData ?
-                    <div className="panel panel-info datasource-ExAC">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
-                                <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
-                            </h3>
+                    {this.state.hasExacData ?
+                        <div className="panel panel-info datasource-ExAC">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
+                                    <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
+                                </h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Population</th>
+                                        <th>Allele Count</th>
+                                        <th>Allele Number</th>
+                                        <th>Number of Homozygotes</th>
+                                        <th>Allele Frequency</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {exacStatic._order.map(key => {
+                                        return (this.renderExacRow(key, exac, exacStatic));
+                                    })}
+                                </tbody>
+                                <tfoot>
+                                    {this.renderExacRow('_tot', exac, exacStatic, 'Total', 'count')}
+                                </tfoot>
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Population</th>
-                                    <th>Allele Count</th>
-                                    <th>Allele Number</th>
-                                    <th>Number of Homozygotes</th>
-                                    <th>Allele Frequency</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {exacStatic._order.map(key => {
-                                    return (this.renderExacRow(key, exac, exacStatic));
-                                })}
-                            </tbody>
-                            <tfoot>
-                                {this.renderExacRow('_tot', exac, exacStatic, 'Total', 'count')}
-                            </tfoot>
-                        </table>
-                    </div>
-                :
-                    <div className="panel panel-info datasource-ExAC">
-                        <div className="panel-heading"><h3 className="panel-title">ExAC</h3></div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']}>Search ExAC</a> for this variant.</th>
-                                </tr>
-                            </thead>
-                        </table>
-                    </div>
-                }
-                {this.state.hasTGenomesData ?
-                    <div className="panel panel-info datasource-1000G">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">1000 Genomes: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
-                                <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
-                            </h3>
+                    :
+                        <div className="panel panel-info datasource-ExAC">
+                            <div className="panel-heading"><h3 className="panel-title">ExAC</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']}>Search ExAC</a> for this variant.</th>
+                                    </tr>
+                                </thead>
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Population</th>
-                                    <th colSpan="2">Allele Frequency (count)</th>
-                                    <th colSpan="3">Genotype Frequency (count)</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {this.renderTGenomesRow('_tot', tGenomes, tGenomesStatic, 'ALL')}
-                                {tGenomesStatic._order.map(key => {
-                                    return (this.renderTGenomesRow(key, tGenomes, tGenomesStatic));
-                                })}
-                            </tbody>
-                        </table>
-                    </div>
-                :
-                    <div className="panel panel-info datasource-1000G">
-                        <div className="panel-heading"><h3 className="panel-title">1000 Genomes</h3></div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']}>Search 1000 Genomes</a> for this variant.</th>
-                                </tr>
-                            </thead>
-                        </table>
-                    </div>
-                }
-                {this.state.hasEspData ?
-                    <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}
-                                <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
-                            </h3>
+                    }
+                    {this.state.hasTGenomesData ?
+                        <div className="panel panel-info datasource-1000G">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">1000 Genomes: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
+                                    <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
+                                </h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Population</th>
+                                        <th colSpan="2">Allele Frequency (count)</th>
+                                        <th colSpan="3">Genotype Frequency (count)</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {this.renderTGenomesRow('_tot', tGenomes, tGenomesStatic, 'ALL')}
+                                    {tGenomesStatic._order.map(key => {
+                                        return (this.renderTGenomesRow(key, tGenomes, tGenomesStatic));
+                                    })}
+                                </tbody>
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Population</th>
-                                    <th colSpan="2">Allele Count</th>
-                                    <th colSpan="3">Genotype Count</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {espStatic._order.map(key => {
-                                    return (this.renderEspRow(key, esp, espStatic));
-                                })}
-                                {this.renderEspRow('_tot', esp, espStatic, 'All Allele', 'count')}
-                            </tbody>
-                            <tfoot>
-                                <tr className="count">
-                                    <td colSpan="6">Average Sample Read Depth: {esp._extra.avg_sample_read}</td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </div>
-                :
-                    <div className="panel panel-info datasource-ESP">
-                        <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)</h3></div>
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']}>Search ESP</a> for this variant.</th>
-                                </tr>
-                            </thead>
-                        </table>
-                    </div>
-                }
+                    :
+                        <div className="panel panel-info datasource-1000G">
+                            <div className="panel-heading"><h3 className="panel-title">1000 Genomes</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']}>Search 1000 Genomes</a> for this variant.</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+                    {this.state.hasEspData ?
+                        <div className="panel panel-info datasource-ESP">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}
+                                    <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
+                                </h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Population</th>
+                                        <th colSpan="2">Allele Count</th>
+                                        <th colSpan="3">Genotype Count</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {espStatic._order.map(key => {
+                                        return (this.renderEspRow(key, esp, espStatic));
+                                    })}
+                                    {this.renderEspRow('_tot', esp, espStatic, 'All Allele', 'count')}
+                                </tbody>
+                                <tfoot>
+                                    <tr className="count">
+                                        <td colSpan="6">Average Sample Read Depth: {esp._extra.avg_sample_read}</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    :
+                        <div className="panel panel-info datasource-ESP">
+                            <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)</h3></div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']}>Search ESP</a> for this variant.</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    }
+                </Panel></PanelGroup>
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -620,7 +620,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     : null}
                 </div>
 
-                <PanelGroup accordion><Panel title="Population Criteria Evaluation" open>
+                <PanelGroup accordion><Panel title="Population Criteria Evaluation" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -225,12 +225,10 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
 
     render: function() {
         return (
-            <PanelGroup accordion><Panel title={". Biochemical Function"} open>
+
             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
+            <PanelGroup accordion><Panel title={this.props.formTitle} open>
                 <div className="evaluation">
-                    {this.props.formTitle ?
-                        <h3>{this.props.formTitle}</h3>
-                    : null}
                     {this.props.renderedFormContent.call(this)}
                 </div>
                 <div className="curation-submit clearfix">
@@ -239,9 +237,9 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                     {this.state.updateMsg ?
                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                     : null}
-                </div>
-            </Form></Panel>
+                </div></Panel>
             </PanelGroup>
+            </Form>
         );
     }
 });

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -110,7 +110,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
         var flatInterpretation = null;
         var freshInterpretation = null;
         var evidenceObjectId = null;
-        var submittedCriteria = this.props.criteria;
+        var submittedCriteria = this.props.criteria ? this.props.criteria : [];
         this.getRestData('/interpretation/' + this.state.interpretation.uuid).then(interpretation => {
             freshInterpretation = interpretation;
             // get fresh update of interpretation object so we have newest evaluation list, then flatten it
@@ -230,7 +230,8 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                     {this.props.renderedFormContent.call(this)}
                 </div>
                 <div className="curation-submit clearfix">
-                    <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save" submitBusy={this.state.submitBusy} inputDisabled={this.state.submitDisabled} />
+                    <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
+                        submitBusy={this.state.submitBusy} inputDisabled={(!this.props.criteria || this.props.criteria.length == 0) && !this.state.diseaseAssociated} />
                     {this.state.updateMsg ?
                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -1,10 +1,13 @@
 'use strict';
 var React = require('react');
 var _ = require('underscore');
+var panel = require('../../../../libs/bootstrap/panel');
 var form = require('../../../../libs/bootstrap/form');
 var RestMixin = require('../../../rest').RestMixin;
 var curator = require('../../../curator');
 
+var PanelGroup = panel.PanelGroup;
+var Panel = panel.Panel;
 var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
@@ -222,6 +225,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
 
     render: function() {
         return (
+            <PanelGroup accordion><Panel title={". Biochemical Function"} open>
             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                 <div className="evaluation">
                     {this.props.formTitle ?
@@ -236,7 +240,8 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                     : null}
                 </div>
-            </Form>
+            </Form></Panel>
+            </PanelGroup>
         );
     }
 });

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -1,13 +1,10 @@
 'use strict';
 var React = require('react');
 var _ = require('underscore');
-var panel = require('../../../../libs/bootstrap/panel');
 var form = require('../../../../libs/bootstrap/form');
 var RestMixin = require('../../../rest').RestMixin;
 var curator = require('../../../curator');
 
-var PanelGroup = panel.PanelGroup;
-var Panel = panel.Panel;
 var Form = form.Form;
 var FormMixin = form.FormMixin;
 var Input = form.Input;
@@ -18,7 +15,6 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
     mixins: [RestMixin, FormMixin],
 
     propTypes: {
-        formTitle: React.PropTypes.string, // the title of this form section
         renderedFormContent: React.PropTypes.func, // the function that returns the rendering of the form items
         evidenceType: React.PropTypes.string, // specified what type of evidence object is created
         evidenceData: React.PropTypes.object, // any extra evidence data that is passed from the parent page
@@ -224,9 +220,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
 
     render: function() {
         return (
-
             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
-            <PanelGroup accordion><Panel title={this.props.formTitle} open>
                 <div className="evaluation">
                     {this.props.renderedFormContent.call(this)}
                 </div>
@@ -236,8 +230,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                     {this.state.updateMsg ?
                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                     : null}
-                </div></Panel>
-            </PanelGroup>
+                </div>
             </Form>
         );
     }

--- a/src/clincoded/static/libs/bootstrap/panel.js
+++ b/src/clincoded/static/libs/bootstrap/panel.js
@@ -55,7 +55,7 @@ var Panel = module.exports.Panel = React.createClass({
 
     render: function() {
         var panelWrapperClasses = 'panel panel-default' + (this.props.panelClassName ? ' ' + this.props.panelClassName : '');
-        var panelClasses = 'panel-body panel-std' + ((!this.state.open && this.props.accordion) ? ' panel-closed' : '') + (this.props.panelBodyClassName ? ' ' + this.props.panelBodyClassName : ' panel-bg-std');
+        var panelClasses = 'panel-body' + ((!this.state.open && this.props.accordion) ? ' panel-closed' : '') + (this.props.panelBodyClassName ? ' ' + this.props.panelBodyClassName : ' panel-std panel-bg-std');
         var indicatorClasses = 'icon panel-header-indicator ' + (this.props.accordion ? (this.state.open ? 'icon-chevron-up' : 'icon-chevron-down') : '');
         var children = (this.props.children instanceof Array && this.props.children.length === 0) ? null : this.props.children;
         var title;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -998,13 +998,13 @@
 .curation-variant-tab-group {
     margin-bottom: 20px;
 
-    .react-tabs [role=tablist] {
+    .ReactTabs ul[role=tablist] {
         border: none;
         margin: 0;
         padding: 0;
     }
 
-    .react-tabs [role=tab] {
+    .ReactTabs li[role=tab] {
         background-color: #1b75bc;
         border-top: none;
         border-left: none;
@@ -1020,30 +1020,30 @@
         text-align: center;
     }
 
-    .react-tabs [role=tab][aria-selected=true] {
+    .ReactTabs li[role=tab][aria-selected=true] {
         background-color: #fff;
         border: solid 1px #1b75bc;
         border-bottom: solid 1px #fff;
         color: #000;
     }
 
-    .react-tabs [role=tab][aria-selected=true] ~ li {
+    .ReactTabs li[role=tab][aria-selected=true] ~ li {
         border-right: none;
         border-left: solid 1px #fff;
     }
 
-    .react-tabs [role=tab][aria-disabled=true] {
+    .ReactTabs li[role=tab][aria-disabled=true] {
         color: GrayText;
         cursor: default;
     }
 
-    .react-tabs [role=tab]:focus {
+    .ReactTabs li[role=tab]:focus {
         box-shadow: 0 0 5px hsl(208, 99%, 50%);
         border-color: hsl(208, 99%, 50%);
         outline: none;
     }
 
-    .react-tabs [role=tab]:focus:after {
+    .ReactTabs li[role=tab]:focus:after {
         background: #fff;
         content: "";
         position: absolute;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1428,3 +1428,7 @@ dl.inline-dl {
         margin-top: 15px;
     }
 }
+
+.panel-wide-content {
+    padding: 20px 30px;
+}


### PR DESCRIPTION
* Computational eval forms are in
* Collapsible panels for both population and computational tabs
* CSS updated for wider content area in tabs
* CSS updated so that tabs and panel css names do not collide
* `form.js` updated to remove form title and Panel groups; these were moved to their respective tabs

Population tab w/ Interpretation:
![image](https://cloud.githubusercontent.com/assets/4326866/16825070/378684fc-4926-11e6-9c7e-deed6f711817.png)
Predictors tab w/ Interpretation:
![image](https://cloud.githubusercontent.com/assets/4326866/16825077/447f1e76-4926-11e6-849e-39d62e9ec458.png)

Testing:

1. Get to VCI, w/ no interpretation
2. Check population tab, check that panel displays and collapses properly
3. Check predictors tab, check that panels display and collapse properly
4. Add interpretation
5. Check population tab, check that form + data displays and collapses properly
6. Check predictors tab, check that forms + data displays and collapses properly
7. Check evaluation forms and output data in predictors tab
  * If CRITERIA1 OR CRITERIA2 criteria, make sure that both criteria cannot be checked together
  * Make sure that criteria that are disease dependent are disabled while no disease is associated
  * Make sure when saving, the feedback message reports back the proper criteria codes
  * When saving, only the first set of criteria code should actually save evidence data, the rest of the forms should have no evidence data associated with them