### PR TITLE
Connects to #835. Added button progress indicator.

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -210,6 +210,7 @@ var AssociateDisease = React.createClass({
                             this.props.updateInterpretationObj();
                             this.props.updateParentState();
                             this.setState({submitResourceBusy: false});
+                            // Need 'submitResourceBusy' state to proceed closing modal
                             return Promise.resolve(this.state.submitResourceBusy);
                         }).then(submitState => {
                             // Close modal after 'submitResourceBusy' is completed

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -173,7 +173,8 @@ var AssociateDisease = React.createClass({
     // When the form is submitted...
     submitForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-
+        // Invoke button progress indicator
+        this.setState({submitResourceBusy: true});
         // Get values from form and validate them
         this.saveFormValue('orphanetid', this.refs.orphanetid.getValue());
         if (this.validateForm()) {
@@ -208,7 +209,13 @@ var AssociateDisease = React.createClass({
                         return this.putRestData('/interpretation/' + this.props.interpretation.uuid, interpretationObj).then(result => {
                             this.props.updateInterpretationObj();
                             this.props.updateParentState();
-                            this.props.closeModal();
+                            this.setState({submitResourceBusy: false});
+                            return Promise.resolve(this.state.submitResourceBusy);
+                        }).then(submitState => {
+                            // Close modal after 'submitResourceBusy' is completed
+                            if (submitState !== true) {
+                                this.props.closeModal();
+                            }
                         });
                     }
                 });


### PR DESCRIPTION
This PR consists of change pertinent to show progress indicator (e.g. spinning gear) in the "Associate with Disease" modal's "OK" button upon user's click event.

**Steps to test:**
1. Login and enter 53423 ClinVar ID on variant selection page.
2. Proceed to evidence pool only interface and click on the "Start New Interpretation" button.
3. Upon the appearance of the "Associate with Disease" button, click on it and invoke the modal.
4. Enter ORPHA777 and click on the "OK" button. Expect to see the button to be in "disabled" mode with a "spinning gear" in it momentarily before the modal is closed.
5. This behavior should be consistent even when user edits disease (e.g. ORPHA891) via the same modal.