### PR TITLE
Connects to #814. Disease subtitle handling in titlebar

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -636,7 +636,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <div className="panel panel-info datasource-ExAC">
                             <div className="panel-heading">
                                 <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
-                                    <a className="panel-subtitle pull-right" href={this.props.protocol + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
+                                    <a className="panel-subtitle pull-right" href={'http:' + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
                             <table className="table">

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -30,7 +30,7 @@ var Title = module.exports.Title = React.createClass({
             if (interpretation.disease && interpretation.disease.term) {
                 associatedDisease = <span>This interpretation is associated with the disease <strong>{interpretation.disease.term}</strong></span>;
             } else {
-                associatedDisease = 'This interpretation is not yet associated with a diasese';
+                associatedDisease = 'This interpretation is not yet associated with a disease';
             }
         }
         return associatedDisease;

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -25,21 +25,12 @@ var Title = module.exports.Title = React.createClass({
     },
 
     renderSubtitle: function(interpretation, variant) {
-        var associatedDisease = 'Not yet associated with a disease';
+        var associatedDisease = 'Evidence View Only';
         if (interpretation) {
-            if (interpretation.disease) {
-                if (interpretation.disease.term) {
-                    associatedDisease = 'This interpretation is associated with disease: ' + interpretation.disease.term;
-                }
-            }
-        }
-        if (variant && !interpretation) {
-            if (variant.associatedInterpretations.length) {
-                if (variant.associatedInterpretations[0].disease) {
-                    if (variant.associatedInterpretations[0].disease.term) {
-                        associatedDisease = 'This interpretation is associated with disease: ' + variant.associatedInterpretations[0].disease.term;
-                    }
-                }
+            if (interpretation.disease && interpretation.disease.term) {
+                associatedDisease = <span>This interpretation is associated with the disease <strong>{interpretation.disease.term}</strong></span>;
+            } else {
+                associatedDisease = 'This interpretation is not yet associated with a diasese';
             }
         }
         return associatedDisease;
@@ -60,7 +51,7 @@ var Title = module.exports.Title = React.createClass({
         if (this.props.interpretationUuid) {
             calculatePatho_button = true;
         }
-        
+
         return (
             <div>
                 <h1>{variantTitle}{this.props.children}</h1>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/16858432/9783cf8a-49db-11e6-8da8-e2d7ed06dd08.png)
⬇️ 
![image](https://cloud.githubusercontent.com/assets/4326866/16858649/3bee5986-49dd-11e6-8bef-1155d6a70db7.png)
⬇️ 
![image](https://cloud.githubusercontent.com/assets/4326866/16858442/b21a9d10-49db-11e6-81c0-696bc66087a5.png)

Testing:

1. Get to VCI
2. Check text in title bar
3. Add interpretation
4. Check text in title bar
5. Add disease
6. Check text in title bar

Also check that the 'See data in ExAC' link in population tab works properly (addresses bug report in #767)