### PR TITLE
R7Alpha1 bugfixes and tweaks

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -559,16 +559,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
-                    {(this.props.data && this.state.interpretation) ?
-                    <div className="row">
-                        <div className="col-sm-12">
-                            <CurationInterpretationForm renderedFormContent={criteriaGroup2}
-                                evidenceType={'computational'} evidenceDataUpdated={true}
-                                formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
-                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                        </div>
-                    </div>
-                    : null}
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
@@ -584,6 +574,16 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             }
                         </div>
                     </div>
+                    {(this.props.data && this.state.interpretation) ?
+                    <div className="row">
+                        <div className="col-sm-12">
+                            <CurationInterpretationForm renderedFormContent={criteriaGroup2}
+                                evidenceType={'computational'} evidenceDataUpdated={true}
+                                formDataUpdater={criteriaGroup2Update} variantUuid={this.props.data['@id']} criteriaDisease={['PM5', 'PS1']}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        </div>
+                    </div>
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Molecular Consequence: Missense" panelBodyClassName="panel-wide-content" open>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -155,15 +155,17 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             return Promise.resolve(clinVarObj);
                         }
                     }).then(clinvar => {
-                        var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
-                        var symbol = clinvar.gene_symbol;
-                        this.getRestData(this.props.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
-                            var codonObj = {};
-                            codonObj.count = result.esearchresult.count;
-                            codonObj.term = term;
-                            codonObj.symbol = symbol;
-                            this.setState({hasClinVarData: true, codonObj: codonObj});
-                        });
+                        if (clinvar.protein_change) {
+                            var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
+                            var symbol = clinvar.gene_symbol;
+                            this.getRestData(this.props.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+                                var codonObj = {};
+                                codonObj.count = result.esearchresult.count;
+                                codonObj.term = term;
+                                codonObj.symbol = symbol;
+                                this.setState({hasClinVarData: true, codonObj: codonObj});
+                            });
+                        }
                     }).catch(function(e) {
                         console.log('ClinVar Fetch Error=: %o', e);
                     });

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -758,7 +758,7 @@ var criteriaGroup1 = function() {
         <div>
             <div className="col-sm-7 col-sm-offset-5 input-note-top">
                 <p className="alert alert-info">
-                    <strong>BA1:</strong> Allele frequence is > 5% in ExAC, 1000 Genomes, or ESP
+                    <strong>BA1:</strong> Allele frequency is > 5% in ExAC, 1000 Genomes, or ESP
                     <br /><br />
                     <strong>PM2:</strong> Absent from controls (or at extremely low frequency if recessive) in ExAC, 1000 Genomes, or ESP
                 </p>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -68,6 +68,10 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
         // when props are updated, update the parent interpreatation object, if applicable
         if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
             this.setState({interpretation: nextProps.interpretation});
+            // check to see if the interpretation has a disease associated with it
+            if (nextProps.interpretation.interpretation_disease && nextProps.interpretation.interpretation_disease !== '') {
+                this.setState({diseaseAssociated: true});
+            }
         }
         // when props are updated, update the form with new extra data, if applicable
         if (typeof nextProps.evidenceData !== undefined && nextProps.evidenceData != this.props.evidenceData) {

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -104,7 +104,7 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.gene.symbol = geneNode.getAttribute('Symbol');
     variant.gene.full_name = geneNode.getAttribute('FullName');
     var protein_change = allele.getElementsByTagName('ProteinChange')[0];
-    variant.allele.ProteinChange = protein_change.textContent;
+    variant.allele.ProteinChange = protein_change ? protein_change.textContent : null;
     // Parse <SequenceLocation> nodes
     var SequenceLocationNodes = allele.getElementsByTagName('SequenceLocation');
     for(let y of SequenceLocationNodes) {


### PR DESCRIPTION
* Fix typo in BA1 label
* Add conditionals to `parseClinVarExtended()` `protein_change` parser, as well as computational tab parsers that relies on this `protein_change` field
* Switch form and table order for computational tab's 'Variant in Same Codon' section
* Update `form.js` to check for disease in `componentWillReceiveProps`; forms properly become activated when disease is added without refresh