### PR TITLE
Connects to #812. Fixed clipped long hgvs terms and criteria bar wrapping.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -194,7 +194,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (item.hgvsc) {
             return (
                 <tr key={key}>
-                    <td>{item.hgvsc}</td>
+                    <td><span className="ellipsis">{item.hgvsc}</span></td>
                     <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
                     <td>
                         {(item.consequence_terms) ? this.handleSOTerms(item.consequence_terms) : '--'}
@@ -302,8 +302,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="bs-callout-content-container">
                         <h4>Genomic</h4>
                         <ul>
-                            {(GRCh38) ? <li><span>{GRCh38 + ' (GRCh38)'}</span></li> : null}
-                            {(GRCh37) ? <li><span>{GRCh37 + ' (GRCh37)'}</span></li> : null}
+                            {(GRCh38) ? <li><span className="ellipsis">{GRCh38}</span><span> (GRCh38)</span></li> : null}
+                            {(GRCh37) ? <li><span className="ellipsis">{GRCh37}</span><span> (GRCh37)</span></li> : null}
                         </ul>
                     </div>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -194,7 +194,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (item.hgvsc) {
             return (
                 <tr key={key}>
-                    <td><span className="ellipsis">{item.hgvsc}</span></td>
+                    <td><span className="title-ellipsis" title={item.hgvsc}>{item.hgvsc}</span></td>
                     <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
                     <td>
                         {(item.consequence_terms) ? this.handleSOTerms(item.consequence_terms) : '--'}
@@ -302,8 +302,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="bs-callout-content-container">
                         <h4>Genomic</h4>
                         <ul>
-                            {(GRCh38) ? <li><span className="ellipsis">{GRCh38}</span><span> (GRCh38)</span></li> : null}
-                            {(GRCh37) ? <li><span className="ellipsis">{GRCh37}</span><span> (GRCh37)</span></li> : null}
+                            {(GRCh38) ? <li><span className="title-ellipsis title-ellipsis-short">{GRCh38}</span><span> (GRCh38)</span></li> : null}
+                            {(GRCh37) ? <li><span className="title-ellipsis title-ellipsis-short">{GRCh37}</span><span> (GRCh37)</span></li> : null}
                         </ul>
                     </div>
                 </div>
@@ -322,7 +322,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <tbody>
                                 <tr>
                                     <td>
-                                        {(primary_transcript) ? primary_transcript.nucleotide : '--'}
+                                        <span className="title-ellipsis">{(primary_transcript) ? primary_transcript.nucleotide : '--'}</span>
                                     </td>
                                     <td>
                                         {(primary_transcript) ? primary_transcript.protein : '--'}
@@ -347,7 +347,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     <td>
                                         <ul>
                                             {clinvar_hgvs_names.map(function(name, index) {
-                                                return <li key={index}>{name}</li>;
+                                                return <li key={index}><span className="title-ellipsis">{name}</span></li>;
                                             })}
                                         </ul>
                                     </td>

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1140,6 +1140,15 @@ div.react-tabs .ReactTabs__TabPanel--selected {
                 font-weight: bold;
             }
         }
+
+        .ellipsis {
+            display: inline-block;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            vertical-align: bottom;
+            max-width: 100%;
+        }
     }
 }
 
@@ -1264,6 +1273,7 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     .bs-callout-content-container {
         float: left;
         margin-right: 10%;
+        width: 100%;
     }
 }
 
@@ -1310,7 +1320,8 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     background-color: #ddd;
     color: #555;
     cursor: default;
-    padding: 5px 0.725em;
+    padding: 5px 0.72em;
+    font-size: 12px;
     font-weight: bold;
 
     &.benign-strong {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1140,15 +1140,6 @@ div.react-tabs .ReactTabs__TabPanel--selected {
                 font-weight: bold;
             }
         }
-
-        .ellipsis {
-            display: inline-block;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow: hidden;
-            vertical-align: bottom;
-            max-width: 100%;
-        }
     }
 }
 


### PR DESCRIPTION
**This PR consists of changes pertinent to the following changes:**
1. For really really long HGVS terms displayed in the Genomic panel on the "Basic Info" tab, ellipsis has been applied to the terms width equals to the width of the panel.
2. For really long HGVS terms displayed in the Ensembl Transcripts table on the "Basic Info" tab, ellipsis has been applied to the terms width equals to the width of the table column.
3. Added CSS rules to fix the wrapping issue on the static criteria bar.

Steps to verify:
See screen shots attached in https://github.com/ClinGen/clincoded/issues/812.