### PR TITLE
Connects to #846. Connects to #885.

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -195,6 +195,7 @@ module.exports.external_url_map = {
     'EXAC': '//exac.broadinstitute.org/variant/',
     'EXACHome': 'http://exac.broadinstitute.org/',
     'ExACGene': 'http://exac.broadinstitute.org/gene/',
+    'ExACRegion': 'http://exac.broadinstitute.org/region/',
     'ESPHome': 'http://evs.gs.washington.edu/EVS/',
     '1000GenomesHome': 'http://browser.1000genomes.org/',
     'mutalyzer': 'https://mutalyzer.nl/',

--- a/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
+++ b/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
@@ -7,7 +7,9 @@ var genomic_chr_mapping = require('../interpretation/mapping/NC_genomic_chr_form
 
 export function getHgvsNotation(variant, assembly, omitChrString) {
     let hgvs,
-        genomicHGVS;
+        genomicHGVS,
+        ncGenomic,
+        match;
 
     if (assembly === 'GRCh37' && variant.hgvsNames.GRCh37) {
         genomicHGVS = variant.hgvsNames.GRCh37;
@@ -19,8 +21,10 @@ export function getHgvsNotation(variant, assembly, omitChrString) {
     // either GRCh37 or GRCh38. By looking up the genomic-to-chromosome mappings,
     // it formats the HGVS notation either as 'chr3:g.70970756G>A' or '3:g.70970756G>A',
     // depending on whether the 'omitChrString' optional argument is set to true.
-    let ncGenomic = genomicHGVS.substr(0, genomicHGVS.indexOf(':'));
-    let match = genomic_chr_mapping[assembly].find((entry) => entry.GenomicRefSeq === ncGenomic);
+    if (genomicHGVS) {
+        ncGenomic = genomicHGVS.substr(0, genomicHGVS.indexOf(':'));
+        match = genomic_chr_mapping[assembly].find((entry) => entry.GenomicRefSeq === ncGenomic);
+    }
 
     // The 'chr3:g.70970756G>A' format is for myvariant.info that uses GRCh37 assembly.
     // The '3:g.70970756G>A' format is for Ensembl VEP that uses GRCh38 assembly. Due to the

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -91,6 +91,22 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         });
     },
 
+    componentDidUpdate: function(prevProps, prevState) {
+        // Finds all hgvs terms in tables and
+        // sets 'title' and 'class' attributes
+        // if text overflows
+        let nodeList = document.querySelectorAll('.hgvs-term span');
+        let hgvsNodes = Array.from(nodeList);
+        if (hgvsNodes) {
+            hgvsNodes.forEach(node => {
+                if (node.offsetWidth < node.scrollWidth) {
+                    node.setAttribute('title', node.innerHTML);
+                    node.className += ' dotted';
+                }
+            });
+        }
+    },
+
     parseData: function(variant) {
         if (variant.clinvarVariantId) {
             this.setState({clinvar_id: variant.clinvarVariantId});
@@ -180,7 +196,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (item.hgvsc && item.source === source) {
             return (
                 <tr key={key} className={(item.canonical && item.canonical === 1) ? 'primary-transcript' : null}>
-                    <td><span className="title-ellipsis" title={item.hgvsc}>{item.hgvsc}</span></td>
+                    <td className="hgvs-term"><span className="title-ellipsis">{item.hgvsc}</span></td>
                     <td>{(item.exon) ? item.exon : '--'}</td>
                     <td>{(item.hgvsp) ? item.hgvsp : '--'}</td>
                     <td className="clearfix">
@@ -356,8 +372,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="bs-callout-content-container-fullwidth">
                         <h4>Genomic</h4>
                         <ul>
-                            {(GRCh38) ? <li><span className="title-ellipsis title-ellipsis-short">{GRCh38}</span><span> (GRCh38)</span></li> : null}
-                            {(GRCh37) ? <li><span className="title-ellipsis title-ellipsis-short">{GRCh37}</span><span> (GRCh37)</span></li> : null}
+                            {(GRCh38) ? <li className="hgvs-term"><span className="title-ellipsis title-ellipsis-short">{GRCh38}</span><span> (GRCh38)</span></li> : null}
+                            {(GRCh37) ? <li className="hgvs-term"><span className="title-ellipsis title-ellipsis-short">{GRCh37}</span><span> (GRCh37)</span></li> : null}
                         </ul>
                     </div>
                 </div>
@@ -399,7 +415,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>
+                                    <td className="hgvs-term">
                                         <span className="title-ellipsis">{(primary_transcript) ? primary_transcript.nucleotide : '--'}</span>
                                     </td>
                                     <td>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -134,25 +134,25 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     SO_id_term = found.SO_term + ' ' + found.SO_id;
                 }
             }
-            // Find RefSeq transcript (from VEP) whose nucleotide HGVS matches ClinVar's
-            // and map the Exon and Protein HGVS of the found RefSeq transcript to ClinVar
-            // Filter RefSeq transcripts by 'source' and 'hgvsc' flags
-            ensemblTranscripts.forEach(refseqTranscript => {
-                if (refseqTranscript.source === 'RefSeq') {
-                    if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === result.HGVS) {
-                        exon = refseqTranscript.exon ? refseqTranscript.exon : '--';
-                        protein_hgvs = refseqTranscript.hgvsp ? refseqTranscript.hgvsp : '--';
-                    }
-                }
-            });
-            // Set transcript object properties
-            transcript = {
-                "nucleotide": result.HGVS,
-                "exon": exon,
-                "protein": protein_hgvs,
-                "molecular": SO_id_term
-            };
         }
+        // Find RefSeq transcript (from VEP) whose nucleotide HGVS matches ClinVar's
+        // and map the Exon and Protein HGVS of the found RefSeq transcript to ClinVar
+        // Filter RefSeq transcripts by 'source' and 'hgvsc' flags
+        ensemblTranscripts.forEach(refseqTranscript => {
+            if (refseqTranscript.source === 'RefSeq') {
+                if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === result.HGVS) {
+                    exon = refseqTranscript.exon ? refseqTranscript.exon : '--';
+                    protein_hgvs = refseqTranscript.hgvsp ? refseqTranscript.hgvsp : '--';
+                }
+            }
+        });
+        // Set transcript object properties
+        transcript = {
+            "nucleotide": result.HGVS,
+            "exon": exon,
+            "protein": protein_hgvs,
+            "molecular": SO_id_term
+        };
         this.setState({primary_transcript: transcript});
     },
 
@@ -332,7 +332,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             links_37 = externalLinks.setContextLinks(GRCh37, 'GRCh37');
         }
 
-
         return (
             <div className="variant-interpretation basic-info">
                 <div className="bs-callout bs-callout-info clearfix">
@@ -425,7 +424,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </tbody>
                         </table>
                         :
-                        <table className="table"><tbody><tr><td>No data was found for this allele in RefSeq. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
+                        <table className="table"><tbody><tr><td>No data was found for this allele in RefSeq. <a href="http://www.ncbi.nlm.nih.gov/refseq/" target="_blank">Search RefSeq</a> for this variant.</td></tr></tbody></table>
                     }
                 </div>
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -92,9 +92,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     componentDidUpdate: function(prevProps, prevState) {
-        // Finds all hgvs terms in tables and
-        // sets 'title' and 'class' attributes
-        // if text overflows
+        // Finds all hgvs terms in <li> and <td> nodes
+        // Then sets 'title' and 'class' attributes if text overflows
         let nodeList = document.querySelectorAll('.hgvs-term span');
         let hgvsNodes = Array.from(nodeList);
         if (hgvsNodes) {

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -346,7 +346,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info datasource-clinvar-interpretaions">
                     <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretations</h3></div>
-                    {(clinVarRCV) ?
+                    {(clinVarRCV.length > 0) ?
                         <table className="table">
                             <thead>
                                 <tr>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -28,7 +28,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         return {
             clinvar_id: null, // ClinVar ID
             car_id: null, // ClinGen Allele Registry ID
-            clinvar_hgvs_names: [],
             dbSNP_id: null,
             nucleotide_change: [],
             molecular_consequence: [],
@@ -103,7 +102,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     parseClinVarEutils: function(variantData) {
         this.setState({
             hasRefseqData: true,
-            clinvar_hgvs_names: this.parseHgvsNames(variantData.hgvsNames),
             nucleotide_change: variantData.RefSeqTranscripts.NucleotideChangeList,
             protein_change: variantData.RefSeqTranscripts.ProteinChangeList,
             molecular_consequence: variantData.RefSeqTranscripts.MolecularConsequenceList,
@@ -115,17 +113,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // Calling method to identify nucleotide change, protein change and molecular consequence
         // Used for UI display in the Primary Transcript table
         this.getPrimaryTranscript(variantData.clinvarVariantTitle, variantData.RefSeqTranscripts.NucleotideChangeList, variantData.RefSeqTranscripts.MolecularConsequenceList);
-    },
-
-    // Return all non NC_ genomic hgvsNames in an array
-    parseHgvsNames: function(hgvsNames) {
-        var hgvs_names = [];
-        if (hgvsNames) {
-            if (hgvsNames.others) {
-                hgvs_names = hgvsNames.others;
-            }
-        }
-        return hgvs_names;
     },
 
     // Create ClinVar primary transcript object
@@ -333,7 +320,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var GRCh37 = this.state.hgvs_GRCh37;
         var GRCh38 = this.state.hgvs_GRCh38;
         var primary_transcript = this.state.primary_transcript;
-        var clinvar_hgvs_names = this.state.clinvar_hgvs_names;
         var clinVarRCV = this.state.clinVarRCV;
         var self = this;
 
@@ -422,7 +408,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <span className="help-note panel-subtitle pull-right"><i className="icon icon-asterisk"></i> Canonical transcript</span>
                         </h3>
                     </div>
-                    {(clinvar_id && clinvar_hgvs_names) ?
+                    {(this.state.hasHgvsGRCh38 && GRCh38) ?
                         <table className="table">
                             <thead>
                                 <tr>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -66,6 +66,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             geneENSG: null,
             CILow: null,
             CIhigh: null,
+            exacVariantLink: null,
             populationObj: {
                 highestMAF: null,
                 desiredCI: 95,
@@ -186,6 +187,32 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             populationObj.exac._extra.alt = response.exac.alt;
             // update populationObj, and set flag indicating that we have ExAC data
             this.setState({hasExacData: true, populationObj: populationObj});
+        } else {
+            let chrom = response.chrom,
+                pos = response.hg19.start,
+                regionStart = parseInt(response.hg19.start) - 30,
+                regionEnd = parseInt(response.hg19.end) + 30,
+                exacVariantLink;
+            if (response.clinvar) {
+                // Try 'clinvar' as primary data object
+                let clinvar = response.clinvar;
+                // Applies to substitution variant (e.g. C>T in which '>' means 'changes to')
+                if (clinvar.type && clinvar.type === 'single nucleotide variant') {
+                    exacVariantLink = 'http://exac.broadinstitute.org/variant/' + chrom + '-' + pos + '-' + clinvar.ref + '-' + clinvar.alt;
+                } else {
+                    // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
+                    exacVariantLink = 'http://exac.broadinstitute.org/region/' + chrom + '-' + regionStart + '-' + regionEnd;
+                }
+            } else if (response.cadd) {
+                // Fallback to 'cadd' as alternative data object
+                let cadd = response.cadd;
+                if (cadd.type && cadd.type === 'SNV') {
+                    exacVariantLink = 'http://exac.broadinstitute.org/variant/' + chrom + '-' + pos + '-' + cadd.ref + '-' + cadd.alt;
+                } else {
+                    exacVariantLink = 'http://exac.broadinstitute.org/region/' + chrom + '-' + regionStart + '-' + regionEnd;
+                }
+            }
+            this.setState({exacVariantLink: exacVariantLink});
         }
     },
 
@@ -626,7 +653,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <table className="table">
                                 <thead>
                                     <tr>
-                                        <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']}>Search ExAC</a> for this variant.</th>
+                                        <th>No population data was found for this allele in ExAC. <a href={this.state.exacVariantLink} target="_blank">Search ExAC</a> for this variant.</th>
                                     </tr>
                                 </thead>
                             </table>

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -65,37 +65,41 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.RefSeqTranscripts.ProteinChangeList = [];
     // Parse <MolecularConsequence> nodes
     var MolecularConsequenceList = allele.getElementsByTagName('MolecularConsequenceList')[0];
-    var MolecularConsequence = MolecularConsequenceList.getElementsByTagName('MolecularConsequence');
-    for(let n of MolecularConsequence) {
-        // Used for transcript tables on "Basic Information" tab in VCI
-        // HGVS property for mapping to transcripts with matching HGVS names
-        // SOid and Function properties for UI display
-        var MolecularObj = {
-            "HGVS": n.getAttribute('HGVS'),
-            "SOid": n.getAttribute('SOid'),
-            "Function": n.getAttribute('Function')
-        };
-        variant.RefSeqTranscripts.MolecularConsequenceList.push(MolecularObj);
+    if (MolecularConsequenceList) {
+        var MolecularConsequence = MolecularConsequenceList.getElementsByTagName('MolecularConsequence');
+        for(let n of MolecularConsequence) {
+            // Used for transcript tables on "Basic Information" tab in VCI
+            // HGVS property for mapping to transcripts with matching HGVS names
+            // SOid and Function properties for UI display
+            var MolecularObj = {
+                "HGVS": n.getAttribute('HGVS'),
+                "SOid": n.getAttribute('SOid'),
+                "Function": n.getAttribute('Function')
+            };
+            variant.RefSeqTranscripts.MolecularConsequenceList.push(MolecularObj);
+        }
     }
     // Parse <HGVS> nodes
     var HGVSnodes = hgvs_list.getElementsByTagName('HGVS');
-    for (let x of HGVSnodes) {
-        // Used for transcript tables on "Basic Information" tab in VCI
-        // Type property for identifying the nucleotide change transcripts
-        // and protein change transcripts
-        var hgvsObj = {
-            "HGVS": x.textContent,
-            "Change": x.getAttribute('Change'),
-            "AccessionVersion": x.getAttribute('AccessionVersion'),
-            "Type": x.getAttribute('Type')
-        };
-        // nucleotide change
-        if (x.getAttribute('Type') === 'HGVS, coding, RefSeq') {
-            variant.RefSeqTranscripts.NucleotideChangeList.push(hgvsObj);
-        }
-        // protein change
-        if (x.getAttribute('Type') === 'HGVS, protein, RefSeq') {
-            variant.RefSeqTranscripts.ProteinChangeList.push(hgvsObj);
+    if (HGVSnodes) {
+        for (let x of HGVSnodes) {
+            // Used for transcript tables on "Basic Information" tab in VCI
+            // Type property for identifying the nucleotide change transcripts
+            // and protein change transcripts
+            var hgvsObj = {
+                "HGVS": x.textContent,
+                "Change": x.getAttribute('Change'),
+                "AccessionVersion": x.getAttribute('AccessionVersion'),
+                "Type": x.getAttribute('Type')
+            };
+            // nucleotide change
+            if (x.getAttribute('Type') === 'HGVS, coding, RefSeq') {
+                variant.RefSeqTranscripts.NucleotideChangeList.push(hgvsObj);
+            }
+            // protein change
+            if (x.getAttribute('Type') === 'HGVS, protein, RefSeq') {
+                variant.RefSeqTranscripts.ProteinChangeList.push(hgvsObj);
+            }
         }
     }
     // Parse <gene> node
@@ -107,22 +111,24 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.allele.ProteinChange = protein_change ? protein_change.textContent : null;
     // Parse <SequenceLocation> nodes
     var SequenceLocationNodes = allele.getElementsByTagName('SequenceLocation');
-    for(let y of SequenceLocationNodes) {
-        // Properties in SequenceLocationObj are used to construct LinkOut URLs
-        // Used primarily for LinkOut links on "Basic Information" tab in VCI
-        // referenceAllele and alternateAllele properties are added for Population tab
-        var SequenceLocationObj = {
-            "Assembly": y.getAttribute('Assembly'),
-            "AssemblyAccessionVersion": y.getAttribute('AssemblyAccessionVersion'),
-            "AssemblyStatus": y.getAttribute('AssemblyStatus'),
-            "Chr": y.getAttribute('Chr'),
-            "Accession": y.getAttribute('Accession'),
-            "start": y.getAttribute('start'),
-            "stop": y.getAttribute('stop'),
-            "referenceAllele": y.getAttribute('referenceAllele'),
-            "alternateAllele": y.getAttribute('alternateAllele')
-        };
-        variant.allele.SequenceLocation.push(SequenceLocationObj);
+    if (SequenceLocationNodes) {
+        for(let y of SequenceLocationNodes) {
+            // Properties in SequenceLocationObj are used to construct LinkOut URLs
+            // Used primarily for LinkOut links on "Basic Information" tab in VCI
+            // referenceAllele and alternateAllele properties are added for Population tab
+            var SequenceLocationObj = {
+                "Assembly": y.getAttribute('Assembly'),
+                "AssemblyAccessionVersion": y.getAttribute('AssemblyAccessionVersion'),
+                "AssemblyStatus": y.getAttribute('AssemblyStatus'),
+                "Chr": y.getAttribute('Chr'),
+                "Accession": y.getAttribute('Accession'),
+                "start": y.getAttribute('start'),
+                "stop": y.getAttribute('stop'),
+                "referenceAllele": y.getAttribute('referenceAllele'),
+                "alternateAllele": y.getAttribute('alternateAllele')
+            };
+            variant.allele.SequenceLocation.push(SequenceLocationObj);
+        }
     }
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1157,10 +1157,6 @@
                 margin: 0 4px;
             }
 
-            .basic-info .table .primary-transcript {
-                background-color: #fff4f4;
-            }
-
             .basic-info .table .primary-transcript td:last-child:after {
                 content: "\f069";
                 font-family: 'FontAwesome';

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1119,6 +1119,10 @@
             .basic-info .table th,
             .basic-info .table td {
                 width: 25%;
+
+                .title-ellipsis {
+                    max-width: 250px;
+                }
             }
 
             .basic-info .datasource-clinvar-interpretaions .table th,


### PR DESCRIPTION
This PR consists of implementations pertinent to the change requests in constructing the external ExAC linkout differently when there is no ExAC population data is found for the table display on the Population tab.

**Technical details:**
1. In the `hgvs_notation.js` and `parse-resources.js` files, I added "if" statements to several places to ensure script execution even when the expected data is absent in the REST API response.
2. In the `basic_info.js` file, removed no-longer-used code and refactored code to ensure script execution even when the expected data is absent in the REST API response.

**Steps to test:**
1. Login and use **53981** and/or **90973** for selecting a variant (relevant to #885).
2. Expect to see that the long HGVS terms are ellipsis and not pushing the table beyond the page on the Basic Info tab.
3. Also expect to see that the "asterisk-marked" canonical transcripts are no longer having a tinted red background color on the Basic Info tab (this was missed in my previous PR).
4. The following variants are for testing the external ExAC linkout on the Population tab:
* **55962** - expect the "See ExAC" link going to ExAC variant page.
* **53905, 53205, 54032, 53981** - expect the "See ExAC" link going to ExAC region search.
* **CA501146, CA501097** - expect the "See ExAC" link going to ExAC homepage.