### PR TITLE
Connects to #790. Remove react-localstorage npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "node-ckeditor": "^4.3.2",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react-localstorage": "^0.3.0",
     "react-tabs": "^0.5.3",
     "scriptjs": "^2.5.7",
     "shivie8": "^1.0.0",

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -4,7 +4,6 @@ var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
-//var LocalStorageMixin = require('react-localstorage');
 var CurationInterpretationForm = require('./shared/form').CurationInterpretationForm;
 var parseAndLogError = require('../../mixins').parseAndLogError;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;

--- a/src/clincoded/static/components/variant_central/record_curator.js
+++ b/src/clincoded/static/components/variant_central/record_curator.js
@@ -4,11 +4,10 @@ var _ = require('underscore');
 var moment = require('moment');
 var globals = require('../globals');
 var RestMixin = require('../rest').RestMixin;
-var LocalStorageMixin = require('react-localstorage');
 
 // Display in-progress or provisional interpretations associated with variant
 var CurationRecordCurator = module.exports.CurationRecordCurator = React.createClass({
-    mixins: [RestMixin, LocalStorageMixin],
+    mixins: [RestMixin],
 
     propTypes: {
         data: React.PropTypes.object, // ClinVar data payload


### PR DESCRIPTION
This PR consists of changes pertinent to removing the react-localstorage npm package and references to this npm package.

**Technical details:**
The react-localstorage npm package is no longer used in the VCI app.

**Steps to test:**
1. Remove any pre-existing local storage objects in Chrome, by going to Chrome DevTools and selecting "Resources" in the menu bar. Then from **"Local Storage"** in nav bar on the left, select "http://localhost:6543" and particularly remove the `CurationRecordCurator` object if it exists.
2. Login and enter the 139214 ClinVar ID via the variant selection interface.
3. Upon arriving at the evidence only view of the VCI, check the **"Local Storage"** in Chrome DevTools again. Expect to see that the VCI app no longer stores the `CurationRecordCurator` object.