### PR TITLE
Connects to #910 new rules and very-strong in PS2 only

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
@@ -122,6 +122,7 @@ var calculatePathogenicity = function(evaluationObjList) {
             // Algorithm, ACMG Standarts & Guidelines 2015
             // setup cases for 4 types of assertions (Pathogenic, Likely pathogenic, Benign and Likely benign)
             var cases = {
+                path_pvs2: pvs_count >= 2 ? true : false,
                 path_pvs1_ps1: (pvs_count === 1 && ps_count >= 1) ? true : false,
                 path_pvs1_pm2: (pvs_count === 1 && pm_count >= 2) ? true : false,
                 path_pvs1_pm1_pp1: (pvs_count === 1 && pm_count == 1 && pp_count == 1) ? true : false,
@@ -138,7 +139,7 @@ var calculatePathogenicity = function(evaluationObjList) {
                 likelyPath_pm2_pp2: (pm_count === 2 && pp_count >= 2) ? true : false,
                 likelyPath_pm1_pp4: (pm_count === 1 && pp_count >= 4) ? true : false,
 
-                benign_ba1: ba_count === 1 ? true : false,
+                benign_ba1: ba_count >= 1 ? true : false,
                 benign_bs2: bs_count >= 2 ? true : false,
 
                 likelyBenign_bs1_pp1: (bs_count === 1 && bp_count === 1) ? true : false,

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -455,7 +455,7 @@ function evalFormValueDropdown(criteria) {
             {criteria[0] === 'P' && criteria[1] !== 'M' ? <option value="moderate">{criteria}_M</option> : null}
             {criteria[1] === 'S' ? null : <option value="strong">{criteria}_S</option>}
             {(criteria[0] === 'B' && criteria[1] !== 'A') ? <option value="stand-alone">{criteria}_stand alone</option> : null}
-            {criteria[0] === 'P' && criteria[1] !== 'V' ? <option value="very-strong">{criteria}_VS</option> : null}
+            {criteria === 'PS2' ? <option value="very-strong">{criteria}_VS</option> : null}
         </Input>
     );
 }


### PR DESCRIPTION
This PR is for ticket #910 to edit Pathogenicity calculator.

**Changes**
1. Edited code in file `src/clincoded/static/components/variant_central/interpretation/shared/calculator.js` to handle case of multiple PVS and case of multiple Stand alone.
2. Edited code in file `src/clincoded/static/components/variant_central/interpretation/shared/form.js` to assign option "very strong" to criteria PS2 only.

**Test**
* In VCI, enter a variant id, click Save and View Evidence, click Start New Interpretation.
* In Population tab or Predictors tab, click any "P" criteria, expect not to see "PXX_VS" option in pulldown list, like below.
![screen shot 2016-08-17 at 5 11 34 pm](https://cloud.githubusercontent.com/assets/9206696/17757703/c38e7936-649d-11e6-9563-375832716a6e.png)

* In Population tab select Met at BA1 and Save. And then, in Predictors/Missense tab select "BP4_stand alone" at BP4 and Save. Expect to see:
![screen shot 2016-08-17 at 5 43 50 pm](https://cloud.githubusercontent.com/assets/9206696/17758189/3079961c-64a2-11e6-9f43-473847dfd5d4.png)
* Select "Not Evaluate" at BA1 and Save in Population. Select "Not Met" at BP4 and Save in Predictors/Missense tab.
* Click Associate with Disease button, enter an Orphanet id e.g. ORPHA891 and click OK button.
* In Segregation/Case tab, click PS2 selection and expect to see option "PS2_VS" in pulldown list.
![screen shot 2016-08-18 at 10 42 20 am]
(https://cloud.githubusercontent.com/assets/9206696/17784423/58504a0c-6531-11e6-8492-6fb600beb6a7.png)
* Select "PS2_VS" and Save.
* In Predictors/Loss of Function tab, select "Met" at PVS1 criteria and Save. Expect to see:
![screen shot 2016-08-18 at 11 02 14 am](https://cloud.githubusercontent.com/assets/9206696/17784945/83e52dd4-6533-11e6-9afa-c71a525a2025.png)

**End of Test**
