### PR TITLE
Connects to #759. Connects to #761. Connects to #770.

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -4,37 +4,33 @@ var globals = require('../globals');
 var RestMixin = require('../rest').RestMixin;
 var parseAndLogError = require('../mixins').parseAndLogError;
 var form = require('../../libs/bootstrap/form');
+var modal = require('../../libs/bootstrap/modal');
 
 var Input = form.Input;
+var Form = form.Form;
+var FormMixin = form.FormMixin;
+var Modal = modal.Modal;
+var ModalMixin = modal.ModalMixin;
 var queryKeyValue = globals.queryKeyValue;
 
 // Display the variant curation action bar above the criteria and tabs
 var VariantCurationActions = module.exports.VariantCurationActions = React.createClass({
-    mixins: [RestMixin],
+    mixins: [RestMixin, ModalMixin],
 
     propTypes: {
         variantData: React.PropTypes.object, // ClinVar data payload
         session: React.PropTypes.object,
-        interpretationUuid: React.PropTypes.string,
+        interpretation: React.PropTypes.object,
         editKey: React.PropTypes.bool
     },
 
     getInitialState: function() {
         return {
             variantUuid: null,
-            interpretationUuid: null
+            editKey: queryKeyValue('edit', this.props.href)
         };
     },
 
-    /*
-    componentDidUpdate: function(prevProps, prevState) {
-        if (prevState.interpretationUuid !== this.state.interpretationUuid && this.state.interpretationUuid && this.state.variantUuid) {
-            this.context.navigate('/curation-variant/?variant=' + this.state.variantUuid + '&interpretation=' + this.state.interpretationUuid);
-        } else {
-            return false;
-        }
-    },
-    */
     // handler for 'Start new interpreation' button click event
     handleNewInterpretation: function(e) {
         e.preventDefault(); e.stopPropagation();
@@ -49,32 +45,160 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         // the new interpretation UUID in the query string.
         this.postRestData('/interpretations/', newInterpretationObj).then(data => {
             var newInterpretationUuid = data['@graph'][0].uuid;
-            // this.setState({interpretationUuid: newInterpretationUuid});
             window.location.href = '/variant-central/?variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
         }).catch(e => {parseAndLogError.bind(undefined, 'postRequest')});
     },
 
+    // handler for 'Continue interpretation' button click event
+    handleExistingInterpretation: function(e) {
+        e.preventDefault(); e.stopPropagation();
+        var variantObj = this.props.variantData;
+        window.location.href = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid;
+    },
+
     render: function() {
-        /*
-        var session = this.props.session;
-        if (session) {
-            var userId = (session.user_properties.uuid) ? session.user_properties.uuid : '';
-        }
-        */
         return (
-            <div>
+            <Form formClassName="form-horizontal form-std">
                 <div className="container curation-actions curation-variant">
-                {((this.props.interpretationUuid && this.props.interpretationUuid.length > 0) || (this.props.editKey && this.props.interpretationUuid.length > 0)) ?
-                    <div className="interpretation-record clearfix">
-                        <Input type="button-button" inputClassName="btn-primary pull-left" title="Return to Evidence Only" />
-                        <h2><span>Variant Interpretation Record</span></h2>
-                        <Input type="button-button" inputClassName="btn-primary pull-right" title="Associate with Disease" />
-                    </div>
-                    :
-                    <div className="evidence-only clearfix"><Input type="button-button" inputClassName="btn-primary pull-right" title="Start new interpretation" clickHandler={this.handleNewInterpretation} /></div>
+                    {((this.props.editKey || this.state.editKey) && this.props.interpretation) ?
+                        <div className="interpretation-record clearfix">
+                            <h2><span>Variant Interpretation Record</span></h2>
+                            <div className="btn-group">
+                                <Modal title="Associate with Disease" wrapperClassName="modal-associate-disease">
+                                    <button className="btn btn-primary pull-right"
+                                        modal={<AssociateDisease closeModal={this.closeModal} data={this.props.variantData} interpretation={this.props.interpretation} editKey={this.props.editkey} />}>Associate with Disease</button>
+                                </Modal>
+                            </div>
+                        </div>
+                        :
+                        <RenderInterpretationButton data={this.props.variantData} session={this.props.session} 
+                            handleExistingInterpretation={this.handleExistingInterpretation} handleNewInterpretation={this.handleNewInterpretation} />
+                    }
+                </div>
+            </Form>
+        );
+    }
+});
+
+// Render 'Start new interpretation' or 'Continue interpretation' button
+var RenderInterpretationButton = React.createClass({
+    propTypes: {
+        data: React.PropTypes.object,
+        session: React.PropTypes.object,
+        handleExistingInterpretation: React.PropTypes.func,
+        handleNewInterpretation: React.PropTypes.func
+    },
+
+    getInitialState: function() {
+        return {
+            hasExistingInterpretation: false
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        if (nextProps.data && this.props.data) {
+            if (this.props.data.associatedInterpretations) {
+                if (this.props.data.associatedInterpretations.length && this.props.data.submitted_by['@id'] === this.props.session.user_properties['@id']) {
+                    this.setState({hasExistingInterpretation: true});
                 }
+            }
+        }
+    },
+
+    render: function() {
+        return (
+            <div className="evidence-only clearfix">
+                {(this.state.hasExistingInterpretation) ?
+                    <Input type="button-button" inputClassName="btn-primary pull-right" title="Continue interpretation" clickHandler={this.props.handleExistingInterpretation} />
+                    :
+                    <Input type="button-button" inputClassName="btn-primary pull-right" title="Start new interpretation" clickHandler={this.props.handleNewInterpretation} />
+                }
+            </div>
+        );
+    }
+});
+
+// handle 'Associate with Disease' button click event
+var AssociateDisease = React.createClass({
+    mixins: [RestMixin, FormMixin],
+
+    propTypes: {
+        data: React.PropTypes.object,
+        closeModal: React.PropTypes.func, // Function to call to close the modal
+        interpretation: React.PropTypes.object,
+        editKey: React.PropTypes.bool
+    },
+
+    getInitialState: function() {
+        return {
+            submitResourceBusy: false
+        };
+    },
+
+    // Form content validation
+    validateForm: function() {
+        // Start with default validation
+        var valid = this.validateDefault();
+
+        // Check if orphanetid
+        if (valid) {
+            valid = this.getFormValue('orphanetid').match(/^ORPHA[0-9]{1,6}$/i);
+            if (!valid) {
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
+            }
+        }
+        return valid;
+    },
+
+    // When the form is submitted...
+    submitForm: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+
+        // Get values from form and validate them
+        this.saveFormValue('orphanetid', this.refs.orphanetid.getValue());
+        if (this.validateForm()) {
+            // Get the free-text values for the Orphanet ID to check against the DB
+            var orphaId = this.getFormValue('orphanetid').match(/^ORPHA([0-9]{1,6})$/i)[1];
+
+            // Get the disease orresponding to the given Orphanet ID.
+            // If either error out, set the form error fields
+            this.getRestDatas([
+                '/diseases/' + orphaId
+            ], [
+                function() { this.setFormErrors('orphanetid', 'Orphanet ID not found'); }.bind(this)
+            ]).then(data => {
+                this.props.closeModal();
+            }).catch(e => {
+                // Some unexpected error happened
+                parseAndLogError.bind(undefined, 'fetchedRequest');
+            });
+        }
+    },
+
+    // Called when the modal 'Cancel' button is clicked
+    cancelAction: function(e) {
+        this.props.closeModal();
+    },
+
+    render: function() {
+        return (
+            <div className="modal-box">
+                <div className="modal-body">
+                    <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15"
+                        error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
+                        labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
+                </div>
+                <div className='modal-footer'>
+                    <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelAction} title="Cancel" />
+                    <Input type="button" inputClassName="btn-primary btn-inline-spacer" clickHandler={this.submitForm} title="OK" submitBusy={this.state.submitResourceBusy} />
                 </div>
             </div>
         );
+    }
+});
+
+var LabelOrphanetId = React.createClass({
+    render: function() {
+        return <span>Enter <a href="http://www.orpha.net/" target="_blank" title="Orphanet home page in a new tab">Orphanet</a> ID</span>;
     }
 });

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -20,25 +20,34 @@ var queryKeyValue = globals.queryKeyValue;
 var VariantCurationActions = module.exports.VariantCurationActions = React.createClass({
     mixins: [RestMixin, ModalMixin, FormMixin, CuratorHistory],
 
+    childContextTypes: {
+        handleStateChange: React.PropTypes.func
+    },
+
+    getChildContext: function() {
+        return {handleStateChange: this.handleStateChange};
+    },
+
     propTypes: {
         variantData: React.PropTypes.object, // ClinVar data payload
         session: React.PropTypes.object,
         interpretation: React.PropTypes.object,
         editKey: React.PropTypes.string,
-        href_url: React.PropTypes.string
+        href_url: React.PropTypes.string,
+        updateInterpretationObj: React.PropTypes.func
     },
 
     getInitialState: function() {
         return {
             variantUuid: null,
             hasExistingInterpretation: false,
-            isEditMode: false,
+            isInterpretationActive: false,
             hasAssociatedDisease: false
         };
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (nextProps.variantData && this.props.variantData) {
+        if (this.props.variantData) {
             if (this.props.variantData.associatedInterpretations) {
                 if (this.props.variantData.associatedInterpretations.length && this.props.variantData.submitted_by['@id'] === this.props.session.user_properties['@id']) {
                     this.setState({hasExistingInterpretation: true});
@@ -46,18 +55,22 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
             }
         }
         if (this.props.editKey === 'true' && this.props.interpretation) {
-            this.setState({isEditMode: true});
+            this.setState({isInterpretationActive: true});
             if (this.props.interpretation.interpretation_disease) {
                 this.setState({hasAssociatedDisease: true});
             }
         }
     },
 
+    handleStateChange: function() {
+        this.setState({hasAssociatedDisease: true});
+    },
+
     // handler for 'Start new interpretation' & 'Continue interpretation' button click events
     handleInterpretationEvent: function(e) {
         e.preventDefault(); e.stopPropagation();
         var variantObj = this.props.variantData;
-        var newInterpretationObj;
+        var newInterpretationObj, href_url;
         if (!this.state.hasExistingInterpretation) {
             if (variantObj) {
                 this.setState({variantUuid: variantObj.uuid});
@@ -70,7 +83,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
                 var newInterpretationUuid = data['@graph'][0].uuid;
                 window.location.href = '/variant-central/?edit=true&variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
             }).catch(e => {parseAndLogError.bind(undefined, 'postRequest')});
-        } else if (this.state.hasExistingInterpretation && !this.isEditMode) {
+        } else if (this.state.hasExistingInterpretation && !this.state.isInterpretationActive) {
             window.location.href = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid;
         }
     },
@@ -79,7 +92,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         var interpretationButtonTitle = '';
         if (!this.state.hasExistingInterpretation) {
             interpretationButtonTitle = 'Start New Interpretation';
-        } else if (this.state.hasExistingInterpretation && !this.isEditMode) {
+        } else if (this.state.hasExistingInterpretation && !this.state.isInterpretationActive) {
             interpretationButtonTitle = 'Continue Interpretation';
         }
 
@@ -95,14 +108,14 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         return (
             <Form formClassName="form-horizontal form-std">
                 <div className="container curation-actions curation-variant">
-                    {(this.state.isEditMode) ?
+                    {(this.state.isInterpretationActive) ?
                         <div className="interpretation-record clearfix">
                             <h2><span>Variant Interpretation Record</span></h2>
                             <div className="btn-group">
                                 <Modal title={associateDiseaseModalTitle} wrapperClassName="modal-associate-disease">
                                     <button className="btn btn-primary pull-right"
                                         modal={<AssociateDisease closeModal={this.closeModal} data={this.props.variantData} url={this.props.href_url} session={this.props.session}
-                                            interpretation={this.props.interpretation} editKey={this.props.editkey} />}>{associateDiseaseButtonTitle}</button>
+                                            interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj} />}>{associateDiseaseButtonTitle}</button>
                                 </Modal>
                             </div>
                         </div>
@@ -121,13 +134,18 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
 var AssociateDisease = React.createClass({
     mixins: [RestMixin, FormMixin],
 
+    contextTypes: {
+        handleStateChange: React.PropTypes.func
+    },
+
     propTypes: {
         data: React.PropTypes.object,
         session: React.PropTypes.object,
         closeModal: React.PropTypes.func, // Function to call to close the modal
         interpretation: React.PropTypes.object,
         editKey: React.PropTypes.bool,
-        url: React.PropTypes.string
+        url: React.PropTypes.string,
+        updateInterpretationObj: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -178,6 +196,8 @@ var AssociateDisease = React.createClass({
                         flatInterpretation.disease = '';
                         // Return the newly flattened interpretation object in a Promise
                         return Promise.resolve(flatInterpretation);
+                    } else {
+                        return Promise.resolve(flatInterpretation);
                     }
                 }).then(interpretationObj => {
                     if (interpretationDisease) {
@@ -185,9 +205,9 @@ var AssociateDisease = React.createClass({
                         interpretationObj.disease = interpretationDisease;
                         // Update the intepretation object partially with the new disease property value
                         return this.putRestData('/interpretation/' + this.props.interpretation.uuid, interpretationObj).then(result => {
-                            return Promise.resolve(result['@graph'][0]);
+                            this.props.updateInterpretationObj(result);
                             this.props.closeModal();
-                            window.location.replace(this.props.url);
+                            window.history.replaceState(window.state, '', this.props.url);
                         });
                     }
                 });
@@ -201,16 +221,21 @@ var AssociateDisease = React.createClass({
     // Called when the modal 'Cancel' button is clicked
     cancelAction: function(e) {
         this.props.closeModal();
-        window.location.replace(this.props.url);
+        window.history.replaceState(window.state, '', this.props.url);
     },
 
     render: function() {
-        var disease = this.props.interpretation.interpretation_disease;
+        var disease_id = '';
+        if (this.props.interpretation) {
+            if (this.props.interpretation.interpretation_disease) {
+                disease_id = this.props.interpretation.interpretation_disease;
+            }
+        }
 
         return (
             <div className="modal-box">
                 <div className="modal-body">
-                    <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15" defaultValue={(disease) ? disease : null}
+                    <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15" value={(disease_id) ? disease_id : null}
                         error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                         labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
                 </div>

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -70,15 +70,11 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     handleInterpretationEvent: function(e) {
         e.preventDefault(); e.stopPropagation();
         var variantObj = this.props.variantData;
-        var newInterpretationObj;
-
-        // get tab from current window href. If get one, it will be added into the new url
-        var tab = null, href_url;
-        var page_url = window.location.href;
-        if (page_url.indexOf('tab=') > -1 ) {
-            tab = '&tab=' + page_url.split('tab=').pop();
+        var selectedTab = '';
+        if (window.location.href.indexOf('tab=') > -1) {
+            selectedTab = '&tab=' + window.location.href.split('tab=').pop();
         }
-
+        var newInterpretationObj;
         if (!this.state.hasExistingInterpretation) {
             if (variantObj) {
                 this.setState({variantUuid: variantObj.uuid});
@@ -89,20 +85,10 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
             // the new interpretation UUID in the query string.
             this.postRestData('/interpretations/', newInterpretationObj).then(data => {
                 var newInterpretationUuid = data['@graph'][0].uuid;
-                var new_url = '/variant-central/?edit=true&variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid;
-                // add tab
-                if (tab) {
-                    href_url = new_url + tab;
-                }
-                window.location.href =  href_url;
+                window.location.href = '/variant-central/?edit=true&variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid + selectedTab;
             }).catch(e => {parseAndLogError.bind(undefined, 'postRequest');});
         } else if (this.state.hasExistingInterpretation && !this.state.isInterpretationActive) {
-            var new_url = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid;
-            // add tab
-            if (tab) {
-                href_url = new_url + tab;
-            }
-            window.location.href =  href_url;
+            window.location.href = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid + selectedTab;
         }
     },
 

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var _ = require('underscore');
 var globals = require('../globals');
 
 var Title = require('./title').Title;
@@ -16,10 +17,24 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
         session: React.PropTypes.object
     },
 
+    getInitialState: function() {
+        return {
+            interpretation: null // parent interpretation object
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        // this block is for handling props and states when props (external data) is updated after the initial load/rendering
+        // when props are updated, update the parent interpreatation object, if applicable
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
+    },
+
     render: function() {
         var variant = this.props.variantData;
         var interpretationUuid = this.props.interpretationUuid;
-        var interpretation = this.props.interpretation;
+        var interpretation = this.state.interpretation;
         var session = this.props.session;
 
         return (
@@ -33,7 +48,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                     <div className="row equal-height">
                         <CurationRecordVariant data={variant} />
                         <CurationRecordGeneDisease data={variant} />
-                        <CurationRecordCurator data={variant} interpretationUuid={interpretationUuid} session={session} />
+                        <CurationRecordCurator data={variant} interpretationUuid={interpretationUuid} interpretation={interpretation} session={session} />
                     </div>
                     {variant && !variant.hgvsNames.GRCh37 ?
                         <div className="alert alert-warning">

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -12,19 +12,21 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
     propTypes: {
         variantData: React.PropTypes.object, // ClinVar data payload
         interpretationUuid: React.PropTypes.string,
+        interpretation: React.PropTypes.object,
         session: React.PropTypes.object
     },
 
     render: function() {
         var variant = this.props.variantData;
         var interpretationUuid = this.props.interpretationUuid;
+        var interpretation = this.props.interpretation;
         var session = this.props.session;
 
         return (
             <div>
                 <div className="curation-data-title">
                     <div className="container">
-                        <Title data={variant} />
+                        <Title data={variant} interpretation={interpretation} />
                     </div>
                 </div>
                 <div className="container curation-data curation-variant">

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -60,7 +60,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretationUuid={interpretationUuid} eidtKey={editKey} session={session} />
+                <VariantCurationActions variantData={variantData} interpretation={interpretation} eidtKey={editKey} session={session} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -60,7 +60,8 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} interpretation={interpretation} />
-                <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session} href_url={this.props.href} />
+                <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
+                    href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -41,7 +41,7 @@ var VariantCurationHub = React.createClass({
             this.setState({variantObj: response});
             this.setState({isLoadingComplete: true});
         }).catch(function(e) {
-            console.log('GETGDM ERROR=: %o', e);
+            console.log('FETCH CLINVAR ERROR=: %o', e);
         });
     },
 
@@ -60,7 +60,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretation={interpretation} eidtKey={editKey} session={session} />
+                <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -59,7 +59,7 @@ var VariantCurationHub = React.createClass({
 
         return (
             <div>
-                <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
+                <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} interpretation={interpretation} />
                 <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session} href_url={this.props.href} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -60,7 +60,7 @@ var VariantCurationHub = React.createClass({
         return (
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session} />
-                <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session} />
+                <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session} href_url={this.props.href} />
                 <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                     href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} />
             </div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -45,8 +45,10 @@ var VariantCurationHub = React.createClass({
         });
     },
 
-    updateInterpretationObj: function(interpretation) {
-        this.setState({interpretation: interpretation});
+    updateInterpretationObj: function() {
+        this.getRestData('/interpretation/' + this.state.interpretationUuid).then(interpretation => {
+            this.setState({interpretation: interpretation});
+        });
     },
 
     render: function() {

--- a/src/clincoded/static/components/variant_central/record_curator.js
+++ b/src/clincoded/static/components/variant_central/record_curator.js
@@ -13,6 +13,7 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload
         interpretationUuid: React.PropTypes.string,
+        interpretation: React.PropTypes.object,
         session: React.PropTypes.object
     },
 
@@ -24,12 +25,17 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
 
     getInitialState: function() {
         return {
-            interpretationUuid: this.props.interpretationUuid
+            interpretationUuid: this.props.interpretationUuid,
+            interpretation: null // parent interpretation object
         };
     },
 
     componentWillReceiveProps: function(nextProps) {
-        this.setState({interpretationUuid: nextProps.interpretationUuid});
+        // this block is for handling props and states when props (external data) is updated after the initial load/rendering
+        // when props are updated, update the parent interpreatation object, if applicable
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
+            this.setState({interpretation: nextProps.interpretation, interpretationUuid: nextProps.interpretationUuid});
+        }
     },
 
     // Create 2 arrays of interpretations: one associated with current user

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -4,14 +4,22 @@ var React = require('react');
 // General purpose title rendering
 var Title = module.exports.Title = React.createClass({
     propTypes: {
-        data: React.PropTypes.object // ClinVar data payload
+        data: React.PropTypes.object, // ClinVar data payload
+        interpretation: React.PropTypes.object
     },
 
     render: function() {
         var variant = this.props.data;
+        var disease_term = '';
+        if (this.props.interpretation) {
+            if (this.props.interpretation.disease) {
+                disease_term = this.props.interpretation.disease.term;
+            }
+        }
+
         if (variant) {
             var clinVarTitle = (variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : 'A preferred title is not available';
-            var associatedDisease = (variant.disease) ? variant.disease : 'Not yet associated with a disease';
+            var associatedDisease = (disease_term) ? 'This interpretation is associated with disease: ' + disease_term : 'Not yet associated with a disease';
         }
 
         return (

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var _ = require('underscore');
 
 // General purpose title rendering
 var Title = module.exports.Title = React.createClass({
@@ -8,9 +9,44 @@ var Title = module.exports.Title = React.createClass({
         interpretation: React.PropTypes.object
     },
 
+    getInitialState: function() {
+        return {
+            interpretation: null // parent interpretation object
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        // this block is for handling props and states when props (external data) is updated after the initial load/rendering
+        // when props are updated, update the parent interpreatation object, if applicable
+        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
+    },
+
+    renderSubtitle: function(interpretation, variant) {
+        var associatedDisease = 'Not yet associated with a disease';
+        if (interpretation) {
+            if (interpretation.disease) {
+                if (interpretation.disease.term) {
+                    associatedDisease = 'This interpretation is associated with disease: ' + interpretation.disease.term;
+                }
+            }
+        }
+        if (variant && !interpretation) {
+            if (variant.associatedInterpretations.length) {
+                if (variant.associatedInterpretations[0].disease) {
+                    if (variant.associatedInterpretations[0].disease.term) {
+                        associatedDisease = 'This interpretation is associated with disease: ' + variant.associatedInterpretations[0].disease.term;
+                    }
+                }
+            }
+        }
+        return associatedDisease;
+    },
+
     render: function() {
         var variant = this.props.data;
-        var associatedDisease = '';
+        var interpretation = this.state.interpretation;
 
         var variantTitle = (variant && variant.clinvarVariantTitle) ? variant.clinvarVariantTitle : null;
         if (variant && !variantTitle && variant.hgvsNames && variant.hgvsNames != {}) {
@@ -19,18 +55,10 @@ var Title = module.exports.Title = React.createClass({
             variantTitle = 'A preferred title is not available';
         }
 
-        if (variant) {
-            if (variant.associatedInterpretations.length) {
-                if (variant.associatedInterpretations[0].disease) {
-                    associatedDisease = (disease_term) ? 'This interpretation is associated with disease: ' + variant.associatedInterpretations[0].disease.term : 'Not yet associated with a disease';
-                }
-            }
-        }
-
         return (
             <div>
                 <h1>{variantTitle}{this.props.children}</h1>
-                <h2>{associatedDisease}</h2>
+                <h2>{this.renderSubtitle(interpretation, variant)}</h2>
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -11,9 +11,11 @@ var Title = module.exports.Title = React.createClass({
     render: function() {
         var variant = this.props.data;
         var disease_term = '';
-        if (this.props.interpretation) {
-            if (this.props.interpretation.disease) {
-                disease_term = this.props.interpretation.disease.term;
+        if (variant) {
+            if (variant.associatedInterpretations.length) {
+                if (variant.associatedInterpretations[0].disease) {
+                    disease_term = variant.associatedInterpretations[0].disease.term;
+                }
             }
         }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1318,7 +1318,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     color: #fff;
     content: attr(data-tooltip);
     text-align: center;
-    font-size: 14px;
+    font-size: 12px;
+    font-weight: normal;
     line-height: 1.2;
     white-space: normal;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1120,12 +1120,19 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     .interpretation-record {
         padding: 20px 0;
 
-        h2 {
-            margin-top: 0;
-            margin-bottom: 0;
-            position: absolute;
+         h2 {
+            left: 0;
+            margin: 0;
             text-align: center;
-            width: 1128px;
+            width: 100%;
+        }
+
+        .btn-group {
+            left: 0;
+            padding: 0 15px;
+            position: absolute;
+            top: 20px;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
This PR consists of changes pertinent to #759, #761 and #770.

**Known issues:**
1. Currently, after the modal is closed upon associating the interpretation with disease, the disease id/term is not immediately reflected in the interpretation record slugline under "My interpretations" in the static header. Refreshing the page would invoke the disease id/term to be displayed.
2. After merging with the latest `dev`, I noticed that the criteria bar now wraps to a second line when the interpretation is active.

**Steps to test:**
1. Login and enter ClinVar ID 55980 via the variant selection interface.
2. In the evidence only view, expect to see the "Start new interpretation" button when there is not associated interpretation.
3. Proceed to the "Population" or "Predictors" tab, click on the "Start new interpretation" button. Expect to see 1) staying on the "Population" or "Predictors" tab instead of navigating back to "Basic Info" tab; 2) the display of the "Associate with disease" button.
4. Navigate back to the variant selection interface and enter the same ClinVar ID 55980. Upon returning to the evidence only view, expect to see the "Continue interpretation" button.
5. Click on the "Continue interpretation" button and expect to see the active interpretation and "Associate with disease" button appearing above the criteria bar.
6. Click on the "Associate with disease" button and expect to see the modal.
7. Enter "@@@" and click the OK button. Expect to see error in the modal.
8. Enter "orpha777" and click the OK button. Expect to see the modal to be closed and the subtitle in the header being updated with the disease term. And expect to see the "Associate with disease" button to be changed "Edit Disease" as a result.