### PR TITLE
Connects to #827. Codon data display.

### DIFF
--- a/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
+++ b/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
@@ -1,0 +1,49 @@
+// # HGVS Notation Helper: Getter Method
+// # Parameters: variant object, assembly (GRCh37 or GRCh38), optional boolean value
+// # Usage: getHgvsNotation(variant, 'GRCh38', true)
+//
+// This method extracts the genomic substring from HGVS name whose assembly is
+// either GRCh37 or GRCh38. By looking up the genomic-to-chromosome mappings,
+// it formats the HGVS notation either as 'chr3:g.70970756G>A' or '3:g.70970756G>A',
+// depending on whether the 'chr' optional argument is set to true.
+//
+// The 'chr3:g.70970756G>A' format is for myvariant.info that uses GRCh37 assembly.
+// The '3:g.70970756G>A' format is for Ensembl VEP that uses GRCh38 assembly. Due to the
+// presence of 'chrX' and 'chrY' chromosome, substr method is used instead of filtering
+// alpha letters.
+
+'use strict';
+var genomic_chr_mapping = require('./interpretation/mapping/NC_genomic_chr_format.json');
+
+const getHgvsNotation = function (variant, assembly, omitChrString) {
+    let hgvs;
+    let nc;
+    let ncGenomic;
+    let match;
+
+    if (assembly === 'GRCh37' && variant.hgvsNames.GRCh37) {
+        nc = variant.hgvsNames.GRCh37;
+    } else if (assembly === 'GRCh38' && variant.hgvsNames.GRCh38) {
+        nc = variant.hgvsNames.GRCh38;
+    }
+
+    ncGenomic = nc.substr(0, nc.indexOf(':'));
+    match = genomic_chr_mapping[assembly].find((entry) => entry.GenomicRefSeq === ncGenomic);
+
+    if (match) {
+        if (omitChrString) {
+            let chromosome = match.ChrFormat.substr(3);
+            hgvs = chromosome + nc.slice(nc.indexOf(':'));
+        } else {
+            hgvs = match.ChrFormat + nc.slice(nc.indexOf(':'));
+        }
+    }
+
+    if (hgvs && hgvs.indexOf('del') > 0) {
+        hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
+    }
+
+    return hgvs;
+};
+
+module.exports = getHgvsNotation;

--- a/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
+++ b/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
@@ -1,49 +1,44 @@
 // # HGVS Notation Helper: Getter Method
 // # Parameters: variant object, assembly (GRCh37 or GRCh38), optional boolean value
 // # Usage: getHgvsNotation(variant, 'GRCh38', true)
-//
-// This method extracts the genomic substring from HGVS name whose assembly is
-// either GRCh37 or GRCh38. By looking up the genomic-to-chromosome mappings,
-// it formats the HGVS notation either as 'chr3:g.70970756G>A' or '3:g.70970756G>A',
-// depending on whether the 'chr' optional argument is set to true.
-//
-// The 'chr3:g.70970756G>A' format is for myvariant.info that uses GRCh37 assembly.
-// The '3:g.70970756G>A' format is for Ensembl VEP that uses GRCh38 assembly. Due to the
-// presence of 'chrX' and 'chrY' chromosome, substr method is used instead of filtering
-// alpha letters.
 
 'use strict';
-var genomic_chr_mapping = require('./interpretation/mapping/NC_genomic_chr_format.json');
+var genomic_chr_mapping = require('../interpretation/mapping/NC_genomic_chr_format.json');
 
-const getHgvsNotation = function (variant, assembly, omitChrString) {
-    let hgvs;
-    let nc;
-    let ncGenomic;
-    let match;
+export function getHgvsNotation(variant, assembly, omitChrString) {
+    let hgvs,
+        genomicHGVS;
 
     if (assembly === 'GRCh37' && variant.hgvsNames.GRCh37) {
-        nc = variant.hgvsNames.GRCh37;
+        genomicHGVS = variant.hgvsNames.GRCh37;
     } else if (assembly === 'GRCh38' && variant.hgvsNames.GRCh38) {
-        nc = variant.hgvsNames.GRCh38;
+        genomicHGVS = variant.hgvsNames.GRCh38;
     }
 
-    ncGenomic = nc.substr(0, nc.indexOf(':'));
-    match = genomic_chr_mapping[assembly].find((entry) => entry.GenomicRefSeq === ncGenomic);
+    // Extract the NC genomic substring from the HGVS name whose assembly is
+    // either GRCh37 or GRCh38. By looking up the genomic-to-chromosome mappings,
+    // it formats the HGVS notation either as 'chr3:g.70970756G>A' or '3:g.70970756G>A',
+    // depending on whether the 'omitChrString' optional argument is set to true.
+    let ncGenomic = genomicHGVS.substr(0, genomicHGVS.indexOf(':'));
+    let match = genomic_chr_mapping[assembly].find((entry) => entry.GenomicRefSeq === ncGenomic);
 
+    // The 'chr3:g.70970756G>A' format is for myvariant.info that uses GRCh37 assembly.
+    // The '3:g.70970756G>A' format is for Ensembl VEP that uses GRCh38 assembly. Due to the
+    // presence of 'chrX' and 'chrY' chromosome, substr method is used instead of filtering
+    // alpha letters.
     if (match) {
         if (omitChrString) {
             let chromosome = match.ChrFormat.substr(3);
-            hgvs = chromosome + nc.slice(nc.indexOf(':'));
+            hgvs = chromosome + genomicHGVS.slice(genomicHGVS.indexOf(':'));
         } else {
-            hgvs = match.ChrFormat + nc.slice(nc.indexOf(':'));
+            hgvs = match.ChrFormat + genomicHGVS.slice(genomicHGVS.indexOf(':'));
         }
     }
 
+    // Handle deleted genomic HGVS
     if (hgvs && hgvs.indexOf('del') > 0) {
         hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
     }
 
     return hgvs;
-};
-
-module.exports = getHgvsNotation;
+}

--- a/src/clincoded/static/components/variant_central/helpers/primary_transcript.js
+++ b/src/clincoded/static/components/variant_central/helpers/primary_transcript.js
@@ -1,0 +1,22 @@
+// # Primary Transcript Helper: Setter Method
+// # Parameters: data or response object
+// # Usage: setPrimaryTranscript(data)
+// # Dependency: Ensembl HGVS VEP API response
+
+'use strict';
+
+export function setPrimaryTranscript(data) {
+    let transcripts = data[0].transcript_consequences;
+    let primaryTranscript = {};
+
+    // Filter transcripts with 'canonical', 'source' and 'hgvsc' flags
+    transcripts.forEach(transcript => {
+        if (transcript.canonical && transcript.canonical === 1) {
+            if (transcript.source === 'RefSeq' && transcript.hgvsc) {
+                primaryTranscript = transcript;
+            }
+        }
+    });
+
+    return primaryTranscript;
+}

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -13,6 +13,8 @@ var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 var queryKeyValue = globals.queryKeyValue;
 var parseClinvar = require('../../libs/parse-resources').parseClinvar;
+import { getHgvsNotation } from './helpers/hgvs_notation';
+import { setPrimaryTranscript } from './helpers/primary_transcript';
 
 // Variant Curation Hub
 var VariantCurationHub = React.createClass({
@@ -52,33 +54,40 @@ var VariantCurationHub = React.createClass({
             this.setState({variantObj: response});
             this.setState({isLoadingComplete: true});
             // ping out external resources (all async)
-            this.fetchMyVariantInfoAndBustamante();
-            this.fetchEnsemblVEP();
-            this.fetchEnsemblVariation();
-            this.fetchEnsemblHGVSVEP();
-            this.fetchClinVarEutilsEsearch();
+            this.fetchClinVarEutils(this.state.variantObj);
+            this.fetchMyVariantInfoAndBustamante(this.state.variantObj);
+            this.fetchEnsemblVEP(this.state.variantObj);
+            this.fetchEnsemblVariation(this.state.variantObj);
+            this.fetchEnsemblHGVSVEP(this.state.variantObj);
         }).catch(function(e) {
             console.log('FETCH CLINVAR ERROR=: %o', e);
         });
     },
 
-    // Retrieve data from MyVariantInfo and Bustamante data
-    fetchMyVariantInfoAndBustamante: function() {
-        var variant = this.state.variantObj;
+    // Retrieve ClinVar data from Eutils
+    fetchClinVarEutils: function(variant) {
         if (variant) {
-            // Extract genomic substring from HGVS name whose assembly is GRCh37
-            // Both of "GRCh37" and "gRCh37" instances are possibly present in the variant object
-            var hgvs_GRCh37 = (variant.hgvsNames.GRCh37) ? variant.hgvsNames.GRCh37 : variant.hgvsNames.gRCh37;
-            var NC_genomic = hgvs_GRCh37 ? hgvs_GRCh37.substr(0, hgvs_GRCh37.indexOf(':')) : null;
-            // 'genomic_chr_mapping' is defined via requiring external mapping file
-            var found = genomic_chr_mapping.GRCh37.find((entry) => entry.GenomicRefSeq === NC_genomic);
-            // Format variant_id for use of myvariant.info REST API
-            var variant_id = (hgvs_GRCh37 && found) ? found.ChrFormat + hgvs_GRCh37.slice(hgvs_GRCh37.indexOf(':')) : null;
-            if (variant_id && variant_id.indexOf('del') > 0) {
-                variant_id = variant_id.substring(0, variant_id.indexOf('del') + 3);
+            if (variant.clinvarVariantId) {
+                this.setState({clinvar_id: variant.clinvarVariantId});
+                // Get ClinVar data via the parseClinvar method defined in parse-resources.js
+                this.getRestDataXml(this.props.href_url.protocol + external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
+                    // Passing 'true' option to invoke 'mixin' function
+                    // To extract more ClinVar data for 'Basic Information' tab
+                    var variantData = parseClinvar(xml, true);
+                    this.setState({ext_clinvarEutils: variantData});
+                }).catch(function(e) {
+                    console.log('ClinVarEutils Fetch Error=: %o', e);
+                });
             }
-            if (variant_id) {
-                this.getRestData(this.props.href_url.protocol + external_url_map['MyVariantInfo'] + variant_id).then(response => {
+        }
+    },
+
+    // Retrieve data from MyVariantInfo and Bustamante data
+    fetchMyVariantInfoAndBustamante: function(variant) {
+        if (variant) {
+            let hgvs_notation = getHgvsNotation(variant, 'GRCh37');
+            if (hgvs_notation) {
+                this.getRestData(this.props.href_url.protocol + external_url_map['MyVariantInfo'] + hgvs_notation).then(response => {
                     this.setState({ext_myVariantInfo: response});
                     // check dbsnfp data for bustamante query
                     var hgvsObj = {};
@@ -105,8 +114,7 @@ var VariantCurationHub = React.createClass({
     },
 
     // Retrieve data from Ensembl VEP
-    fetchEnsemblVEP: function() {
-        var variant = this.state.variantObj;
+    fetchEnsemblVEP: function(variant) {
         if (variant) {
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
@@ -122,8 +130,7 @@ var VariantCurationHub = React.createClass({
     },
 
     // Retrieve data from Ensembl Variation
-    fetchEnsemblVariation: function() {
-        var variant = this.state.variantObj;
+    fetchEnsemblVariation: function(variant) {
         if (variant) {
             // Extract only the number portion of the dbSNP id
             var numberPattern = /\d+/g;
@@ -141,68 +148,47 @@ var VariantCurationHub = React.createClass({
     },
 
     // Retrieve data from Ensembl HGVS VEP
-    fetchEnsemblHGVSVEP: function() {
-        var variant = this.state.variantObj;
+    fetchEnsemblHGVSVEP: function(variant) {
         if (variant) {
-            // Due to GRCh38 HGVS notations being used at Ensembl for their VEP API
-            // We are extracting genomic substring from HGVS name whose assembly is GRCh38
-            // Both of "GRCh38" and "gRCh38" instances are possibly present in the variant object
-            var hgvs_GRCh38 = (variant.hgvsNames.GRCh38) ? variant.hgvsNames.GRCh38 : variant.hgvsNames.gRCh38;
-            if (hgvs_GRCh38) {
-                var NC_genomic = hgvs_GRCh38.substr(0, hgvs_GRCh38.indexOf(':'));
-                // 'genomic_chr_mapping' is defined via requiring external mapping file
-                var found = genomic_chr_mapping.GRCh38.find((entry) => entry.GenomicRefSeq === NC_genomic);
-                // Can't simply filter alpha letters due to the presence of 'chrX' and 'chrY'
-                var chrosome = (found.ChrFormat) ? found.ChrFormat.substr(3) : '';
-                // Format hgvs_notation for vep/:species/hgvs/:hgvs_notation api
-                var hgvs_notation = chrosome + hgvs_GRCh38.slice(hgvs_GRCh38.indexOf(':'));
-                if (hgvs_notation) {
-                    if (hgvs_notation.indexOf('del') > 0) {
-                        hgvs_notation = hgvs_notation.substring(0, hgvs_notation.indexOf('del') + 3);
-                    }
-                    this.getRestData(this.props.href_url.protocol + external_url_map['EnsemblHgvsVEP'] + hgvs_notation + '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&domains=1').then(response => {
-                        this.setState({ext_ensemblHgvsVEP: response});
-                    }).catch(function(e) {
-                        console.log('Ensembl Fetch Error=: %o', e);
-                    });
-                }
+            let hgvs_notation = getHgvsNotation(variant, 'GRCh38', true);
+            let request_params = '?content-type=application/json&hgvs=1&protein=1&xref_refseq=1&ExAC=1&MaxEntScan=1&GeneSplicer=1&Conservation=1&numbers=1&domains=1&canonical=1&merged=1';
+            if (hgvs_notation) {
+                this.getRestData(this.props.href_url.protocol + external_url_map['EnsemblHgvsVEP'] + hgvs_notation + request_params).then(response => {
+                    this.setState({ext_ensemblHgvsVEP: response});
+                    this.handleCodonEsearch(response);
+                }).catch(function(e) {
+                    console.log('Ensembl Fetch Error=: %o', e);
+                });
             }
         }
     },
 
-    // Retrieve data from ClinVar Eutils and Esearch
-    fetchClinVarEutilsEsearch: function() {
-        var variant = this.state.variantObj;
-        if (variant) {
-            if (variant.clinvarVariantId) {
-                this.setState({clinvar_id: variant.clinvarVariantId});
-                // Get ClinVar data via the parseClinvar method defined in parse-resources.js
-                this.getRestDataXml(this.props.href_url.protocol + external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
-                    // Passing 'true' option to invoke 'mixin' function
-                    // To extract more ClinVar data for 'Basic Information' tab
-                    var variantData = parseClinvar(xml, true);
-                    this.setState({ext_clinvarEutils: variantData});
-                    var clinVarObj = {};
-                    clinVarObj.protein_change = variantData.allele.ProteinChange;
-                    clinVarObj.gene_symbol = variantData.gene.symbol;
-                    if (clinVarObj) {
-                        return Promise.resolve(clinVarObj);
-                    }
-                }).then(clinvar => {
-                    if (clinvar.protein_change && clinvar.gene_symbol) {
-                        var term = clinvar.protein_change.substr(0, clinvar.protein_change.length-1);
-                        var symbol = clinvar.gene_symbol;
-                        this.getRestData(this.props.href_url.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
-                            // pass in these additional values, in case receiving component needs them
-                            result.vci_term = term;
-                            result.vci_symbol = symbol;
-                            this.setState({ext_clinVarEsearch: result});
-                        });
-                    }
-                }).catch(function(e) {
-                    console.log('ClinVarEutils or ClinVarEsearch Fetch Error=: %o', e);
-                });
+    // Retrieve codon data from ClinVar Esearch given Ensembl VEP response
+    handleCodonEsearch: function(response) {
+        let primaryTranscript = setPrimaryTranscript(response);
+        if (primaryTranscript) {
+            let amino_acid = '',
+                term = null;
+            // Get amino acid
+            if (primaryTranscript.amino_acids) {
+                let amino_acids = primaryTranscript.amino_acids;
+                amino_acid = amino_acids.substr(0, amino_acids.indexOf('/'));
             }
+            // Get protein location
+            let protein_start = (primaryTranscript.protein_start) ? primaryTranscript.protein_start : null;
+            // Construct NCBI Esearch query
+            if (amino_acid.length && protein_start) {
+                term = amino_acid + protein_start;
+            }
+            let symbol = primaryTranscript.gene_symbol;
+            this.getRestData(this.props.href_url.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+                // pass in these additional values, in case receiving component needs them
+                result.vci_term = term;
+                result.vci_symbol = symbol;
+                this.setState({ext_clinVarEsearch: result});
+            }).catch(function(e) {
+                console.log('ClinVarEsearch Fetch Error=: %o', e);
+            });
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -1,7 +1,5 @@
 'use strict';
 var React = require('react');
-var _ = require('underscore');
-var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
@@ -369,28 +367,28 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 if (parseInt(codon.count) > 1) {
                     return (
                         <dl className="inline-dl clearfix">
-                            <dt>Number of other variants in codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
-                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
+                            <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
+                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
                         </dl>
                     );
                 } else {
                     return (
                         <dl className="inline-dl clearfix">
-                            <dd>Current variant is the only variant found at this codon in ClinVar.</dd>
+                            <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
                         </dl>
                     );
                 }
             } else {
                 return (
                     <dl className="inline-dl clearfix">
-                        <dd>ClinVar variant with no codon data. Search is unavailable.</dd>
+                        <dd>This ClinVar variant is in a non-coding region.</dd>
                     </dl>
                 );
             }
         } else {
             return (
                 <dl className="inline-dl clearfix">
-                    <dd>Non-ClinVar variant. Search is unavailable.</dd>
+                    <dd>ClinVar search for this variant is currently not available. <span className="wip">IN PROGRESS</span></dd>
                 </dl>
             );
         }

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -277,34 +277,47 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     },
 
     // Method to temporarily render other variant count in same codon and link out to clinvar
-    renderVariantCodon: function(codon) {
-        if (codon.term) {
-            if (codon.count > 0) {
-                if (codon.count > 1) {
-                    return (
-                        <dl className="inline-dl clearfix">
-                            <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
-                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
-                        </dl>
-                    );
+    renderVariantCodon: function(variant, codon) {
+        if (variant && variant.clinvarVariantId) {
+            if (codon.term) {
+                if (codon.count > 0) {
+                    if (codon.count > 1) {
+                        // Esearch returns more than 1 counts from ClinVar
+                        return (
+                            <dl className="inline-dl clearfix">
+                                <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{codon.count-1}</span></dt>
+                                <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
+                            </dl>
+                        );
+                    } else {
+                        // Esearch returns 1 count from ClinVar
+                        return (
+                            <dl className="inline-dl clearfix">
+                                <dd>The current variant is the only variant found in this codon in ClinVar.</dd>
+                            </dl>
+                        );
+                    }
                 } else {
+                    // Esearch returns 0 count from ClinVar
                     return (
                         <dl className="inline-dl clearfix">
-                            <dd>The current variant is the only variant found in this codon in ClinVar.</dd>
+                            <dd>No variants have been found in this codon in ClinVar.</dd>
                         </dl>
                     );
                 }
             } else {
+                // Variant exists in ClinVar but has no <ProteinChange> data (e.g. amino acid, location)
                 return (
                     <dl className="inline-dl clearfix">
-                        <dd>No variants have been found in this codon in ClinVar.</dd>
+                        <dd>The current variant is in a non-coding region.</dd>
                     </dl>
                 );
             }
         } else {
+            // Variant does not exist in ClinVar
             return (
                 <dl className="inline-dl clearfix">
-                    <dd>The current variant is in a non-coding region.</dd>
+                    <dd>ClinVar search for this variant is currently not available.</dd>
                 </dl>
             );
         }
@@ -545,7 +558,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
-                            {this.renderVariantCodon(codon)}
+                            {this.renderVariantCodon(variant, codon)}
                         </div>
                     </div>
                     {(this.props.data && this.state.interpretation) ?

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -290,14 +290,14 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 } else {
                     return (
                         <dl className="inline-dl clearfix">
-                            <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
+                            <dd>The current variant is the only variant found in this codon in ClinVar.</dd>
                         </dl>
                     );
                 }
             } else {
                 return (
                     <dl className="inline-dl clearfix">
-                        <dd>No variants have been found at this codon in ClinVar.</dd>
+                        <dd>No variants have been found in this codon in ClinVar.</dd>
                     </dl>
                 );
             }

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -350,23 +350,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         );
     },
 
-    // Method to map prediction names to their letter codes
-    mapPredictionName: function(pred) {
-        var name = '';
-        let predictionNames = {
-            'B': 'B(enign)',
-            'D': 'D(amaging)',
-            'N': 'N(eutral)',
-            'T': 'T(olerated)'
-        };
-        for (let key in predictionNames) {
-            if (key === pred) {
-                name = predictionNames[key];
-            }
-        }
-        return name;
-    },
-
     // method to render a row of data for the conservation analysis table
     renderConservationRow: function(key, conservation, conservationStatic) {
         let rowName = conservationStatic._labels[key];

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -379,6 +379,40 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         );
     },
 
+    // Method to temporarily render other variant count in same codon and link out to clinvar
+    renderVariantCodon: function(variant, codon, hasClinVarData) {
+        if (variant && variant.clinvarVariantId) {
+            if (codon && hasClinVarData) {
+                if (parseInt(codon.count) > 1) {
+                    return (
+                        <dl className="inline-dl clearfix">
+                            <dt>Number of other variants in codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
+                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
+                        </dl>
+                    );
+                } else {
+                    return (
+                        <dl className="inline-dl clearfix">
+                            <dd>Current variant is the only variant found at this codon in ClinVar.</dd>
+                        </dl>
+                    );
+                }
+            } else {
+                return (
+                    <dl className="inline-dl clearfix">
+                        <dd>ClinVar variant with no codon data. Search is unavailable.</dd>
+                    </dl>
+                );
+            }
+        } else {
+            return (
+                <dl className="inline-dl clearfix">
+                    <dd>Non-ClinVar variant. Search is unavailable.</dd>
+                </dl>
+            );
+        }
+    },
+
     render: function() {
         var conservationStatic = computationStatic.conservation, otherPredStatic = computationStatic.other_predictors, clingenPredStatic = computationStatic.clingen;
         var conservation = (this.state.computationObj && this.state.computationObj.conservation) ? this.state.computationObj.conservation : null;
@@ -639,16 +673,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
-                            {this.state.hasClinVarData && codon ?
-                                <dl className="inline-dl clearfix">
-                                    <dt>Number of variants in codon: <span className="condon-variant-count">{codon.count}</span></dt>
-                                    <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">See data in ClinVar <i className="icon icon-external-link"></i></a>)</dd>
-                                </dl>
-                            :
-                                <dl className="inline-dl clearfix">
-                                    <dd>No ClinVar data was found for this variant.</dd>
-                                </dl>
-                            }
+                            {this.renderVariantCodon(variant, codon, this.state.hasClinVarData)}
                         </div>
                     </div>
                     {(this.props.data && this.state.interpretation) ?

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -112,7 +112,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         }
         if (nextProps.ext_clinVarEsearch) {
             var codonObj = {};
-            codonObj.count = nextProps.ext_clinVarEsearch.esearchresult.count;
+            codonObj.count = parseInt(nextProps.ext_clinVarEsearch.esearchresult.count);
             codonObj.term = nextProps.ext_clinVarEsearch.vci_term;
             codonObj.symbol = nextProps.ext_clinVarEsearch.vci_symbol;
             this.setState({codonObj: codonObj});
@@ -279,8 +279,8 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     // Method to temporarily render other variant count in same codon and link out to clinvar
     renderVariantCodon: function(codon) {
         if (codon.term) {
-            if (parseInt(codon.count < 1)) {
-                if (parseInt(codon.count) > 1) {
+            if (codon.count > 0) {
+                if (codon.count > 1) {
                     return (
                         <dl className="inline-dl clearfix">
                             <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -278,18 +278,26 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
     // Method to temporarily render other variant count in same codon and link out to clinvar
     renderVariantCodon: function(codon) {
-        if (codon.count > 0 && codon.term) {
-            if (parseInt(codon.count) > 1) {
-                return (
-                    <dl className="inline-dl clearfix">
-                        <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
-                        <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
-                    </dl>
-                );
+        if (codon.term) {
+            if (parseInt(codon.count < 1)) {
+                if (parseInt(codon.count) > 1) {
+                    return (
+                        <dl className="inline-dl clearfix">
+                            <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
+                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
+                        </dl>
+                    );
+                } else {
+                    return (
+                        <dl className="inline-dl clearfix">
+                            <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
+                        </dl>
+                    );
+                }
             } else {
                 return (
                     <dl className="inline-dl clearfix">
-                        <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
+                        <dd>No variants have been found at this codon in ClinVar.</dd>
                     </dl>
                 );
             }

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -71,7 +71,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             interpretation: this.props.interpretation,
             hasConservationData: false,
             hasOtherPredData: false,
-            hasClinVarData: false,
             hasBustamanteData: false,
             codonObj: {},
             computationObj: {
@@ -116,7 +115,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             codonObj.count = nextProps.ext_clinVarEsearch.esearchresult.count;
             codonObj.term = nextProps.ext_clinVarEsearch.vci_term;
             codonObj.symbol = nextProps.ext_clinVarEsearch.vci_symbol;
-            this.setState({hasClinVarData: true, codonObj: codonObj});
+            this.setState({codonObj: codonObj});
         }
     },
 
@@ -124,7 +123,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         this.setState({
             hasConservationData: false,
             hasOtherPredData: false,
-            hasClinVarData: false,
             hasBustamanteData: false
         });
     },
@@ -279,34 +277,26 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     },
 
     // Method to temporarily render other variant count in same codon and link out to clinvar
-    renderVariantCodon: function(variant, codon, hasClinVarData) {
-        if (variant && variant.clinvarVariantId) {
-            if (codon && hasClinVarData) {
-                if (parseInt(codon.count) > 1) {
-                    return (
-                        <dl className="inline-dl clearfix">
-                            <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
-                            <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
-                        </dl>
-                    );
-                } else {
-                    return (
-                        <dl className="inline-dl clearfix">
-                            <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
-                        </dl>
-                    );
-                }
+    renderVariantCodon: function(codon) {
+        if (codon.count > 0 && codon.term) {
+            if (parseInt(codon.count) > 1) {
+                return (
+                    <dl className="inline-dl clearfix">
+                        <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{parseInt(codon.count)-1}</span></dt>
+                        <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
+                    </dl>
+                );
             } else {
                 return (
                     <dl className="inline-dl clearfix">
-                        <dd>This ClinVar variant is in a non-coding region.</dd>
+                        <dd>The current variant is the only variant found at this codon in ClinVar.</dd>
                     </dl>
                 );
             }
         } else {
             return (
                 <dl className="inline-dl clearfix">
-                    <dd>ClinVar search for this variant is currently not available. <span className="wip">IN PROGRESS</span></dd>
+                    <dd>The current variant is in a non-coding region.</dd>
                 </dl>
             );
         }
@@ -435,144 +425,119 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             <table className="table">
                                 <thead>
                                     <tr>
-                                        <td>No predictors were found for this allele.</td>
+                                        <td>No conservation analysis data was found for this allele.</td>
                                     </tr>
                                 </thead>
                             </table>
                         </div>
                     }
 
-                    {this.state.hasConservationData ?
-                        <div className="panel panel-info datasource-splice">
-                            <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
-                            <div className="panel-body">
-                                <span className="pull-right">
-                                    <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">See data in MaxEntScan <i className="icon icon-external-link"></i></a>
-                                    <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">See data in NNSPLICE <i className="icon icon-external-link"></i></a>
-                                    <a href="http://www.cbcb.umd.edu/software/GeneSplicer/gene_spl.shtml" target="_blank">See data in GeneSplicer <i className="icon icon-external-link"></i></a>
-                                    <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">See data in HumanSplicingFinder <i className="icon icon-external-link"></i></a>
-                                </span>
-                            </div>
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <th>Source</th>
-                                        <th>5' or 3'</th>
-                                        <th>Score Range</th>
-                                        <th>Score</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <th colSpan="4">WT Sequence</th>
-                                    </tr>
-                                    <tr>
-                                        <td>MaxEntScan</td>
-                                        <td rowSpan="2" className="row-span">5'</td>
-                                        <td>[0-12]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>NNSPLICE</td>
-                                        <td>[0-1]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>MaxEntScan</td>
-                                        <td rowSpan="2" className="row-span">3'</td>
-                                        <td>[0-16]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>NNSPLICE</td>
-                                        <td>[0-1]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <th colSpan="4">Variant Sequence</th>
-                                    </tr>
-                                    <tr>
-                                        <td>MaxEntScan</td>
-                                        <td rowSpan="2" className="row-span">5'</td>
-                                        <td>[0-12]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>NNSPLICE</td>
-                                        <td>[0-1]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>MaxEntScan</td>
-                                        <td rowSpan="2" className="row-span">3'</td>
-                                        <td>[0-16]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>NNSPLICE</td>
-                                        <td>[0-1]</td>
-                                        <td><span className="wip">IN PROGRESS</span></td>
-                                    </tr>
-                                </tbody>
-                                <tfoot>
-                                    <tr>
-                                        <td colSpan="4">Average Change to Nearest Splice Site: <span className="splice-avg-change wip">IN PROGRESS</span></td>
-                                    </tr>
-                                </tfoot>
-                            </table>
+                    <div className="panel panel-info datasource-splice">
+                        <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
+                        <div className="panel-body">
+                            <span className="pull-right">
+                                <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">See data in MaxEntScan <i className="icon icon-external-link"></i></a>
+                                <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">See data in NNSPLICE <i className="icon icon-external-link"></i></a>
+                                <a href="http://www.cbcb.umd.edu/software/GeneSplicer/gene_spl.shtml" target="_blank">See data in GeneSplicer <i className="icon icon-external-link"></i></a>
+                                <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">See data in HumanSplicingFinder <i className="icon icon-external-link"></i></a>
+                            </span>
                         </div>
-                    :
-                        <div className="panel panel-info datasource-splice">
-                            <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <td>No predictions were found for this allele.</td>
-                                    </tr>
-                                </thead>
-                            </table>
-                        </div>
-                    }
+                        <table className="table">
+                            <thead>
+                                <tr>
+                                    <th>Source</th>
+                                    <th>5' or 3'</th>
+                                    <th>Score Range</th>
+                                    <th>Score</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th colSpan="4">WT Sequence</th>
+                                </tr>
+                                <tr>
+                                    <td>MaxEntScan</td>
+                                    <td rowSpan="2" className="row-span">5'</td>
+                                    <td>[0-12]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>NNSPLICE</td>
+                                    <td>[0-1]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>MaxEntScan</td>
+                                    <td rowSpan="2" className="row-span">3'</td>
+                                    <td>[0-16]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>NNSPLICE</td>
+                                    <td>[0-1]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <th colSpan="4">Variant Sequence</th>
+                                </tr>
+                                <tr>
+                                    <td>MaxEntScan</td>
+                                    <td rowSpan="2" className="row-span">5'</td>
+                                    <td>[0-12]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>NNSPLICE</td>
+                                    <td>[0-1]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>MaxEntScan</td>
+                                    <td rowSpan="2" className="row-span">3'</td>
+                                    <td>[0-16]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                                <tr>
+                                    <td>NNSPLICE</td>
+                                    <td>[0-1]</td>
+                                    <td><span className="wip">IN PROGRESS</span></td>
+                                </tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <td colSpan="4">Average Change to Nearest Splice Site: <span className="splice-avg-change wip">IN PROGRESS</span></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
 
-                    {this.state.hasConservationData ?
-                        <div className="panel panel-info datasource-additional">
-                            <div className="panel-heading"><h3 className="panel-title">Additional Information</h3></div>
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <th>Distance to nearest splice site</th>
-                                        <th><span className="wip">IN PROGRESS</span></th>
-                                    </tr>
-                                    <tr>
-                                        <th>Exon location</th>
-                                        <th><span className="wip">IN PROGRESS</span></th>
-                                    </tr>
-                                    <tr>
-                                        <th>Distance of truncation mutation from end of last exon</th>
-                                        <th><span className="wip">IN PROGRESS</span></th>
-                                    </tr>
-                                </thead>
-                            </table>
-                        </div>
-                    :
-                        <div className="panel panel-info datasource-additional">
-                            <div className="panel-heading"><h3 className="panel-title">Additional Information</h3></div>
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <td>No additional information was found for this allele.</td>
-                                    </tr>
-                                </thead>
-                            </table>
-                        </div>
-                    }
+                    <div className="panel panel-info datasource-additional">
+                        <div className="panel-heading"><h3 className="panel-title">Additional Information</h3></div>
+                        <table className="table">
+                            <thead>
+                                <tr>
+                                    <th>Distance to nearest splice site</th>
+                                    <th><span className="wip">IN PROGRESS</span></th>
+                                </tr>
+                                <tr>
+                                    <th>Exon location</th>
+                                    <th><span className="wip">IN PROGRESS</span></th>
+                                </tr>
+                                <tr>
+                                    <th>Distance of truncation mutation from end of last exon</th>
+                                    <th><span className="wip">IN PROGRESS</span></th>
+                                </tr>
+                            </thead>
+                        </table>
+                    </div>
+
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
                     <div className="panel panel-info datasource-clinvar">
                         <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                         <div className="panel-body">
-                            {this.renderVariantCodon(variant, codon, this.state.hasClinVarData)}
+                            {this.renderVariantCodon(codon)}
                         </div>
                     </div>
                     {(this.props.data && this.state.interpretation) ?


### PR DESCRIPTION
This PR consists of changes pertinent to the handling of UI display in the variant codon table on the computational tab.

**Technical details:**
1. Abstracted the repetitive code from index.js and created a helper method to get HGVS notation in the formats required by either myvariant.info or Ensembl VEP.
2. Created a helper method to set the primary transcript based on the logical filtering of properties such as 'canonical', 'source' and 'hgvsc' in the Ensembl VEP response.
3. Added '&canonical=1&merged=1' params to Ensembl VEP API request to expose **canonical** flags and **RefSeq** transcripts in response.
4. Decoupled the Eutils/Esearch combo fetch method since the Esearch method for codon data relies on Ensembl VEP response going forward.
5. Updated the handling of UI display in the variant codon table given different test cases.

**Steps to test:**
Via the variant selection interface, try the following example IDs. Verify the expected display given the different test cases.

Test case 1 - Variant does not exist in ClinVar.
Expected display - **ClinVar search for this variant is currently not available.**
Example IDs: CA501097, CA501096, CA501104

Test case 2 - Protein change data, such as amino acid and/or location, not found in ClinVar.
Expected display - **The current variant is in a non-coding region.**
Example IDs: 139214, CA003323

Test case 3 - Has protein change, but ClinVar response returns count of 0.
Expected display - **No variants have been found at this codon in ClinVar.**
Example IDs: 

Test case 4 - Has protein change, and ClinVar response returns count of 1.
Expected display - **The current variant is the only variant found at this codon in ClinVar.**
Example IDs: 55847, 35824

Test case 5 - Has protein change, and ClinVar response returns count of more than 1. 
Expected display - **Additional ClinVar variants found in the same codon: count (Search ClinVar for variants in this codon)**
Example IDs: 35816, 53423