### PR TITLE
Connects to #890 bug stand-alone option not work

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -451,7 +451,7 @@ function evalFormValueDropdown(criteria) {
             {criteria[1] === 'P' ? null : <option value="supporting">{criteria}_P</option>}
             {criteria[0] === 'P' && criteria[1] !== 'M' ? <option value="moderate">{criteria}_M</option> : null}
             {criteria[1] === 'S' ? null : <option value="strong">{criteria}_S</option>}
-            {criteria[0] === 'B' ? <option value="stand-alone">{criteria}_stand alone</option> : null}
+            {(criteria[0] === 'B' && criteria[1] !== 'A') ? <option value="stand-alone">{criteria}_stand alone</option> : null}
             {criteria[0] === 'P' && criteria[1] !== 'V' ? <option value="very-strong">{criteria}_VS</option> : null}
         </Input>
     );

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -291,7 +291,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                 };
 
                 // set criterion status and modifiers
-                if (['supporting', 'moderate', 'strong', 'very-strong'].indexOf(this.refs[criterion + '-status'].getValue()) > -1) {
+                if (['supporting', 'moderate', 'strong', 'very-strong', 'stand-alone'].indexOf(this.refs[criterion + '-status'].getValue()) > -1) {
                     // if dropdown selection is a modifier to met, set status to met, and set modifier as needed...
                     evaluations[criterion]['criteriaStatus'] = 'met';
                     evaluations[criterion]['criteriaModifier'] = this.refs[criterion + '-status'].getValue();


### PR DESCRIPTION
This PR fixes bug that "Stand alone" option doesn't result expected change in progress bar and removes option "stand alone" from pulldown list of BA1 selection(ticket #890).

**Code Change** in File `src/clincoded/static/components/variant_central/interpretation/shared/form.js`
1. Added element "stand-alone" in an array that containing all modified values in file.
2. Edited condition to filter out option "stand alone" from BA1 criteria 

**Test**
* In VCI, enter a variant id, click Start New Interpretation button and go to Population tab, 
  1. Change BS1 selection to option "BS1_stand alone" and click Save. Expect to see changes in progress bar as:
![screen shot 2016-08-15 at 5 20 32 pm](https://cloud.githubusercontent.com/assets/9206696/17684004/9c804dde-630c-11e6-94d4-fcbcd2e66d33.png)

  2. Click criteria BA1 selection and expect not to see "BA1_stand alone" in pulldown list.
![screen shot 2016-08-15 at 5 18 27 pm](https://cloud.githubusercontent.com/assets/9206696/17683964/5542818a-630c-11e6-902f-a5674d42cc19.png)

**End of Test**

