### PR TITLE
Connects to #800. External data source crediting.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
     "extends": "eslint:recommended",
     "ecmaFeatures": {
         "jsx": true,
-        "experimentalObjectRestSpread": true
+        "experimentalObjectRestSpread": true,
+        "modules": true
     },
     "plugins": [
         "react"

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -12,6 +12,8 @@ var externalLinks = require('./shared/externalLinks');
 var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 
+import { renderDataCredit } from './shared/credit';
+
 // Display the curator data of the curation data
 var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasicInfo = React.createClass({
     mixins: [RestMixin],
@@ -508,11 +510,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     </div>
                 </div>
 
-                <div className="credits">
-                    <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
-                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using: The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>) McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F. Genome Biol. 2016 Jun 6;17(1):122. doi: 10.1186/s13059-016-0974-4. PMID: 27268795
-                    </div>
-                </div>
+                {renderDataCredit('vep')}
 
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -418,7 +418,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info">
                     <div className="panel-heading">
-                        <h3 className="panel-title">RefSeq Transcripts
+                        <h3 className="panel-title">RefSeq Transcripts<a href="#credit-vep" className="label label-primary">VEP</a>
                             <span className="help-note panel-subtitle pull-right"><i className="icon icon-asterisk"></i> Canonical transcript</span>
                         </h3>
                     </div>
@@ -445,7 +445,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info">
                     <div className="panel-heading">
-                        <h3 className="panel-title">Ensembl Transcripts
+                        <h3 className="panel-title">Ensembl Transcripts<a href="#credit-vep" className="label label-primary">VEP</a>
                             <span className="help-note panel-subtitle pull-right"><i className="icon icon-asterisk"></i> Canonical transcript</span>
                         </h3>
                     </div>
@@ -505,6 +505,12 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                 null
                             }
                         </dl>
+                    </div>
+                </div>
+
+                <div className="credits">
+                    <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
+                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using: The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>) McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F. Genome Biol. 2016 Jun 6;17(1):122. doi: 10.1186/s13059-016-0974-4. PMID: 27268795
                     </div>
                 </div>
 

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -18,6 +18,8 @@ var form = require('../../../libs/bootstrap/form');
 
 var externalLinks = require('./shared/externalLinks');
 
+import { renderDataCredit } from './shared/credit';
+
 var PanelGroup = panel.PanelGroup;
 var Panel = panel.Panel;
 var Form = form.Form;
@@ -688,15 +690,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </Panel></PanelGroup>
                 </div>
 
-                <div className="credits">
-                    <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
-                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
-                        MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
-                        Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
-                        Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
-                        High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7
-                    </div>
-                </div>
+                {renderDataCredit('mvi')}
 
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -415,7 +415,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                         {this.state.hasOtherPredData ?
                             <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors</h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -434,7 +434,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                         :
                             <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors</h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -447,7 +447,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                         {this.state.hasConservationData ?
                             <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis</h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -464,7 +464,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                         :
                             <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis</h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -686,6 +686,16 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         </div>
                         : null}
                     </Panel></PanelGroup>
+                </div>
+
+                <div className="credits">
+                    <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
+                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
+                        MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
+                        Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
+                        Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
+                        High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7
+                    </div>
                 </div>
 
             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -473,7 +473,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                         {this.state.hasOtherPredData ?
                             <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -492,7 +492,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                         :
                             <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -505,7 +505,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
                         {this.state.hasConservationData ?
                             <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -522,7 +522,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                         :
                             <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                                 <table className="table">
                                     <thead>
                                         <tr>
@@ -776,7 +776,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 </div>
                 : null}
 
-                {renderDataCredit('mvi')}
+                {renderDataCredit('myvariant')}
 
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -598,7 +598,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     {this.state.hasExacData ?
                         <div className="panel panel-info datasource-ExAC">
                             <div className="panel-heading">
-                                <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}
+                                <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href="#credit-mvi" className="label label-primary">MVi</a>
                                     <a className="panel-subtitle pull-right" href={'http:' + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
@@ -624,7 +624,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     :
                         <div className="panel panel-info datasource-ExAC">
-                            <div className="panel-heading"><h3 className="panel-title">ExAC</h3></div>
+                            <div className="panel-heading"><h3 className="panel-title">ExAC<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -637,7 +637,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     {this.state.hasTGenomesData ?
                         <div className="panel panel-info datasource-1000G">
                             <div className="panel-heading">
-                                <h3 className="panel-title">1000 Genomes: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}
+                                <h3 className="panel-title">1000 Genomes: {tGenomes._extra.name + ' ' + tGenomes._extra.var_class}<a href="#credit-vep" className="label label-primary">VEP</a>
                                     <a className="panel-subtitle pull-right" href={external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
@@ -659,7 +659,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     :
                         <div className="panel panel-info datasource-1000G">
-                            <div className="panel-heading"><h3 className="panel-title">1000 Genomes</h3></div>
+                            <div className="panel-heading"><h3 className="panel-title">1000 Genomes<a href="#credit-vep" className="label label-primary">VEP</a></h3></div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -672,7 +672,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     {this.state.hasEspData ?
                         <div className="panel panel-info datasource-ESP">
                             <div className="panel-heading">
-                                <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}
+                                <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href="#credit-mvi" className="label label-primary">MVi</a>
                                     <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
@@ -699,7 +699,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     :
                         <div className="panel panel-info datasource-ESP">
-                            <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)</h3></div>
+                            <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -710,6 +710,26 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     }
                 </Panel></PanelGroup>
+
+                <div className="credits">
+                    <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
+                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
+                        MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
+                        Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
+                        Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
+                        High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7
+                    </div>
+                </div>
+
+                <div className="credits">
+                    <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
+                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using:
+                    The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
+                    McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
+                    Genome Biol. 2016 Jun 6;17(1):122. doi: 10.1186/s13059-016-0974-4. PMID: 27268795
+                    </div>
+                </div>
+
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -654,7 +654,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     {this.state.hasExacData ?
                         <div className="panel panel-info datasource-ExAC">
                             <div className="panel-heading">
-                                <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href="#credit-mvi" className="label label-primary">MVi</a>
+                                <h3 className="panel-title">ExAC {exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt}<a href="#credit-myvariant" className="label label-primary">MyVariant</a>
                                     <a className="panel-subtitle pull-right" href={'http:' + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
@@ -680,7 +680,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     :
                         <div className="panel panel-info datasource-ExAC">
-                            <div className="panel-heading"><h3 className="panel-title">ExAC<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                            <div className="panel-heading"><h3 className="panel-title">ExAC<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -728,7 +728,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     {this.state.hasEspData ?
                         <div className="panel panel-info datasource-ESP">
                             <div className="panel-heading">
-                                <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href="#credit-mvi" className="label label-primary">MVi</a>
+                                <h3 className="panel-title">Exome Sequencing Project (ESP): {esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt}<a href="#credit-myvariant" className="label label-primary">MyVariant</a>
                                     <a className="panel-subtitle pull-right" href={dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0'} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
                                 </h3>
                             </div>
@@ -755,7 +755,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     :
                         <div className="panel panel-info datasource-ESP">
-                            <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)<a href="#credit-mvi" className="label label-primary">MVi</a></h3></div>
+                            <div className="panel-heading"><h3 className="panel-title">Exome Sequencing Project (ESP)<a href="#credit-myvariant" className="label label-primary">MyVariant</a></h3></div>
                             <table className="table">
                                 <thead>
                                     <tr>
@@ -767,7 +767,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     }
                 </Panel></PanelGroup>
 
-                {renderDataCredit('mvi')}
+                {renderDataCredit('myvariant')}
 
                 {renderDataCredit('vep')}
 

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -17,6 +17,8 @@ var queryKeyValue = globals.queryKeyValue;
 var panel = require('../../../libs/bootstrap/panel');
 var form = require('../../../libs/bootstrap/form');
 
+import { renderDataCredit } from './shared/credit';
+
 var PanelGroup = panel.PanelGroup;
 var Panel = panel.Panel;
 var Form = form.Form;
@@ -711,24 +713,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     }
                 </Panel></PanelGroup>
 
-                <div className="credits">
-                    <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
-                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
-                        MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
-                        Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
-                        Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
-                        High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7
-                    </div>
-                </div>
+                {renderDataCredit('mvi')}
 
-                <div className="credits">
-                    <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
-                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using:
-                    The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
-                    McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
-                    Genome Biol. 2016 Jun 6;17(1):122. doi: 10.1186/s13059-016-0974-4. PMID: 27268795
-                    </div>
-                </div>
+                {renderDataCredit('vep')}
 
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -1,0 +1,40 @@
+// # Static method to render credits of data source
+// # Parameters: data source identifier
+// # Usage: getClinvarInterpretations(xml)
+// # Dependency: None
+
+'use strict';
+var React = require('react');
+
+export function renderDataCredit(source) {
+	if (source === 'mvi') {
+		return (
+	    	<div className="credits">
+	            <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
+                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
+                    MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
+                    Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
+                    Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
+                    High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7. 
+                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a> 
+                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a> 
+                    DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
+                </div>
+	        </div>
+	    );
+	} else if (source === 'vep') {
+		return (
+	    	<div className="credits">
+	            <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
+                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using:
+                    The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
+                    McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
+                    Genome Biol. 2016 Jun 6;17(1):122. 
+                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a> 
+                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a> 
+                    DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
+              	</div>
+	        </div>
+	    );
+	}
+}

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -7,11 +7,11 @@
 var React = require('react');
 
 export function renderDataCredit(source) {
-	if (source === 'mvi') {
+	if (source === 'myvariant') {
 		return (
 	    	<div className="credits">
-	            <div className="credit credit-mvi" id="credit-mvi"><a name="credit-mvi"></a>
-                    <span className="label label-primary">MVi</span> - The data in this table were retrieved using:
+	            <div className="credit credit-myvariant" id="credit-myvariant"><a name="credit-myvariant"></a>
+                    <span className="label label-primary">MyVariant</span> - The data in this table were retrieved using:
                     MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -7,34 +7,34 @@
 var React = require('react');
 
 export function renderDataCredit(source) {
-	if (source === 'myvariant') { 
-		return (
-	    	<div className="credits">
-	            <div className="credit credit-myvariant" id="credit-myvariant"><a name="credit-myvariant"></a>
+    if (source === 'myvariant') { 
+        return (
+            <div className="credits">
+                <div className="credit credit-myvariant" id="credit-myvariant"><a name="credit-myvariant"></a>
                     <span className="label label-primary">MyVariant</span> - The data in this table was retrieved using:
                     MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
                     High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7.
                     PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a>&nbsp;
-					PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
-					DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
+                PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
+                DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
                 </div>
-	        </div>
-	    );
-	} else if (source === 'vep') {
-		return (
-	    	<div className="credits">
-	            <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
+            </div>
+        );
+    } else if (source === 'vep') {
+        return (
+            <div className="credits">
+                <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
                     <span className="label label-primary">VEP</span> - The data in this table was retrieved using:
                     The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
                     McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
                     Genome Biol. 2016 Jun 6;17(1):122.
                     PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a>&nbsp;
-					PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a>&nbsp;
-					DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
-              	</div>
-	        </div>
-	    );
-	}
+                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a>&nbsp;
+                    DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
+                </div>
+            </div>
+        );
+    }
 }

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -15,10 +15,10 @@ export function renderDataCredit(source) {
                     MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
-                    High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7. 
-                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a> 
-                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a> 
-                    DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
+                    High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7.
+                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a>&nbsp;
+					PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
+					DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
                 </div>
 	        </div>
 	    );
@@ -29,10 +29,10 @@ export function renderDataCredit(source) {
                     <span className="label label-primary">VEP</span> - The data in this table were retrieved using:
                     The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
                     McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
-                    Genome Biol. 2016 Jun 6;17(1):122. 
-                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a> 
-                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a> 
-                    DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
+                    Genome Biol. 2016 Jun 6;17(1):122.
+                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a>&nbsp;
+					PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a>&nbsp;
+					DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
               	</div>
 	        </div>
 	    );

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -7,11 +7,11 @@
 var React = require('react');
 
 export function renderDataCredit(source) {
-	if (source === 'myvariant') {
+	if (source === 'myvariant') { 
 		return (
 	    	<div className="credits">
 	            <div className="credit credit-myvariant" id="credit-myvariant"><a name="credit-myvariant"></a>
-                    <span className="label label-primary">MyVariant</span> - The data in this table were retrieved using:
+                    <span className="label label-primary">MyVariant</span> - The data in this table was retrieved using:
                     MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
@@ -26,7 +26,7 @@ export function renderDataCredit(source) {
 		return (
 	    	<div className="credits">
 	            <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
-                    <span className="label label-primary">VEP</span> - The data in this table were retrieved using:
+                    <span className="label label-primary">VEP</span> - The data in this table was retrieved using:
                     The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
                     McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
                     Genome Biol. 2016 Jun 6;17(1):122.

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1364,6 +1364,14 @@
         .help-note span {
             font-style: italic;
         }
+
+        a.label-primary {
+            color: #fff;
+            font-size: 55%;
+            font-weight: bold;
+            margin-left: 10px;
+            vertical-align: top;
+        }
     }
 
     .panel-subtitle {
@@ -1527,4 +1535,14 @@ dl.inline-dl {
 
 .hidden {
     display: none;
+}
+
+/* Credits at the bottom of tabs */
+.credits {
+    font-size: 12px;
+    margin: 20px 0 0 0;
+
+    .label-primary {
+        vertical-align: text-top;
+    }
 }


### PR DESCRIPTION
This PR consists of implementation pertinent to adding UIs for crediting external data sources such as myvariant.info and VEP.

**Steps to test:**
1. Login and select 55962 variant id.
2. On the Basic Info tab, expect to see the "VEP" icons next to the headers of **RefSeq Transcripts** and **Ensembl Transcripts** tables. Expect to see the "VEP" credit at the bottom of the page.
3. On the Population tab, expect to see the "MVi" icons next to the headers of **ExAC** and **ESP** tables, and the "VEP" icon next to the header of **1000 Genomes** table. Expect to see the "MVi" and "VEP" credits at the bottom of the page.
3. On the Predictors tab, expect to see the "MVi" icons next to the headers of **Other Predictors** and **Conservation Analysis** tables. Expect to see the "MVi" credit at the bottom of the page.