### PR TITLE
Connects to #771 kl note for non function tab

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -26,8 +26,9 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                 <ul className="section-functional-interpretation clearfix">
                     <li className="col-xs-12 gutter-exc">
                         <div>
-                            <h4>Functional Interpretation</h4>
-                            <div>Functional Data placeholder</div>
+                            <span className="wip">IN PROGRESS</span>
+                            <br /><br />
+                            <div>Experimental evidence associated with this variant as part of gene curation will appear here. Also included will be the ability to add additional functional evidence for this variant.</div>
                         </div>
                     </li>
                 </ul>

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -26,8 +26,9 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                 <ul className="section-gene-specific-interpretation clearfix">
                     <li className="col-xs-12 gutter-exc">
                         <div>
-                            <h4>Gene-specific Interpretation</h4>
-                            <div>Gene-specific Data placeholder</div>
+                            <span className="wip">IN PROGRESS</span>
+                            <br /><br />
+                            <div>This tab will include information about the gene with which this variant is associated, including gene-specific links, ExAC constraint scores for the gene, domain information, hotspots, etc.</div>
                         </div>
                     </li>
                 </ul>

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -26,8 +26,9 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                 <ul className="section-segregation-interpretation clearfix">
                     <li className="col-xs-12 gutter-exc">
                         <div>
-                            <h4>Segregation Interpretation</h4>
-                            <div>Segregation Data placeholder</div>
+                            <span className="wip">IN PROGRESS</span>
+                            <br /><br />
+                            <div>Segregation (Family) information associated with this variant as part of gene curation will appear here. Also included will be the ability to curate additional segregation (Family) information for this variant.</div>
                         </div>
                     </li>
                 </ul>

--- a/src/clincoded/static/components/variant_central/record_curator.js
+++ b/src/clincoded/static/components/variant_central/record_curator.js
@@ -81,7 +81,9 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                                 return (
                                                     <div key={i}>
                                                         <span className="my-interpretation">
-                                                            {(item.interpretation_disease) ? item.interpretation_disease + ', ' : null}{item.interpretation_status}, (last edited {moment(item.last_modified).format('YYYY MMM DD, h:mm a')}) <button type="button" className="btn btn-link" onClick={handleEditEvent.bind(this, '/interpretations/' + item.uuid)}>View</button> | <button type="button" className="btn btn-link" onClick={handleEditEvent.bind(this, '/variant-central/?edit=true&variant=' + variant.uuid + '&interpretation=' + item.uuid)}>Edit</button>
+                                                            {(item.interpretation_disease) ? item.interpretation_disease + ', ' : null}
+                                                            {item.interpretation_status},&nbsp;
+                                                            (last edited {moment(item.last_modified).format('YYYY MMM DD, h:mm a')})
                                                         </span>
                                                         {(item.uuid === interpretationUuid) ?
                                                             <span className="current-interpretation"> &#x02713;</span>
@@ -97,12 +99,16 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                 <div className="other-users-interpretations">
                                     <dl className="inline-dl clearfix">
                                         <dt>Other interpretations:</dt>
+                                        <br />
                                         <dd>
                                             {otherInterpretations.map(function(item, i) {
                                                 return (
                                                     <div key={i}>
                                                         <span className="other-interpretation">
-                                                            {item.submitted_by.title}, {item.interpretation_status}, {(item.interpretation_disease) ? item.interpretation_disease + ', ' : null}(last edited {moment(item.last_modified).format('YYYY MMM DD, h:mm a')}) <button type="button" className="btn btn-link"  onClick={handleEditEvent.bind(this, '/interpretations/' + item.uuid)}>View</button>
+                                                            {otherInterpretations[0].submitted_by.title + ', '}
+                                                            {(otherInterpretations[0].interpretation_disease !== '') ? otherInterpretations[0].interpretation_disease + ', ' : null}
+                                                            {otherInterpretations[0].interpretation_status + ', '}
+                                                            (last edited {moment(otherInterpretations[0].last_modified).format('YYYY MMM DD, h:mm a')})
                                                         </span>
                                                     </div>
                                                 );

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1150,7 +1150,7 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     .functional li>div,
     .segregation li>div,
     .gene-specific li>div {
-        background: rgba(0, 128, 128, 0.2);
+        background: none;
         margin: 0 15px 10px 0;
     }
 }


### PR DESCRIPTION
This PR is for 2 requirements.
1. Adding text messages to non-function tabs (Functional, Segregation and Gene-specific).
2. Remove links "View" and "Edit" to interpretation object in header.

**Code Changes**
1. Added text message related codes in files `functional.js`, `gene_specific.js` and
`segregation.js` in dir `src/clincoded/static/components/variant_central/interpretation/`.
2. Removed codes related to "View" and "Edit" links in file `src/clincoded/static/components/variant_central/record_curator.js` and removed background color related codes in file `src/clincoded/static/scss/clincoded/modules/_curator.scss`.

**Test**
* Select ClinVar Variation ID and enter 55962. In variant-central page, expect not to see "View" and "Edit" links in header.
![screen shot 2016-07-13 at 6 29 30 pm](https://cloud.githubusercontent.com/assets/9206696/16825242/d562de40-4927-11e6-827e-ae6521272c57.png)

* Select tab "Functional", expect to see test message as below.
![screen shot 2016-07-13 at 6 34 02 pm](https://cloud.githubusercontent.com/assets/9206696/16825306/678c00e4-4928-11e6-83a5-6d79f9d2dbd4.png)

* Click tab "Segregation/Case", expect to see message as:
![screen shot 2016-07-13 at 6 35 18 pm](https://cloud.githubusercontent.com/assets/9206696/16825319/93638b7e-4928-11e6-90cb-655e29b1a784.png)

* Click tab "Gene-specific", expect to see message:
![screen shot 2016-07-13 at 6 36 10 pm](https://cloud.githubusercontent.com/assets/9206696/16825326/b3241500-4928-11e6-9a89-84cb333c2a36.png)

**End Test**