### PR TITLE
Connects to #916. Fix BA1 hover text

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -1,7 +1,7 @@
 {
     "BA1": {
         "class": "benign-strong",
-        "definition": "MAF is too high for disorder",
+        "definition": "Allele frequency greater than 5% in a population database",
         "definitionLong": "Allele frequency is > 5% in ExAC, 1000 Genomes, or ESP",
         "category": "population",
         "diseaseDependent": false


### PR DESCRIPTION
Update BA1 hover text in criteria bar from:

 - "MAF is too high for disorder"

To:
 
 - "Allele frequency greater than 5% in a population database"

As in:
![image](https://cloud.githubusercontent.com/assets/1878194/17801560/c060c8ba-659f-11e6-9568-df90c87cf99e.png)

