### PR TITLE
Separate callout CSS between tabs

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -310,7 +310,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         return (
             <div className="variant-interpretation basic-info">
                 <div className="bs-callout bs-callout-info clearfix">
-                    <div className="bs-callout-content-container">
+                    <div className="bs-callout-content-container-fullwidth">
                         <h4>Genomic</h4>
                         <ul>
                             {(GRCh38) ? <li><span className="title-ellipsis title-ellipsis-short">{GRCh38}</span><span> (GRCh38)</span></li> : null}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1264,6 +1264,11 @@ div.react-tabs .ReactTabs__TabPanel--selected {
     .bs-callout-content-container {
         float: left;
         margin-right: 10%;
+    }
+
+    .bs-callout-content-container-fullwidth {
+        float: left;
+        margin-right: 10%;
         width: 100%;
     }
 }


### PR DESCRIPTION
* Separate out css for bootstrap callouts to retain styling differences between two tabs:

![image](https://cloud.githubusercontent.com/assets/4326866/16869779/63aa3502-4a33-11e6-8d9d-53ce12c6a649.png)
![image](https://cloud.githubusercontent.com/assets/4326866/16869786/6c454c7e-4a33-11e6-84f3-89f0982e902b.png)
