### PR TITLE
Connects to #908. Subtab parameter on interpretation start

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -70,10 +70,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     handleInterpretationEvent: function(e) {
         e.preventDefault(); e.stopPropagation();
         var variantObj = this.props.variantData;
-        var selectedTab = '';
-        if (window.location.href.indexOf('tab=') > -1) {
-            selectedTab = '&tab=' + window.location.href.split('tab=').pop();
-        }
+        var selectedTab = queryKeyValue('tab', window.location.href),
+            selectedSubtab = queryKeyValue('subtab', window.location.href);
         var newInterpretationObj;
         if (!this.state.hasExistingInterpretation) {
             if (variantObj) {
@@ -85,10 +83,10 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
             // the new interpretation UUID in the query string.
             this.postRestData('/interpretations/', newInterpretationObj).then(data => {
                 var newInterpretationUuid = data['@graph'][0].uuid;
-                window.location.href = '/variant-central/?edit=true&variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid + selectedTab;
+                window.location.href = '/variant-central/?edit=true&variant=' + this.state.variantUuid + '&interpretation=' + newInterpretationUuid + (selectedTab ? '&tab=' + selectedTab : '') + (selectedSubtab ? '&subtab=' + selectedSubtab : '');
             }).catch(e => {parseAndLogError.bind(undefined, 'postRequest');});
         } else if (this.state.hasExistingInterpretation && !this.state.isInterpretationActive) {
-            window.location.href = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid + selectedTab;
+            window.location.href = '/variant-central/?edit=true&variant=' + variantObj.uuid + '&interpretation=' + variantObj.associatedInterpretations[0].uuid + (selectedTab ? '&tab=' + selectedTab : '') + (selectedSubtab ? '&subtab=' + selectedSubtab : '');
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -23,6 +23,8 @@ var CurationInterpretationGeneSpecific = require('./interpretation/gene_specific
 var calculator = require('./interpretation/shared/calculator');
 var PathogenicityCalculator = calculator.PathogenicityCalculator;
 
+var validTabs = ['basic-info', 'population', 'predictors', 'experimental', 'segregation-case', 'gene-centric'];
+
 // Curation data header for Gene:Disease
 var VariantCurationInterpretation = module.exports.VariantCurationInterpretation = React.createClass({
     propTypes: {
@@ -53,7 +55,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinvarEutils: this.props.ext_clinvarEutils,
             ext_clinVarEsearch: this.props.ext_clinVarEsearch,
             ext_clinVarRCV: this.props.ext_clinVarRCV,
-            selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info')  : 'basic-info') // set selectedTab to whatever is defined in the address; default to first tab if not set
+            selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('tab', this.props.href_url.href)) > -1 ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info') : 'basic-info')  : 'basic-info'),
         };
     },
 
@@ -94,11 +96,12 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
 
     // set selectedTab to whichever tab the user switches to, and update the address accordingly
     handleSelect: function (tab) {
-        this.setState({selectedTab: tab});
-        if (tab == 'basic-info') {
-            window.history.replaceState(window.state, '', editQueryValue(this.props.href_url.href, 'tab', null));
+        if (tab == 'basic-info' || validTabs.indexOf(tab) == -1) {
+            this.setState({selectedTab: 'basic-info'});
+            window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'tab', null));
         } else {
-            window.history.replaceState(window.state, '', editQueryValue(this.props.href_url.href, 'tab', tab));
+            this.setState({selectedTab: tab});
+            window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'tab', tab));
         }
     },
 

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -30,6 +30,8 @@ var FormMixin = form.FormMixin;
 var Input = form.Input;
 var InputMixin = form.InputMixin;
 
+var validTabs = ['missense', 'lof', 'silent-intron', 'indel'];
+
 var computationStatic = {
     conservation: {
         _order: ['phylop7way', 'phylop20way', 'phastconsp7way', 'phastconsp20way', 'gerp', 'siphy'],
@@ -80,7 +82,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             hasConservationData: false,
             hasOtherPredData: false,
             hasBustamanteData: false,
-            selectedTab: (this.props.href_url.href ? (queryKeyValue('subtab', this.props.href_url.href) ? queryKeyValue('subtab', this.props.href_url.href) : 'missense')  : 'missense'),
+            selectedSubtab: (this.props.href_url.href ? (queryKeyValue('subtab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('subtab', this.props.href_url.href)) > -1 ? queryKeyValue('subtab', this.props.href_url.href) : 'missense') : 'missense')  : 'missense'),
             codonObj: {},
             computationObj: {
                 conservation: {
@@ -159,6 +161,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
     },
 
     componentWillUnmount: function() {
+        window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'subtab', null));
         this.setState({
             hasConservationData: false,
             hasOtherPredData: false,
@@ -326,12 +329,13 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         );
     },
 
-    // set selectedTab to whichever tab the user switches to, and update the address accordingly
-    handleSelect: function (subtab) {
-        this.setState({selectedTab: subtab});
-        if (subtab == 'missense') {
+    // set selectedSubtab to whichever tab the user switches to, and update the address accordingly
+    handleSubtabSelect: function (subtab) {
+        if (subtab == 'missense' || validTabs.indexOf(subtab) == -1) {
+            this.setState({selectedSubtab: 'missense'});
             window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'subtab', null));
         } else {
+            this.setState({selectedSubtab: subtab});
             window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'subtab', subtab));
         }
     },
@@ -413,12 +417,12 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <CompleteSection interpretation={this.state.interpretation} tabName="predictors" updateInterpretationObj={this.props.updateInterpretationObj} />
                 : null}
                 <ul className="vci-tabs-header tab-label-list vci-subtabs" role="tablist">
-                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSelect('missense')} aria-selected={this.state.selectedTab == 'missense'}>Missense</li>
-                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSelect('lof')} aria-selected={this.state.selectedTab == 'lof'}>Loss of Function</li>
-                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSelect('silent-intron')} aria-selected={this.state.selectedTab == 'silent-intron'}>Silent & Intron</li>
-                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSelect('indel')} aria-selected={this.state.selectedTab == 'indel'}>In-frame Indel</li>
+                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('missense')} aria-selected={this.state.selectedSubtab == 'missense'}>Missense</li>
+                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('lof')} aria-selected={this.state.selectedSubtab == 'lof'}>Loss of Function</li>
+                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('silent-intron')} aria-selected={this.state.selectedSubtab == 'silent-intron'}>Silent & Intron</li>
+                    <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('indel')} aria-selected={this.state.selectedSubtab == 'indel'}>In-frame Indel</li>
                 </ul>
-                {this.state.selectedTab == '' || this.state.selectedTab == 'missense' ?
+                {this.state.selectedSubtab == '' || this.state.selectedSubtab == 'missense' ?
                 <div role="tabpanel" className="tab-panel">
                     <PanelGroup accordion><Panel title="Functional, Conservation, and Splicing Predictors" panelBodyClassName="panel-wide-content" open>
                         {(this.props.data && this.state.interpretation) ?
@@ -672,7 +676,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </Panel></PanelGroup>
                 </div>
                 : null}
-                {this.state.selectedTab == 'lof' ?
+                {this.state.selectedSubtab == 'lof' ?
                 <div role="tabpanel" className="tab-panel">
                     <PanelGroup accordion><Panel title="Null variant analysis" panelBodyClassName="panel-wide-content" open>
                         {(this.props.data && this.state.interpretation) ?
@@ -706,7 +710,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </Panel></PanelGroup>
                 </div>
                 : null}
-                {this.state.selectedTab == 'silent-intron' ?
+                {this.state.selectedSubtab == 'silent-intron' ?
                 <div role="tabpanel" className="tab-panel">
                     <PanelGroup accordion><Panel title="Molecular Consequence: Silent & Intron" panelBodyClassName="panel-wide-content" open>
                         {(this.props.data && this.state.interpretation) ?
@@ -722,7 +726,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </Panel></PanelGroup>
                 </div>
                 : null}
-                {this.state.selectedTab == 'indel' ?
+                {this.state.selectedSubtab == 'indel' ?
                 <div role="tabpanel" className="tab-panel">
                     <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" panelBodyClassName="panel-wide-content" open>
                         <div className="panel panel-info">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -191,9 +191,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     parseAlleleFrequencyData: function(response) {
         let populationObj = this.state.populationObj;
         populationStatic.exac._order.map(key => {
-            populationObj.exac[key].af = typeof populationObj.exac[key].af !== 'undefined' ? populationObj.exac[key].af : parseFloat(response[0].colocated_variants[0]['exac_' + key + '_maf']);
+            populationObj.exac[key].af = typeof populationObj.exac[key].af !== 'undefined' ? (isNaN(populationObj.exac[key].af) ? null : populationObj.exac[key].af) : parseFloat(response[0].colocated_variants[0]['exac_' + key + '_maf']);
         });
-        populationObj.exac._tot.af = typeof populationObj.exac._tot.af !== 'undefined' ? populationObj.exac._tot.af : parseFloat(response[0].colocated_variants[0].exac_adj_maf);
+        populationObj.exac._tot.af = typeof populationObj.exac._tot.af !== 'undefined' ? (isNaN(populationObj.exac._tot.af) ? null : populationObj.exac._tot.af) : parseFloat(response[0].colocated_variants[0].exac_adj_maf);
 
         this.setState({populationObj: populationObj});
     },


### PR DESCRIPTION
Parameters in VCI URL should behave better now:

* When starting an interpretation with a subtab, the tab value is no longer replaced with the subtab value
* When starting an interpretation with a subtab, the user should be taken back to where they began the interpretation
* Passing invalid keys to the tab parameter defaults you to the basic-info tab, instead of displaying nothing
* Passing invalid keys to the subtab parameter defaults you to the missense subtab, instead of displaying nothing

Testing:

* Test above conditions in VCI

#### Other changes

Updated the `parseAlleleFrequencyData` method in `population` tab to not store `NaN`s. These `NaN`s were being stored as `null`s in the database, and `find_diff` were flagging them as differences in UI.

Testing:

* Add variant w/ no ExAC data (41312)
* Add interpretation and save evaluations on population tab
* The 'difference found' yellow box should not show up