### PR TITLE
Connects to #807 use external_url_map, Connects to #809 bug: wrong context links

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -195,7 +195,13 @@ module.exports.external_url_map = {
     'ESPHome': 'http://evs.gs.washington.edu/EVS/',
     '1000GenomesHome': 'http://browser.1000genomes.org/',
     'mutalyzer': 'https://mutalyzer.nl/',
-    'mutalyzerSnpConverter': 'https://mutalyzer.nl/snp-converter'
+    'mutalyzerSnpConverter': 'https://mutalyzer.nl/snp-converter',
+    'UCSCGRCh38': 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr',
+    'UCSCGRCh37': 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr',
+    'VariationViewerGRCh38': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
+    'VariationViewerGRCh37': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
+    'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
+    'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
 };
 
 

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -40,7 +40,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
             if (gRCh38 || gRCh37) {
                 var hgvs_term = gRCh38 ? gRCh38 : gRCh37;
                 chr = hgvs_term.substr(7, 2);
-                if (chr.indexOf('0') !== -1) {
+                if (chr.indexOf('0') === 0) {
                     chr = chr.substr(1, 1);
                 } else if (chr === '23') {
                     chr = 'x';
@@ -49,7 +49,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                 }
             }
 
-            // set start and stop points for +/- 60 dp length and generate links
+            // set start and stop points for +/- 60 bp length and generate links
             var start_38 = null;
             var end_38 = null;
             var start_37 = null;
@@ -59,19 +59,17 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                 var point_38 = gRCh38.match(re)[1];
                 start_38 = parseInt(point_38) - 30;
                 end_38 = parseInt(point_38) + 30;
-
-                ucsc_url_38 = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr' + chr + '%3A' + start_38.toString() + '-' + end_38.toString();
-                viewer_url_38 = 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=' + chr + '&assm=GCF_000001405.28&from=' + start_38.toString() + '&to=' + end_38.toString();
-                ensembl_url_38 = 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=' + chr + ':' + start_38.toString() + '-' + end_38.toString();
+                ucsc_url_38 = external_url_map['UCSCGRCh38'] + chr + '%3A' + start_38.toString() + '-' + end_38.toString();
+                viewer_url_38 = external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start_38.toString() + '&to=' + end_38.toString();
+                ensembl_url_38 = external_url_map['EnsemblGRCh38'] + chr + ':' + start_38.toString() + '-' + end_38.toString();
             }
             if (gRCh37) {
                 var point_37 = gRCh37.match(re)[1];
                 start_37 = parseInt(point_37) - 30;
                 end_37 = parseInt(point_37) + 30;
-
-                ucsc_url_37 = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr' + chr + '%3A' + start_37.toString() + '-' + end_37.toString();
-                viewer_url_37 = 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=' + chr + '&assm=GCF_000001405.25&from=' + start_37.toString() + '&to=' + end_37.toString();
-                ensembl_url_37 = 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=' + chr + ':' + start_37.toString() + '-' + end_37.toString();
+                ucsc_url_37 = external_url_map['UCSCGRCh37'] + chr + '%3A' + start_37.toString() + '-' + end_37.toString();
+                viewer_url_37 = external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start_37.toString() + '&to=' + end_37.toString();
+                ensembl_url_37 = external_url_map['EnsemblGRCh37'] + chr + ':' + start_37.toString() + '-' + end_37.toString();
             }
         }
 


### PR DESCRIPTION
This PR is for tickets #807 (use external_url_map in `globals.js`) and #809 (Bug: wrong context links for variants in chr 10 and chr 20).

**Code Change for Fixing Bug**
* Edited code to set chromosome from NC_ HGVS terms in file `src/clincoded/static/components/variant_central/record_gene_disease.js`

**Code Changes for Using external_url_map**
* Added urls in module "external_url_map" in file `src/clincoded/static/components/globals.js`.
* Replaced inline urls with external_url_map module in file `src/clincoded/static/components/variant_central/record_gene_disease.js`

**Test Steps**
1. Select ClinVar Variation ID 24 (chr 10) or 157 (chr 20), Save. 
2. Click each Context links. Expect to open relevant page.