### PR TITLE
Connects to #895 links in new browser tab, Connects to #897 View Summary button

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -108,7 +108,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         return (
             <div className="container curation-variant-tab-group">
                 <PathogenicityCalculator interpretation={interpretation} />
-                <br /><br />
                 <div className="vci-tabs">
                     <ul className="vci-tabs-header tab-label-list" role="tablist">
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('basic-info')} aria-selected={this.state.selectedTab == 'basic-info'}>Basic Information</li>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -682,7 +682,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <table className="table">
                                 <thead>
                                     <tr>
-                                        <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']}>Search ExAC</a> for this variant.</th>
+                                        <th>No population data was found for this allele in ExAC. <a href={external_url_map['EXACHome']} target="_blank">Search ExAC</a> for this variant.</th>
                                     </tr>
                                 </thead>
                             </table>
@@ -717,7 +717,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <table className="table">
                                 <thead>
                                     <tr>
-                                        <th>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']}>Search 1000 Genomes</a> for this variant.</th>
+                                        <th>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']} target="_blank">Search 1000 Genomes</a> for this variant.</th>
                                     </tr>
                                 </thead>
                             </table>
@@ -757,7 +757,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             <table className="table">
                                 <thead>
                                     <tr>
-                                        <th>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']}>Search ESP</a> for this variant.</th>
+                                        <th>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']} target="_blank">Search ESP</a> for this variant.</th>
                                     </tr>
                                 </thead>
                             </table>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
@@ -40,19 +40,22 @@ var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.cre
 
 var progressBar = function(result, rules) {
     return (
-        <div className="progress-bar">
-            <div className="benign-box">
-                <dt>Benign:</dt>
-                {result && result.benign_summary && result.benign_summary.length ? result.benign_summary.join(', ') : 'No criteria met' }
+        <div>
+            <div className="progress-bar">
+                <div className="benign-box">
+                    <dt>Benign:</dt>
+                    {result && result.benign_summary && result.benign_summary.length ? result.benign_summary.join(' | ') : 'No criteria met' }
+                </div>
+                <div className="pathogenic-box">
+                    <dt>Pathogenic:</dt>
+                    {result && result.path_summary && result.path_summary.length ? result.path_summary.join(' | ') : 'No criteria met' }
+                </div>
+                <div className="assertion-box">
+                    <dt>Calculated Pathogenicity{' (' + rules +')'}:</dt>
+                    {result && result.assertion ? result.assertion : 'None'}
+                </div>
             </div>
-            <div className="pathogenic-box">
-                <dt>Pathogenic:</dt>
-                {result && result.path_summary && result.path_summary.length ? result.path_summary.join(', ') : 'No criteria met' }
-            </div>
-            <div className="assertion-box">
-                <dt>Calculated Pathogenicity{' (' + rules +')'}:</dt>
-                {result && result.assertion ? result.assertion : 'None'}
-            </div>
+            <br /><br />
         </div>
     );
 };

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -62,7 +62,7 @@ var Title = module.exports.Title = React.createClass({
                             <div className="feature-in-development pull-right"> {/* FIXME div for temp yellow UI display */}
 
                                 <button type="button-button" className="btn btn-primary pull-right">
-                                    Calculate Pathogenicity
+                                    View Summary
                                 </button>
 
                             </div> {/* /FIXME div for temp yellow UI display */}


### PR DESCRIPTION
**This PR is related to:**
  1. Ticket #895 to fix bug that search links in Population were not opened in new tabs and removes unnecessary extra space under Start New Interpretation button.
  2. Ticket #897 to change text of "Calculate Pathogenicity" button to "View Summary" in title area.

**Code Changes for ticket #895**
* Edited `<a>` tag for opening linked page in new tab in file `src/clincoded/static/components/variant_central/interpretation/population.js`.
* In files `src/clincoded/static/components/variant_central/interpretation.js` and `src/clincoded/static/components/variant_central/interpretation/shared/calculator.js`, edited `<div>` tag to remove space under Start New Interpretation button.

**Code Changes for ticket #897**
* Changed text of `<button>` tag to "View Summary" in file `/src/clincoded/static/components/variant_central/title.js`.

**Test**
* In VCI, enter ClinVar variation id 55962, click Save and View Evidence, expect to see no extra space under Start New Interpretation button:
![screen shot 2016-08-16 at 4 13 29 pm](https://cloud.githubusercontent.com/assets/9206696/17719464/93adbd72-63cf-11e6-95f5-917916f859c9.png)

* Click State New Interpretation, expect to see "View Summary" button (ticket #897) with yellow bar at left like:
![screen shot 2016-08-16 at 5 41 35 pm](https://cloud.githubusercontent.com/assets/9206696/17720697/b771987e-63d8-11e6-842d-0724e5788db1.png)

* In Population tab, click link "Search 1000 Genomes" and link "Search ESP" (for ticket #895), expect to open external pages in new browser tabs.


* Other links should be opened in new browser tabs:
  - In header area:
    1. ClinVar Variant ID
    2. dbSNP ID
    3. Car ID
    4. UCSC GRCh38
    5. UCSC GRCh37
    6. Variation Viewet GRCh38
    7. Variation Viewer GRCh37
    8. Ensembl Browser GRCh38
    9. Ensembl Browser GRCh37

  - In Basic Info tab:
    10. RCV
    11. MedGen
    12. Orphanet
    13. OMIM

  - In Population tab:
    14. View pLI in ExAC
    15. Search ExAC

  - In Predictors / Missense:
    16. REVEL
    17. See data in MaxEntScan
    18. See data in NNSPLICE
    19. See data in HumanSplicingFinder

**End of Test**