### PR TITLE
Connects to #903. Connects to #904.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -38,7 +38,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
         ext_clinVarEsearch: React.PropTypes.object,
-        ext_clinVarRCV: React.PropTypes.array
+        ext_clinVarRCV: React.PropTypes.array,
+        ext_ensemblGeneId: React.PropTypes.string,
+        ext_geneSynonyms: React.PropTypes.array
     },
 
     getInitialState: function() {
@@ -53,6 +55,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinvarEutils: this.props.ext_clinvarEutils,
             ext_clinVarEsearch: this.props.ext_clinVarEsearch,
             ext_clinVarRCV: this.props.ext_clinVarRCV,
+            ext_ensemblGeneId: this.props.ext_ensemblGeneId,
+            ext_geneSynonyms: this.props.ext_geneSynonyms,
             selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info')  : 'basic-info') // set selectedTab to whatever is defined in the address; default to first tab if not set
         };
     },
@@ -89,6 +93,12 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_clinVarRCV) {
             this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV});
+        }
+        if (nextProps.ext_ensemblGeneId) {
+            this.setState({ext_ensemblGeneId: nextProps.ext_ensemblGeneId});
+        }
+        if (nextProps.ext_geneSynonyms) {
+            this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
         }
     },
 
@@ -168,7 +178,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <CurationInterpretationGeneSpecific data={variant} data={variant} href_url={this.props.href_url}
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myGeneInfo={this.state.ext_myGeneInfo}
-                            ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP} />
+                            ext_ensemblGeneId={this.state.ext_ensemblGeneId}
+                            ext_geneSynonyms={this.state.ext_geneSynonyms} />
                     </div>
                     : null}
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -20,48 +20,55 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
         interpretation: React.PropTypes.object,
         updateInterpretationObj: React.PropTypes.func,
         href_url: React.PropTypes.object,
-        ext_ensemblHgvsVEP: React.PropTypes.array,
-        ext_myGeneInfo: React.PropTypes.object
+        ext_myGeneInfo: React.PropTypes.object,
+        ext_ensemblGeneId: React.PropTypes.string,
+        ext_geneSynonyms: React.PropTypes.array
     },
 
     getInitialState: function() {
         return {
             clinvar_id: null,
             interpretation: this.props.interpretation,
-            ensembl_gene_id: null,
-            ext_myGeneInfo: this.props.ext_myGeneInfo
+            ext_myGeneInfo: this.props.ext_myGeneInfo,
+            ext_ensemblGeneId: this.props.ext_ensemblGeneId,
+            ext_geneSynonyms: this.props.ext_geneSynonyms
         };
     },
 
     componentWillReceiveProps: function(nextProps) {
         this.setState({interpretation: nextProps.interpretation});
         // update data based on api call results
-        if (nextProps.ext_ensemblHgvsVEP) {
-            this.parseEnsemblGeneId(nextProps.ext_ensemblHgvsVEP[0].transcript_consequences);
-        }
         if (nextProps.ext_myGeneInfo) {
             this.setState({ext_myGeneInfo: nextProps.ext_myGeneInfo});
+        }
+        if (nextProps.ext_ensemblGeneId) {
+            this.setState({ext_ensemblGeneId: nextProps.ext_ensemblGeneId});
+        }
+        if (nextProps.ext_geneSynonyms) {
+            this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
         }
     },
 
     // Method to render constraint scores table
     renderConstraintScores: function(myGeneInfo) {
-        let allExac = myGeneInfo.exac.all,
-            nonPsych = myGeneInfo.exac.nonpsych,
-            nonTcga = myGeneInfo.exac.nontcga;
-        return (
-            <tbody>
-                <tr>
-                    <td>All ExAC</td><td>{this.parseFloatShort(allExac.p_li)}</td><td>{this.parseFloatShort(allExac.p_rec)}</td><td>{this.parseFloatShort(allExac.p_null)}</td>
-                </tr>
-                <tr>
-                    <td>Non-psych</td><td>{this.parseFloatShort(nonPsych.p_li)}</td><td>{this.parseFloatShort(nonPsych.p_rec)}</td><td>{this.parseFloatShort(nonPsych.p_null)}</td>
-                </tr>
-                <tr>
-                    <td>Non-TCGA</td><td>{this.parseFloatShort(nonTcga.p_li)}</td><td>{this.parseFloatShort(nonTcga.p_rec)}</td><td>{this.parseFloatShort(nonTcga.p_null)}</td>
-                </tr>
-            </tbody>
-        );
+        if (myGeneInfo.exac) {
+            let allExac = myGeneInfo.exac.all,
+                nonPsych = myGeneInfo.exac.nonpsych,
+                nonTcga = myGeneInfo.exac.nontcga;
+            return (
+                <tbody>
+                    <tr>
+                        <td>All ExAC</td><td>{this.parseFloatShort(allExac.p_li)}</td><td>{this.parseFloatShort(allExac.p_rec)}</td><td>{this.parseFloatShort(allExac.p_null)}</td>
+                    </tr>
+                    <tr>
+                        <td>Non-psych</td><td>{this.parseFloatShort(nonPsych.p_li)}</td><td>{this.parseFloatShort(nonPsych.p_rec)}</td><td>{this.parseFloatShort(nonPsych.p_null)}</td>
+                    </tr>
+                    <tr>
+                        <td>Non-TCGA</td><td>{this.parseFloatShort(nonTcga.p_li)}</td><td>{this.parseFloatShort(nonTcga.p_rec)}</td><td>{this.parseFloatShort(nonTcga.p_null)}</td>
+                    </tr>
+                </tbody>
+            );
+        }
     },
 
     // helper function to shorten display of imported float values to 5 decimal places;
@@ -76,23 +83,10 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
         }
     },
 
-    // Method to parse Ensembl gene_id from VEP
-    parseEnsemblGeneId: function(ensemblTranscripts) {
-        let ensemblGeneId = '';
-        if (ensemblTranscripts) {
-            ensemblTranscripts.forEach(transcript => {
-                if (transcript.source === 'Ensembl') {
-                    if (transcript.canonical && transcript.canonical === 1) {
-                        ensemblGeneId = transcript.gene_id;
-                    }
-                }
-            });
-        }
-        this.setState({ensembl_gene_id: ensemblGeneId});
-    },
-
     render: function() {
         let myGeneInfo = (this.state.ext_myGeneInfo) ? this.state.ext_myGeneInfo : null;
+        let geneSynonyms = (this.state.ext_geneSynonyms) ? this.state.ext_geneSynonyms : null;
+        let ensemblGeneId = (this.state.ext_ensemblGeneId) ? this.state.ext_ensemblGeneId : null;
 
         return (
             <div className="variant-interpretation gene-specific">
@@ -102,7 +96,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
 
                 <div className="panel panel-info datasource-constraint-scores">
                     <div className="panel-heading"><h3 className="panel-title">ExAC Constraint Scores<a href="#credit-mygene" className="credit-mygene" title="MyGene.info"><span>MyGene</span></a></h3></div>
-                    {(myGeneInfo) ?
+                    {(myGeneInfo && myGeneInfo.exac) ?
                         <table className="table">
                             <thead>
                                 <tr>
@@ -132,7 +126,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                             </tfoot>
                         </table>
                         :
-                        <div className="panel-body"><span>No other variants found in this gene at ClinVar.</span></div>
+                        <div className="panel-body"><span>No ExAC constraint scores found for this variant.</span></div>
                     }
                 </div>
 
@@ -157,6 +151,9 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                                 <dd>
                                     Symbol: <a href={external_url_map['HGNC'] + myGeneInfo.HGNC} target="_blank">{myGeneInfo.symbol}</a><br/>
                                     Approved Name: {myGeneInfo.name}<br/>
+                                    {(geneSynonyms) ?
+                                        <span>Synonyms: {geneSynonyms.join(', ')}</span>
+                                    : null}
                                 </dd>
                             </dl>
                             <dl className="inline-dl clearfix">
@@ -165,7 +162,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                             </dl>
                             <dl className="inline-dl clearfix">
                                 <dt>Ensembl:</dt>
-                                <dd><a href={dbxref_prefix_map['ENSEMBL'] + this.state.ensembl_gene_id + ';db=core'} target="_blank">{this.state.ensembl_gene_id}</a></dd>
+                                <dd><a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a></dd>
                             </dl>
                             <dl className="inline-dl clearfix">
                                 <dt>GeneCards:</dt>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -11,7 +11,7 @@ export function renderDataCredit(source) {
         return (
             <div className="credits">
                 <div className="credit credit-myvariant" id="credit-myvariant"><a name="credit-myvariant"></a>
-                    <span className="credit-myvariant"><span>MyVariant</span></span> - The data in this table was retrieved using:
+                    <span className="credit-myvariant"><span>MyVariant</span></span> - When available, data in this table was retrieved using:
                     MyVariant.info (<a href="http://myvariant.info" target="_blank">http://myvariant.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
@@ -26,7 +26,7 @@ export function renderDataCredit(source) {
         return (
             <div className="credits">
                 <div className="credit credit-mygene" id="credit-mygene"><a name="credit-mygene"></a>
-                    <span className="credit-mygene"><span>MyGene</span></span> - The data in this table was retrieved using:
+                    <span className="credit-mygene"><span>MyGene</span></span> - When available, data in this table was retrieved using:
                     MyGene.info (<a href="http://mygene.info" target="_blank">http://mygene.info</a>)
                     Xin J, Mark A, Afrasiabi C, Tsueng G, et al. (2016) High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7.
                     PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a>&nbsp;
@@ -43,7 +43,7 @@ export function renderDataCredit(source) {
         return (
             <div className="credits">
                 <div className="credit credit-vep" id="credit-vep"><a name="credit-vep"></a>
-                    <span className="label label-primary">VEP</span> - The data in this table was retrieved using:
+                    <span className="label label-primary">VEP</span> - When available, data in this table was retrieved using:
                     The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
                     McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
                     Genome Biol. 2016 Jun 6;17(1):122.


### PR DESCRIPTION
This PR primarily consists of changes pertinent to:
1) Fixing the bug in which the Ensembl link does not persist if the user navigates to other tabs and returns to the Gene-centric tab (#903).
2) Adding the list of synonyms under **HGNC** in the Gene Resources panel on the Gene-centric tab (#904).

Additional changes:
1) Fixing a bug that causes script execution and UI display to fail when there is no ExAC data included in the MyGene.info response (https://github.com/ClinGen/clincoded/issues/883#issuecomment-240560839).
2) Minor text change in data source attribution (https://github.com/ClinGen/clincoded/issues/800#issuecomment-240558170).

**Steps to test:**
1. Login and use **CA501097** CAR ID to select variant.
2. Click through all the tabs and back to the Gene-centric tab. Expect to see no unexpected UI display even when there is no ExAC constraint score data available.
3. Expect to see the display of Ensembl gene_id link to persist on the Gene-centric tab even after clicking through other tabs.
4. Expect to see the "When available, data in this table was retrieved..." wording in the attribution text at the bottom of the tabs.
5. Now change to **231744** variant id and proceed to the Gene-centric. Expect to see the display of synonyms under **HGNC**, due to the gene being available in the test data.