### PR TITLE
Connects to #806 kl copy context links

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -201,7 +201,7 @@ module.exports.external_url_map = {
     'VariationViewerGRCh38': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
     'VariationViewerGRCh37': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
     'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
-    'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r='
+    'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
 };
 
 

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -195,7 +195,13 @@ module.exports.external_url_map = {
     'ESPHome': 'http://evs.gs.washington.edu/EVS/',
     '1000GenomesHome': 'http://browser.1000genomes.org/',
     'mutalyzer': 'https://mutalyzer.nl/',
-    'mutalyzerSnpConverter': 'https://mutalyzer.nl/snp-converter'
+    'mutalyzerSnpConverter': 'https://mutalyzer.nl/snp-converter',
+    'UCSCGRCh38': 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr',
+    'UCSCGRCh37': 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr',
+    'VariationViewerGRCh38': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
+    'VariationViewerGRCh37': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
+    'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
+    'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r='
 };
 
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -7,6 +7,7 @@ var RestMixin = require('../../rest').RestMixin;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
 var SO_terms = require('./mapping/SO_term.json');
 var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
+var externalLinks = require('./shared/externalLinks');
 
 var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
@@ -296,6 +297,16 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var clinvar_hgvs_names = this.state.clinvar_hgvs_names;
         var self = this;
 
+        var links_38 = null;
+        var links_37 = null;
+        if (GRCh38) {
+            links_38 = externalLinks.setContextLinks(GRCh38, 'GRCh38');
+        }
+        if (GRCh37) {
+            links_37 = externalLinks.setContextLinks(GRCh37, 'GRCh37');
+        }
+
+
         return (
             <div className="variant-interpretation basic-info">
                 <div className="bs-callout bs-callout-info clearfix">
@@ -385,16 +396,36 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="panel-heading"><h3 className="panel-title">LinkOut to external resources</h3></div>
                     <div className="panel-body">
                         <dl className="inline-dl clearfix">
-                            {(sequence_location.length && gene_symbol) ?
-                                <dd>Variation Viewer [<a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh38')} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> - <a href={this.variationViewerURL(sequence_location, gene_symbol, 'GRCh37')} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a>]</dd>
-                                : null }
-                            {(ensembl_data.length) ?
-                                <dd>Ensembl Browser [<a href={dbxref_prefix_map['ENSEMBL'] + this.getGeneId(ensembl_data)} target="_blank" title={'Ensembl Browser page for ' + this.getGeneId(ensembl_data) + ' in a new window'}>GRCh38</a>]</dd>
-                                : null}
-                            {(sequence_location.length) ?
-                                <dd>UCSC [<a href={this.ucscViewerURL(sequence_location, 'hg38', 'GRCh38')} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> - <a href={this.ucscViewerURL(sequence_location, 'hg19', 'GRCh37')} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a>]</dd>
-                                : null}
-                            { /* <dd><a href={dbxref_prefix_map['UniProtKB'] + uniprot_id} target="_blank" title={'UniProtKB page for ' + uniprot_id + ' in a new window'}>UniProtKB</a></dd> */ }
+                            {(links_38 || links_37) ?
+                                <dd>UCSC [
+                                    {links_38 ? <a href={links_38.ucsc_url_38} target="_blank" title={'UCSC Genome Browser for ' + GRCh38 + ' in a new window'}>GRCh38/hg38</a> : null }
+                                    {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                    {links_37 ? <a href={links_37.ucsc_url_37} target="_blank" title={'UCSC Genome Browser for ' + GRCh37 + ' in a new window'}>GRCh37/hg19</a> : null }
+                                    ]
+                                </dd>
+                                :
+                                null
+                            }
+                            {(links_38 || links_37) ?
+                                <dd>Variation Viewer [
+                                    {links_38 ? <a href={links_38.viewer_url_38} target="_blank" title={'Variation Viewer page for ' + GRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                    {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                    {links_37 ? <a href={links_37.viewer_url_37} target="_blank" title={'Variation Viewer page for ' + GRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                    ]
+                                </dd>
+                                :
+                                null
+                            }
+                            {(links_38 || links_37) ?
+                                <dd>Ensembl Browser [
+                                    {links_38 ? <a href={links_38.ensembl_url_38} target="_blank" title={'Ensembl Browser page for ' + GRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                    {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                    {links_37 ? <a href={links_37.ensembl_url_37} target="_blank" title={'Ensembl Browser page for ' + GRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                    ]
+                                </dd>
+                                :
+                                null
+                            }
                         </dl>
                     </div>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -15,6 +15,8 @@ var dbxref_prefix_map = globals.dbxref_prefix_map;
 var panel = require('../../../libs/bootstrap/panel');
 var form = require('../../../libs/bootstrap/form');
 
+var externalLinks = require('./shared/externalLinks');
+
 var PanelGroup = panel.PanelGroup;
 var Panel = panel.Panel;
 var Form = form.Form;
@@ -313,6 +315,22 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         var otherPred = (this.state.computationObj && this.state.computationObj.other_predictors) ? this.state.computationObj.other_predictors : null;
         var codon = (this.state.codonObj) ? this.state.codonObj : null;
 
+        var variant = this.props.data;
+        var gRCh38 = null;
+        var gRCh37 = null;
+        var links_38 = null;
+        var links_37 = null;
+        if (variant && variant.hgvsNames) {
+            gRCh38 = variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.hgvsNames.gRCh38 ? variant.hgvsNames.gRCh38 : null);
+            gRCh37 = variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37 : (variant.hgvsNames.gRCh37 ? variant.hgvsNames.gRCh37 : null);
+        }
+        if (gRCh38) {
+            links_38 = externalLinks.setContextLinks(gRCh38, 'GRCh38');
+        }
+        if (gRCh37) {
+            links_37 = externalLinks.setContextLinks(gRCh37, 'GRCh37');
+        }
+
         return (
             <div className="variant-interpretation computational">
                 <PanelGroup accordion><Panel title="Functional, Conservation, and Splicing Predictors" panelBodyClassName="panel-wide-content" open>
@@ -598,6 +616,43 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" panelBodyClassName="panel-wide-content" open>
+                    <div className="panel panel-info">
+                        <div className="panel-heading"><h3 className="panel-title">LinkOut to external resources</h3></div>
+                        <div className="panel-body">
+                            <dl className="inline-dl clearfix">
+                                {(links_38 || links_37) ?
+                                    <dd>UCSC [
+                                        {links_38 ? <a href={links_38.ucsc_url_38} target="_blank" title={'UCSC Genome Browser for ' + gRCh38 + ' in a new window'}>GRCh38/hg38</a> : null }
+                                        {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                        {links_37 ? <a href={links_37.ucsc_url_37} target="_blank" title={'UCSC Genome Browser for ' + gRCh37 + ' in a new window'}>GRCh37/hg19</a> : null }
+                                        ]
+                                    </dd>
+                                    :
+                                    null
+                                }
+                                {(links_38 || links_37) ?
+                                    <dd>Variation Viewer [
+                                        {links_38 ? <a href={links_38.viewer_url_38} target="_blank" title={'Variation Viewer page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                        {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                        {links_37 ? <a href={links_37.viewer_url_37} target="_blank" title={'Variation Viewer page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                        ]
+                                    </dd>
+                                    :
+                                    null
+                                }
+                                {(links_38 || links_37) ?
+                                    <dd>Ensembl Browser [
+                                        {links_38 ? <a href={links_38.ensembl_url_38} target="_blank" title={'Ensembl Browser page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                        {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                        {links_37 ? <a href={links_37.ensembl_url_37} target="_blank" title={'Ensembl Browser page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                        ]
+                                    </dd>
+                                    :
+                                    null
+                                }
+                            </dl>
+                        </div>
+                    </div>
                     {(this.props.data && this.state.interpretation) ?
                     <div className="row">
                         <div className="col-sm-12">

--- a/src/clincoded/static/components/variant_central/interpretation/shared/externalLinks.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/externalLinks.js
@@ -1,0 +1,42 @@
+'use strict';
+var React = require('react');
+var _ = require('underscore');
+var moment = require('moment');
+var globals = require('../../../globals');
+
+var external_url_map = globals.external_url_map;
+
+module.exports.setContextLinks = function(nc_hgvs, ref) {
+    // get Chromosome
+    var chr = nc_hgvs.substr(7, 2);
+    if (chr.indexOf('0') === 0) {
+        chr = chr.substr(1, 1);
+    } else if (chr === '23') {
+        chr = 'x';
+    } else if (chr === '24') {
+        chr = 'y';
+    }
+
+    // set start and stop points for +/- 30 bp length centered at variation point
+    var start = null;
+    var end = null;
+    var re = /:[g].(\d+)\D/;
+    var point = nc_hgvs.match(re)[1];
+    start = (parseInt(point) - 30).toString();
+    end = (parseInt(point) + 30).toString();
+
+    // set links and return
+    if (ref === 'GRCh38') {
+        return {
+            ucsc_url_38: external_url_map['UCSCGRCh38'] + chr + '%3A' + start + '-' + end,
+            viewer_url_38: external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start + '&to=' + end,
+            ensembl_url_38: external_url_map['EnsemblGRCh38'] + chr + ':' + start + '-' + end
+        };
+    } else if (ref === 'GRCh37') {
+        return {
+            ucsc_url_37: external_url_map['UCSCGRCh37'] + chr + '%3A' + start + '-' + end,
+            viewer_url_37: external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start + '&to=' + end,
+            ensembl_url_37: external_url_map['EnsemblGRCh37'] + chr + ':' + start + '-' + end
+        };
+    }
+};

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -75,7 +75,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
             }
             if (gRCh37) {
                 links_37 = externalLinks.setContextLinks(gRCh37, 'GRCh37');
-                //links_37 = this.setContextLinks(gRCh37, 'GRCh37');
+
             }
         }
 

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -68,40 +68,12 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
             gRCh38 =  variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.hgvsNames.gRCh38 ? variant.hgvsNames.gRCh38 : null);
             gRCh37 =  variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37 : (variant.hgvsNames.gRCh37 ? variant.hgvsNames.gRCh37 : null);
 
-            // get Chromosome
-            if (gRCh38 || gRCh37) {
-                var hgvs_term = gRCh38 ? gRCh38 : gRCh37;
-                chr = hgvs_term.substr(7, 2);
-                if (chr.indexOf('0') === 0) {
-                    chr = chr.substr(1, 1);
-                } else if (chr === '23') {
-                    chr = 'x';
-                } else if (chr === '24') {
-                    chr = 'y';
-                }
-            }
-
-            // set start and stop points for +/- 60 bp length and generate links
-            var start_38 = null;
-            var end_38 = null;
-            var start_37 = null;
-            var end_37 = null;
-            var re = /:[g].(\d+)\D/;
+            // get context links for each NC_
             if (gRCh38) {
-                var point_38 = gRCh38.match(re)[1];
-                start_38 = parseInt(point_38) - 30;
-                end_38 = parseInt(point_38) + 30;
-                ucsc_url_38 = external_url_map['UCSCGRCh38'] + chr + '%3A' + start_38.toString() + '-' + end_38.toString();
-                viewer_url_38 = external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start_38.toString() + '&to=' + end_38.toString();
-                ensembl_url_38 = external_url_map['EnsemblGRCh38'] + chr + ':' + start_38.toString() + '-' + end_38.toString();
+                links_38 = externalLinks.setContextLinks(gRCh38, 'GRCh38');
             }
             if (gRCh37) {
-                var point_37 = gRCh37.match(re)[1];
-                start_37 = parseInt(point_37) - 30;
-                end_37 = parseInt(point_37) + 30;
-                ucsc_url_37 = external_url_map['UCSCGRCh37'] + chr + '%3A' + start_37.toString() + '-' + end_37.toString();
-                viewer_url_37 = external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start_37.toString() + '&to=' + end_37.toString();
-                ensembl_url_37 = external_url_map['EnsemblGRCh37'] + chr + ':' + start_37.toString() + '-' + end_37.toString();
+                links_37 = externalLinks.setContextLinks(gRCh37, 'GRCh37');
             }
         }
 

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -3,6 +3,7 @@ var React = require('react');
 var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../globals');
+var externalLinks = require('./interpretation/shared/externalLinks');
 
 var external_url_map = globals.external_url_map;
 
@@ -19,59 +20,62 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
         };
     },
 
+    setContextLinks: function(nc_hgvs, ref) {
+        // get Chromosome
+        var chr = nc_hgvs.substr(7, 2);
+        if (chr.indexOf('0') === 0) {
+            chr = chr.substr(1, 1);
+        } else if (chr === '23') {
+            chr = 'x';
+        } else if (chr === '24') {
+            chr = 'y';
+        }
+
+        // set start and stop points for +/- 30 bp length centered at variation point
+        var start = null;
+        var end = null;
+        var re = /:[g].(\d+)\D/;
+        var point = nc_hgvs.match(re)[1];
+        start = (parseInt(point) - 30).toString();
+        end = (parseInt(point) + 30).toString();
+
+        // set links and return
+        if (ref === 'GRCh38') {
+            return {
+                ucsc_url_38: external_url_map['UCSCGRCh38'] + chr + '%3A' + start + '-' + end,
+                viewer_url_38: external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start + '&to=' + end,
+                ensembl_url_38: external_url_map['EnsemblGRCh38'] + chr + ':' + start + '-' + end
+            };
+        } else if (ref === 'GRCh37') {
+            return {
+                ucsc_url_37: external_url_map['UCSCGRCh37'] + chr + '%3A' + start + '-' + end,
+                viewer_url_37: external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start + '&to=' + end,
+                ensembl_url_37: external_url_map['EnsemblGRCh37'] + chr + ':' + start + '-' + end
+            };
+        }
+    },
+
     render: function() {
         var variant = this.props.data;
         var recordHeader = this.props.recordHeader;
         var gRCh38 = null;
         var gRCh37 = null;
-        var chr = null;
-        var ucsc_url_38 = null;
-        var ucsc_url_37 = null;
-        var viewer_url_38 = null;
-        var viewer_url_37 = null;
-        var ensembl_url_38 = null;
-        var ensembl_url_37 = null;
+        var links_38 = null;
+        var links_37 = null;
+
         if (variant && variant.hgvsNames) {
             // get GRCh38 and GRCh37 NC_ terms from local db
             gRCh38 =  variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.hgvsNames.gRCh38 ? variant.hgvsNames.gRCh38 : null);
             gRCh37 =  variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37 : (variant.hgvsNames.gRCh37 ? variant.hgvsNames.gRCh37 : null);
 
-            // get Chromosome
-            if (gRCh38 || gRCh37) {
-                var hgvs_term = gRCh38 ? gRCh38 : gRCh37;
-                chr = hgvs_term.substr(7, 2);
-                if (chr.indexOf('0') !== -1) {
-                    chr = chr.substr(1, 1);
-                } else if (chr === '23') {
-                    chr = 'x';
-                } else if (chr === '24') {
-                    chr = 'y';
-                }
-            }
-
-            // set start and stop points for +/- 60 dp length and generate links
-            var start_38 = null;
-            var end_38 = null;
-            var start_37 = null;
-            var end_37 = null;
-            var re = /:[g].(\d+)\D/;
+            // get context links for each NC_
             if (gRCh38) {
-                var point_38 = gRCh38.match(re)[1];
-                start_38 = parseInt(point_38) - 30;
-                end_38 = parseInt(point_38) + 30;
-
-                ucsc_url_38 = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr' + chr + '%3A' + start_38.toString() + '-' + end_38.toString();
-                viewer_url_38 = 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=' + chr + '&assm=GCF_000001405.28&from=' + start_38.toString() + '&to=' + end_38.toString();
-                ensembl_url_38 = 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=' + chr + ':' + start_38.toString() + '-' + end_38.toString();
+                links_38 = externalLinks.setContextLinks(gRCh38, 'GRCh38');
+                //links_38 = this.setContextLinks(gRCh38, 'GRCh38');
             }
             if (gRCh37) {
-                var point_37 = gRCh37.match(re)[1];
-                start_37 = parseInt(point_37) - 30;
-                end_37 = parseInt(point_37) + 30;
-
-                ucsc_url_37 = 'https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr' + chr + '%3A' + start_37.toString() + '-' + end_37.toString();
-                viewer_url_37 = 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=' + chr + '&assm=GCF_000001405.25&from=' + start_37.toString() + '&to=' + end_37.toString();
-                ensembl_url_37 = 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=' + chr + ':' + start_37.toString() + '-' + end_37.toString();
+                links_37 = externalLinks.setContextLinks(gRCh37, 'GRCh37');
+                //links_37 = this.setContextLinks(gRCh37, 'GRCh37');
             }
         }
 
@@ -79,50 +83,38 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
             <div className="col-xs-12 col-sm-3 gutter-exc">
                 <div className="curation-data-disease">
                     <h4>{recordHeader}</h4>
-                    {chr ?
-                        <dl className="inline-dl clearfix">
-                            {(ucsc_url_38 || ucsc_url_37) ?
-                                <dd>UCSC [
-                                    {ucsc_url_38 ?
-                                        <a href={ucsc_url_38} target="_blank" title={'UCSC Genome Browser for ' + gRCh38 + ' in a new window'}>GRCh38/hg38</a>
-                                        :
-                                        null
-                                    }
-                                    {(ucsc_url_38 && ucsc_url_37) ? <span>&nbsp;|&nbsp;</span> : null }
-                                    {ucsc_url_37 ?
-                                        <a href={ucsc_url_37} target="_blank" title={'UCSC Genome Browser for ' + gRCh37 + ' in a new window'}>GRCh37/hg19</a>
-                                        :
-                                        null
-                                    }
-                                    ]
-                                </dd>
-                                :
-                                null
-                            }
-                            {(viewer_url_38 || viewer_url_37) ?
-                                <dd>Variation Viewer [
-                                    {viewer_url_38 ? <a href={viewer_url_38} target="_blank" title={'Variation Viewer page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
-                                    {(viewer_url_38 && viewer_url_37) ? <span>&nbsp;|&nbsp;</span> : null }
-                                    {viewer_url_37 ? <a href={viewer_url_37} target="_blank" title={'Variation Viewer page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
-                                    ]
-                                </dd>
-                                :
-                                null
-                            }
-                            {ensembl_url_38 || ensembl_url_37 ?
-                                <dd>Ensembl Browser [
-                                    {ensembl_url_38 ? <a href={ensembl_url_38} target="_blank" title={'Ensembl Browser page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
-                                    {(ensembl_url_38 && ensembl_url_37) ? <span>&nbsp;|&nbsp;</span> : null }
-                                    {ensembl_url_37 ? <a href={ensembl_url_37} target="_blank" title={'Ensembl Browser page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
-                                    ]
-                                </dd>
-                                :
-                                null
-                            }
-                        </dl>
-                        :
-                        null
-                    }
+                    <dl className="inline-dl clearfix">
+                        {(links_38 || links_37) ?
+                            <dd>UCSC [
+                                {links_38 ? <a href={links_38.ucsc_url_38} target="_blank" title={'UCSC Genome Browser for ' + gRCh38 + ' in a new window'}>GRCh38/hg38</a> : null }
+                                {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                {links_37 ? <a href={links_37.ucsc_url_37} target="_blank" title={'UCSC Genome Browser for ' + gRCh37 + ' in a new window'}>GRCh37/hg19</a> : null }
+                                ]
+                            </dd>
+                            :
+                            null
+                        }
+                        {(links_38 || links_37) ?
+                            <dd>Variation Viewer [
+                                {links_38 ? <a href={links_38.viewer_url_38} target="_blank" title={'Variation Viewer page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                {links_37 ? <a href={links_37.viewer_url_37} target="_blank" title={'Variation Viewer page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                ]
+                            </dd>
+                            :
+                            null
+                        }
+                        {(links_38 || links_37) ?
+                            <dd>Ensembl Browser [
+                                {links_38 ? <a href={links_38.ensembl_url_38} target="_blank" title={'Ensembl Browser page for ' + gRCh38 + ' in a new window'}>GRCh38</a> : null }
+                                {(links_38 && links_37) ? <span>&nbsp;|&nbsp;</span> : null }
+                                {links_37 ? <a href={links_37.ensembl_url_37} target="_blank" title={'Ensembl Browser page for ' + gRCh37 + ' in a new window'}>GRCh37</a> : null }
+                                ]
+                            </dd>
+                            :
+                            null
+                        }
+                    </dl>
                 </div>
             </div>
         );


### PR DESCRIPTION
It's required to display variant context links in the bottom of Basic Info tab and Predictors tab.

**Code Changes** in dir `src/clincoded/static/components/variant_central/interpretation/`
1. Created a module function to set context links for GRCh38 and GRCh37 NC_ HGVS terms in file `shared/externalLinks.js`
2. Edited codes to use the module in file `record_gene_disease.js`.
3. Added the same codes to files `basic_info.js` and `computational.js`.

**Test**
* Select ClinVar Variation ID, enter 139214, click Save. Expect to see context links in Basic Info tab as:
![screen shot 2016-07-14 at 4 37 52 pm](https://cloud.githubusercontent.com/assets/9206696/16859144/579d1a24-49e1-11e6-8b97-ff3ce22d2919.png)
* Click Predictors tab and expect to see:
![screen shot 2016-07-14 at 4 38 48 pm](https://cloud.githubusercontent.com/assets/9206696/16859169/7af0428a-49e1-11e6-853b-a63c972f53bc.png)
* Click each link and expect to open relevant page.

**End Test**