### PR TITLE
Connects to #928. Connects to #936. Fix typos in criteria definitions.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -51,7 +51,7 @@
     "BP3": {
         "class": "benign-supporting",
         "definition": "In-frame indels in repeat w/out known function",
-        "definitionLong": "In-frame deletions/insertions in a repetitive region without a known functoin",
+        "definitionLong": "In-frame deletions/insertions in a repetitive region without a known function",
         "category": "computational",
         "diseaseDependent": false
     },
@@ -107,14 +107,14 @@
     "PP4": {
         "class": "pathogenic-supporting",
         "definition": "Patient's phenotype or FH highly specific for gene",
-        "definitionLong": "Patient's phenotpye or family history is highly specific for a disease with a single genetic etiology",
+        "definitionLong": "Patient's phenotype or family history is highly specific for a disease with a single genetic etiology",
         "category": "functional",
         "diseaseDependent": true
     },
     "PP5": {
         "class": "pathogenic-supporting",
         "definition": "Reputable source = pathogenic",
-        "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform and independent evalutation",
+        "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform an independent evalutation",
         "category": "functional",
         "diseaseDependent": true
     },

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -58,7 +58,7 @@
     "BP4": {
         "class": "benign-supporting",
         "definition": "Multiple lines of computational evidence suggest no impact on gene /gene product",
-        "definitionLong": "Multiple lines of computational evidence suggest no impact on gene or gene product (conservation, evolutionary, splicing impact, more) (has caveat)",
+        "definitionLong": "Multiple lines of computational evidence suggest no impact on the gene or gene product (conservation, evolutionary, splicing impact, etc.) (has caveat)",
         "category": "computational",
         "diseaseDependent": false
     },
@@ -100,7 +100,7 @@
     "PP3": {
         "class": "pathogenic-supporting",
         "definition": "Multiple lines of computational evidence support a deleterious effect on the gene /gene product",
-        "definitionLong": "Multiple lines of computation evidence support a deleteriuos effect on the gene or gene product (conservation, evolutaionary, splicing impact, etc.) (has caveat)",
+        "definitionLong": "Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc.) (has caveat)",
         "category": "computational",
         "diseaseDependent": false
     },


### PR DESCRIPTION
PP3 and BP4:
![image](https://cloud.githubusercontent.com/assets/4326866/17982978/26eba090-6abf-11e6-9b5c-9e35c43cc535.png)

BP3: 
![image](https://cloud.githubusercontent.com/assets/4326866/17983267/86fcbdce-6ac0-11e6-9ce9-9ce38452e783.png)

PP4:
![image](https://cloud.githubusercontent.com/assets/4326866/17983277/9a9f9fa4-6ac0-11e6-9e0d-a2a7cf6c275d.png)

PP5:
![image](https://cloud.githubusercontent.com/assets/4326866/17983289/aa6b9eba-6ac0-11e6-981b-6ecfda97dfee.png)

Testing:

1. Get to VCI and begin interpretation
2. Confirm that definition text for the above criteria codes have no typos