### PR TITLE
Connects to #856 kl bug edit json

### DIFF
--- a/src/clincoded/schemas/evaluation.json
+++ b/src/clincoded/schemas/evaluation.json
@@ -61,8 +61,8 @@
             "title": "Evaluation Value",
             "type": "string"
         },
-        "description": {
-            "title": "Description",
+        "explanation": {
+            "title": "Explanation",
             "description": "The reason to select evaluation value.",
             "type": "string"
         }

--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -35,7 +35,8 @@
         "reasons": {
             "title": "Reasons",
             "description": "Reasons for changing the classification",
-            "type": "string"
+            "type": "string",
+            "default": ""
         },
         "active": {
             "title": "Active",
@@ -49,6 +50,14 @@
             "title": "Owner",
             "type": "string"
         },
+        "date_created": {
+            "title": "Created Date",
+            "type": "string"
+        },
+        "last_modified": {
+            "title": "Last Modified",
+            "type": "string"
+        },
         "totalScore": {
             "title": "Total Score",
             "type": "number"
@@ -57,13 +66,17 @@
             "title": "Assigned Classification",
             "type": "string"
         },
-        "altered_classification": {
+        "alteredClassification": {
             "title": "Altered Classification",
             "type": "string"
         },
-        "reason_explanation": {
+        "reasons": {
             "title": "Reasons",
             "type": "string"
-        }
+        },
+        "active": {
+            "title": "Active",
+            "type": "boolean"
+         }
     }
 }

--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -77,6 +77,6 @@
         "active": {
             "title": "Active",
             "type": "boolean"
-         }
+        }
     }
 }

--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -49,14 +49,6 @@
             "title": "Owner",
             "type": "string"
         },
-        "date_created": {
-            "title": "Created Date",
-            "type": "string"
-        },
-        "last_modified": {
-            "title": "Last Modified",
-            "type": "string"
-        },
         "totalScore": {
             "title": "Total Score",
             "type": "number"
@@ -65,17 +57,13 @@
             "title": "Assigned Classification",
             "type": "string"
         },
-        "alteredClassification": {
+        "altered_classification": {
             "title": "Altered Classification",
             "type": "string"
         },
-        "reasons": {
+        "reason_explanation": {
             "title": "Reasons",
             "type": "string"
-        },
-        "active": {
-            "title": "Active",
-            "type": "boolean"
         }
     }
 }

--- a/src/clincoded/tests/data/inserts/evaluation.json
+++ b/src/clincoded/tests/data/inserts/evaluation.json
@@ -6,7 +6,7 @@
         "disease": "788e024f-16a6-11e5-a0b5-60f81dc5b05a",
         "criteria": "BS1",
         "value": "Yes",
-        "description": "some thing here.",
+        "explanation": "some thing here.",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2016-05-11T22:47:10.000000+00:00",
         "last_modified": "2016-05-11T22:59:10.000000+00:00"
@@ -18,7 +18,7 @@
         "computational": "63727d93-0d51-44b2-a568-d042ba10e8af",
         "criteria": "PVS1",
         "value": "Yes",
-        "description": "description here.",
+        "explanation": "description here.",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",
         "date_created": "2016-05-11T22:47:10.000000+00:00",
         "last_modified": "2016-05-11T22:59:10.000000+00:00"

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -817,8 +817,11 @@ class Pathogenicity(Item):
 
     @calculated_property(schema={
         "title": "Associated GDM",
-        "type": "object",
-        "linkFrom": "gdm.variantPathogenicity"
+        "type": "array",
+        "items": {
+            "type": ['string', 'object'],
+            "linkFrom": "gdm.variantPathogenicity"
+        }
     })
     def associatedGdm(self, request, associatedGdm):
         return paths_filtered_by_status(request, associatedGdm)
@@ -856,16 +859,22 @@ class Assessment(Item):
 
     @calculated_property(schema={
         "title": "Pathogenicity Assessed",
-        "type": ["string", "object"],
-        "linkFrom": "pathogenicity.assessments"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "pathogenicity.assessments"
+        }
     })
     def pathogenicity_assessed(self, request, pathogenicity_assessed):
         return paths_filtered_by_status(request, pathogenicity_assessed)
 
     @calculated_property(schema={
         "title": "Experimental Assessed",
-        "type": ["string", "object"],
-        "linkFrom": "experimental.assessments"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "experimental.assessments"
+        }
     })
     def experimental_assessed(self, request, experimental_assessed):
         return paths_filtered_by_status(request, experimental_assessed)
@@ -892,8 +901,11 @@ class Provisional(Item):
 
     @calculated_property(schema={
         "title": "GDM Associated",
-        "type": ["string", "object"],
-        "linkFrom": "gdm.provisionalClassifications"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "gdm.provisionalClassifications"
+        }
     })
     def gdm_associated(self, request, gdm_associated):
         return paths_filtered_by_status(request, gdm_associated)
@@ -922,8 +934,11 @@ class Transcript(Item):
 
     @calculated_property(schema={
         "title": "Interpretation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "interpretation.transcripts"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "interpretation.transcripts"
+        }
     })
     def interpretation_associated(self, request, interpretation_associated):
         return paths_filtered_by_status(request, interpretation_associated)
@@ -950,8 +965,11 @@ class Protein(Item):
 
     @calculated_property(schema={
         "title": "Interpretation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "interpretation.proteins"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "interpretation.proteins"
+        }
     })
     def interpretation_associated(self, request, interpretation_associated):
         return paths_filtered_by_status(request, interpretation_associated)
@@ -1064,8 +1082,11 @@ class Evaluation(Item):
 
     @calculated_property(schema={
         "title": "Interpretation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "interpretation.evaluations"
+        "type": "array",
+        "items": {
+            "title": ["string", "object"],
+            "linkFrom": "interpretation.evaluations"
+        }
     })
     def interpretation_associated(self, request, interpretation_associated):
         return paths_filtered_by_status(request, interpretation_associated)
@@ -1113,8 +1134,11 @@ class Population(Item):
 
     @calculated_property(schema={
         "title": "Evaluation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "evaluation.population"
+        "type": "array",
+        "items": {
+            "title": ["string", "object"],
+            "linkFrom": "evaluation.population"
+        }
     })
     def evaluation_associated(self, request, evaluation_associated):
         return paths_filtered_by_status(request, evaluation_associated)
@@ -1153,8 +1177,11 @@ class Computational(Item):
 
     @calculated_property(schema={
         "title": "Evaluation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "evaluation.computational"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "evaluation.computational"
+        }
     })
     def evaluation_associated(self, request, evaluation_associated):
         return paths_filtered_by_status(request, evaluation_associated)
@@ -1195,8 +1222,11 @@ class Provisional_variant(Item):
 
     @calculated_property(schema={
         "title": "Interpretation Associated",
-        "type": ["string", "object"],
-        "linkFrom": "interpretation.provisional_variant"
+        "type": "array",
+        "items": {
+            "type": ["string", "object"],
+            "linkFrom": "interpretation.provisional_variant"
+        }
     })
     def interpretation_associated(self, request, interpretation_associated):
         return paths_filtered_by_status(request, interpretation_associated)

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -909,20 +909,6 @@ class Provisional(Item):
     })
     def gdm_associated(self, request, gdm_associated):
         return paths_filtered_by_status(request, gdm_associated)
-
-    @calculated_property(schema={
-        "title": "Altered Classification",
-        "type": "string"
-    })
-    def altered_classification(self, alteredClassification=''):
-        return alteredClassification
-
-    @calculated_property(schema={
-        "title": "Reasons",
-        "type": "string"
-    })
-    def reason_explanation(self, reasons=''):
-        return reasons
 ### end of new collections for gene curation data
 
 

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -909,6 +909,20 @@ class Provisional(Item):
     })
     def gdm_associated(self, request, gdm_associated):
         return paths_filtered_by_status(request, gdm_associated)
+
+    @calculated_property(schema={
+        "title": "Altered Classification",
+        "type": "string"
+    })
+    def altered_classification(self, alteredClassification=''):
+        return alteredClassification
+
+    @calculated_property(schema={
+        "title": "Reasons",
+        "type": "string"
+    })
+    def reason_explanation(self, reasons=''):
+        return reasons
 ### end of new collections for gene curation data
 
 


### PR DESCRIPTION
This PR fixes 2 bugs (failed to use #!edit-json and failed to display provisional classification objects) and corrects 1 schema-related mistake (incorrectly named a property as "description", details in ticket #856).

**Bug 1: Failed to use #!edit-json**
* Reason:  Reverse link as a calculated property should be type of array. Incorrectly set as string or object in some objects including evaluation, population and computational cause failed .

* Code Change: Correct type for all reverse links with wrong type setting in file `src/clincoded/types/__init__.py`.

* Test Sample (evaluation)
 - Go to to [http://localhost:6543/evaluations](http://localhost:6543/evaluations), select one and add `#!edit-json` at the end of url, return. Change `"criteria"` value to "AAA" and click Save. Expect to see:
![screen shot 2016-07-22 at 1 35 29 am](https://cloud.githubusercontent.com/assets/9206696/17051262/9c1120da-4fac-11e6-8117-aa763c436058.png)


**Bug 2: Failed to display provisional classification object**
* Reason: Test data does not match columns properties of schema.

* Code Change: Added default value to property "reasons" in schema file `src/clincoded/schemas/provisionalClassification.json`.

* Test: Go to [http://localhost:6543/provisional/](http://localhost:6543/provisional/) and expect to see provisional classification objects listed.


**Mistake: Incorrectly use "description" to name a property in schema evaluation**
* Reason: "description" is a reserved keyword and should not be use to name data property.
* Correct: Rename the data property as "explanation" in schema file `src/clincoded/schemas/evaluation.json` and test data file `src/clincoded/tests/data/inserts/evaluation.json`