### PR TITLE
Connects to #832. Removing asterisk/wildcard in Entrez codon search.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -642,7 +642,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             {this.state.hasClinVarData && codon ?
                                 <dl className="inline-dl clearfix">
                                     <dt>Number of variants in codon: <span className="condon-variant-count">{codon.count}</span></dt>
-                                    <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
+                                    <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
                                 </dl>
                             :
                                 <dl className="inline-dl clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -173,7 +173,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         if (clinvar.protein_change) {
                             var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
                             var symbol = clinvar.gene_symbol;
-                            this.getRestData(this.props.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '*+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+                            this.getRestData(this.props.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
                                 var codonObj = {};
                                 codonObj.count = result.esearchresult.count;
                                 codonObj.term = term;


### PR DESCRIPTION
This PR consists of change pertinent to address the wildcard search in finding neighboring variants.

**Technical details:**
1. The wildcard "asterisk" has been removed from the following URL construct:
`dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '*+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>`

**Steps to test:**
1. Login and enter the 53423 ClinVar ID at the variant selection page.
2. Proceed to the computational tab and scroll down to the "Variants in the Same Codon" section.
3. Expect to see that there is a "5" for the "Number of variants in codon" label.
4. Examine the linkout and expect to see the wildcard asterisk no longer present in the URL (e.g. http://www.ncbi.nlm.nih.gov/clinvar/?term=M1+%5Bvariant+name%5D+and+CFTR). And clicking on the linkout will come to the ClinVar page with 5 results.
5. Previously, with the wildcard asterisk, there would have been 17 results.