### PR TITLE
Connects to #947. Connects to #937. Connects to #978. Disease-dependency overhaul. Fix rendering on Windows.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -43,7 +43,7 @@
     },
     "BP2": {
         "class": "benign-supporting",
-        "definition": "Observed in <i>trans</i> with path. variant for dominant disorder or <i>cis</i> any inheritance",
+        "definition": "Observed in trans with path. variant for dominant disorder or cis any inheritance",
         "definitionLong": "Observed in <i>trans</i> with a pathogenic variant for a fully penetrant dominant gene/disorder or observed in <i>cis</i> with a pathogenic variant in any inheritance pattern",
         "category": "segregation",
         "diseaseDependent": true
@@ -134,7 +134,7 @@
     },
     "PM3": {
         "class": "pathogenic-moderate",
-        "definition": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
+        "definition": "For recessive disorders, detected in trans with a pathogenic variant",
         "definitionLong": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
         "category": "segregation",
         "diseaseDependent": true
@@ -155,7 +155,7 @@
     },
     "PM6": {
         "class": "pathogenic-moderate",
-        "definition": "<i>De novo</i> (without paternity & maternity confirmed)",
+        "definition": "De novo (without paternity & maternity confirmed)",
         "definitionLong": "Assumed <i>de novo</i>, but without confirmation of maternity/paternity",
         "category": "segregation",
         "diseaseDependent": false
@@ -169,7 +169,7 @@
     },
     "PS2": {
         "class": "pathogenic-strong",
-        "definition": "<i>De novo</i> (paternity and maternity confirmed)",
+        "definition": "De novo (paternity and maternity confirmed)",
         "definitionLong": "<i>De novo</i> (both maternity and paternity confirmed) in a patient with the disease and no family history",
         "category": "segregation",
         "diseaseDependent": true

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -11,42 +11,42 @@
         "definition": "MAF is too high for disorder",
         "definitionLong": "Allele frequency greater than expected due to disorder",
         "category": "population",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BS2": {
         "class": "benign-strong",
         "definition": "Observation in controls inconsistent with disease penetrance",
         "definitionLong": "Observed in a healthy adult individual for a recessive (homozygous), dominant (heterozygous), or X-linked (hemizygous) disorder, with full penetrance expected at an early age",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BS3": {
         "class": "benign-strong",
         "definition": "Well-established functional studies show no deleterious effect",
         "definitionLong": "Well established <i>in vitro</i> or <i>in vivo</i> functional studies show no damaging effect on protein function or splicing",
         "category": "experimental",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BS4": {
         "class": "benign-strong",
         "definition": "Non-segregation with disease",
         "definitionLong": "Lack of segregation in affected members of family (has caveat)",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP1": {
         "class": "benign-supporting",
         "definition": "Missense in gene where primarily truncating cause disease",
         "definitionLong": "Missense variant in a gene for which primarily truncating variants are known to cause disease",
         "category": "predictors",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP2": {
         "class": "benign-supporting",
         "definition": "Observed in <i>trans</i> with path. variant for dominant disorder or <i>cis</i> any inheritance",
         "definitionLong": "Observed in <i>trans</i> with a pathogenic variant for a fully penetrant dominant gene/disorder or observed in <i>cis</i> with a pathogenic variant in any inheritance pattern",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP3": {
         "class": "benign-supporting",
@@ -67,14 +67,14 @@
         "definition": "Found in case with an alternate cause",
         "definitionLong": "Variant found in a case with an alternate molecular basis for disease",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP6": {
         "class": "benign-supporting",
         "definition": "Reputable source w/out shared data = benign",
         "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evaluation",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP7": {
         "class": "benign-supporting",
@@ -88,14 +88,14 @@
         "definition": "Cosegregation with disease in multiple affected family members",
         "definitionLong": "Cosegregation with disease in multiple affected family members in a gene definitively known to cause disease",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PP2": {
         "class": "pathogenic-supporting",
         "definition": "Missense in gene with low rate of benign missense variants and path. missenses common",
         "definitionLong": "Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease",
         "category": "computational",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PP3": {
         "class": "pathogenic-supporting",
@@ -109,21 +109,21 @@
         "definition": "Patient's phenotype or FH highly specific for gene",
         "definitionLong": "Patient's phenotype or family history is highly specific for a disease with a single genetic etiology",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PP5": {
         "class": "pathogenic-supporting",
         "definition": "Reputable source = pathogenic",
         "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform an independent evalutation",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PM1": {
         "class": "pathogenic-moderate",
         "definition": "Mutational hot spot or well-studied functional domain without benign variation",
         "definitionLong": "Located in a mutational hot spot and/or critical and well-established functional domain (e.g. active site of enzyme) without benign variation",
         "category": "functional",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PM2": {
         "class": "pathogenic-moderate",
@@ -137,7 +137,7 @@
         "definition": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
         "definitionLong": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PM4": {
         "class": "pathogenic-moderate",
@@ -151,7 +151,7 @@
         "definition": "Novel missense change at an amino acid residue where a different pathogenic missense change has been seen before",
         "definitionLong": " Novel missense change at an amino acid residue where a different missense change determined to be pathogenic has been seen before",
         "category": "computational",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PM6": {
         "class": "pathogenic-moderate",
@@ -165,21 +165,21 @@
         "definition": "Same amino acid change as an established pathogenic variant",
         "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (caveat - changes impacting splicing)",
         "category": "computational",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PS2": {
         "class": "pathogenic-strong",
         "definition": "De novo (paternity and maternity confirmed)",
         "definitionLong": "De novo (both maternity and paternity confirmed) in a patient with the disease and no family history",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PS3": {
         "class": "pathogenic-strong",
         "definition": "Well-established functional studies show a deleterious effect",
         "definitionLong": "Well established in vitro or in vivo functional studies supportive of a damaging effect on the gene or gene product",
         "category": "functional",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PS4": {
         "class": "pathogenic-strong",
@@ -193,6 +193,6 @@
         "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease",
         "definitionLong": "Null variant (nonsense, frameshift, canonical +/-1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
         "category": "computational",
-        "diseaseDependent": false
+        "diseaseDependent": true
     }
 }

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -191,7 +191,7 @@
     "PVS1": {
         "class": "pathogenic-very-strong",
         "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease",
-        "definitionLong": "Null variant (nonsense, frameshift, canonical +/-1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
+        "definitionLong": "Null variant (nonsense, frameshift, canonical +/- 1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
         "category": "computational",
         "diseaseDependent": true
     }

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -169,15 +169,15 @@
     },
     "PS2": {
         "class": "pathogenic-strong",
-        "definition": "De novo (paternity and maternity confirmed)",
-        "definitionLong": "De novo (both maternity and paternity confirmed) in a patient with the disease and no family history",
+        "definition": "<i>De novo</i> (paternity and maternity confirmed)",
+        "definitionLong": "<i>De novo</i> (both maternity and paternity confirmed) in a patient with the disease and no family history",
         "category": "segregation",
         "diseaseDependent": true
     },
     "PS3": {
         "class": "pathogenic-strong",
         "definition": "Well-established functional studies show a deleterious effect",
-        "definitionLong": "Well established in vitro or in vivo functional studies supportive of a damaging effect on the gene or gene product",
+        "definitionLong": "Well established <i>in vitro</i> or <i>in vivo</i> functional studies supportive of a damaging effect on the gene or gene product",
         "category": "functional",
         "diseaseDependent": true
     },

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -17,48 +17,48 @@
         "class": "benign-strong",
         "definition": "Observation in controls inconsistent with disease penetrance",
         "definitionLong": "Observed in a healthy adult individual for a recessive (homozygous), dominant (heterozygous), or X-linked (hemizygous) disorder, with full penetrance expected at an early age",
-        "category": "population",
+        "category": "segregation",
         "diseaseDependent": false
     },
     "BS3": {
         "class": "benign-strong",
         "definition": "Well-established functional studies show no deleterious effect",
-        "definitionLong": "Well established in vitro or in vivo functional studies show no damaging effect on protein function or splicing",
-        "category": "functional",
+        "definitionLong": "Well established <i>in vitro</i> or <i>in vivo</i> functional studies show no damaging effect on protein function or splicing",
+        "category": "experimental",
         "diseaseDependent": false
     },
     "BS4": {
         "class": "benign-strong",
-        "definition": "Nonsegregation with disease",
+        "definition": "Non-segregation with disease",
         "definitionLong": "Lack of segregation in affected members of family (has caveat)",
         "category": "segregation",
         "diseaseDependent": false
     },
     "BP1": {
         "class": "benign-supporting",
-        "definition": "Missense in gene where only truncating cause disease",
+        "definition": "Missense in gene where primarily truncating cause disease",
         "definitionLong": "Missense variant in a gene for which primarily truncating variants are known to cause disease",
-        "category": "computational",
+        "category": "predictors",
         "diseaseDependent": false
     },
     "BP2": {
         "class": "benign-supporting",
-        "definition": "Observed in trans with a dominant variant",
-        "definitionLong": "Observed in trans with a pathogenic variant for a fully penetrant dominant gene/disorder or observed in cis with a pathogenic variant in any inheritance pattern",
+        "definition": "Observed in <i>trans</i> with path. variant for dominant disorder or <i>cis</i> any inheritance",
+        "definitionLong": "Observed in <i>trans</i> with a pathogenic variant for a fully penetrant dominant gene/disorder or observed in <i>cis</i> with a pathogenic variant in any inheritance pattern",
         "category": "segregation",
         "diseaseDependent": false
     },
     "BP3": {
         "class": "benign-supporting",
         "definition": "In-frame indels in repeat w/out known function",
-        "definitionLong": "In-frame deletions/insertions in a repetitive region without a known functoin",
+        "definitionLong": "In-frame deletions/insertions in a repetitive region without a known function",
         "category": "computational",
         "diseaseDependent": false
     },
     "BP4": {
         "class": "benign-supporting",
         "definition": "Multiple lines of computational evidence suggest no impact on gene /gene product",
-        "definitionLong": "Multiple lines of computational evidence suggest no impact on gene or gene product (conservation, evolutionary, splicing impact, more) (has caveat)",
+        "definitionLong": "Multiple lines of computational evidence suggest no impact on gene or gene product (conservation, evolutionary, splicing impact, etc.) (has caveat)",
         "category": "computational",
         "diseaseDependent": false
     },
@@ -72,13 +72,13 @@
     "BP6": {
         "class": "benign-supporting",
         "definition": "Reputable source w/out shared data = benign",
-        "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evalutation",
-        "category": "functional",
+        "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evaluation",
+        "category": "segregation",
         "diseaseDependent": false
     },
     "BP7": {
         "class": "benign-supporting",
-        "definition": "Silent variant with non predicted splice impact",
+        "definition": "Silent variant predicted with no splice impact",
         "definitionLong": "A synonymous (silent) variant for which splicing prediction algorithms predict no impact to the splice consensus sequence nor the creation of a new splice site AND the nucleotide is not highly conserved",
         "category": "computational",
         "diseaseDependent": false
@@ -100,28 +100,28 @@
     "PP3": {
         "class": "pathogenic-supporting",
         "definition": "Multiple lines of computational evidence support a deleterious effect on the gene /gene product",
-        "definitionLong": "Multiple lines of computation evidence support a deleteriuos effect on the gene or gene product (conservation, evolutaionary, splicing impact, etc.) (has caveat)",
+        "definitionLong": "Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc.) (has caveat)",
         "category": "computational",
         "diseaseDependent": false
     },
     "PP4": {
         "class": "pathogenic-supporting",
         "definition": "Patient's phenotype or FH highly specific for gene",
-        "definitionLong": "Patient's phenotpye or family history is highly specific for a disease with a single genetic etiology",
-        "category": "functional",
+        "definitionLong": "Patient's phenotype or family history is highly specific for a disease with a single genetic etiology",
+        "category": "segregation",
         "diseaseDependent": false
     },
     "PP5": {
         "class": "pathogenic-supporting",
         "definition": "Reputable source = pathogenic",
-        "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform and independent evalutation",
-        "category": "functional",
+        "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform an independent evalutation",
+        "category": "segregation",
         "diseaseDependent": false
     },
     "PM1": {
         "class": "pathogenic-moderate",
         "definition": "Mutational hot spot or well-studied functional domain without benign variation",
-        "definitionLong": "Located in a mutational hot spot and/or critical and well-established functional domain without benign variation",
+        "definitionLong": "Located in a mutational hot spot and/or critical and well-established functional domain (e.g. active site of enzyme) without benign variation",
         "category": "functional",
         "diseaseDependent": false
     },
@@ -134,15 +134,15 @@
     },
     "PM3": {
         "class": "pathogenic-moderate",
-        "definition": "For recessive disorders, detected in trans with a pathogenic variant",
-        "definitionLong": "For recessive disorders, detected in trans with a pathogenic variant",
+        "definition": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
+        "definitionLong": "For recessive disorders, detected in <i>trans</i> with a pathogenic variant",
         "category": "segregation",
         "diseaseDependent": false
     },
     "PM4": {
         "class": "pathogenic-moderate",
         "definition": "Protein length changing variant",
-        "definitionLong": "Protein length changes as a result of in-frame deletions/insertions in a nonrepeat region or stop-loss variant",
+        "definitionLong": "Protein length changes as a result of in-frame deletions/insertions in a non-repeat region or stop-loss variant",
         "category": "computational",
         "diseaseDependent": false
     },
@@ -155,8 +155,8 @@
     },
     "PM6": {
         "class": "pathogenic-moderate",
-        "definition": "De novo (without paternity & maternity confirmed)",
-        "definitionLong": "Assumed de novo, but without confirmation of maternity/paternity",
+        "definition": "<i>De novo</i> (without paternity & maternity confirmed)",
+        "definitionLong": "Assumed <i>de novo</i>, but without confirmation of maternity/paternity",
         "category": "segregation",
         "diseaseDependent": false
     },
@@ -185,13 +185,13 @@
         "class": "pathogenic-strong",
         "definition": "Prevalence in affecteds statistically increased over controls",
         "definitionLong": "The prevalence of the variant in affected individuals is significantly increased compared with the prevalence in controls",
-        "category": "population",
+        "category": "segregation",
         "diseaseDependent": false
     },
     "PVS1": {
         "class": "pathogenic-very-strong",
         "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease",
-        "definitionLong": "Null variant (nonsense, frameshift, cononical +/-1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
+        "definitionLong": "Null variant (nonsense, frameshift, canonical +/-1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
         "category": "computational",
         "diseaseDependent": false
     }

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -163,7 +163,7 @@
     "PS1": {
         "class": "pathogenic-strong",
         "definition": "Same amino acid change as an established pathogenic variant",
-        "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (has caveats)",
+        "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (has caveat)",
         "category": "computational",
         "diseaseDependent": true
     },

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -11,42 +11,42 @@
         "definition": "MAF is too high for disorder",
         "definitionLong": "Allele frequency greater than expected due to disorder",
         "category": "population",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BS2": {
         "class": "benign-strong",
         "definition": "Observation in controls inconsistent with disease penetrance",
         "definitionLong": "Observed in a healthy adult individual for a recessive (homozygous), dominant (heterozygous), or X-linked (hemizygous) disorder, with full penetrance expected at an early age",
         "category": "population",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BS3": {
         "class": "benign-strong",
         "definition": "Well-established functional studies show no deleterious effect",
         "definitionLong": "Well established in vitro or in vivo functional studies show no damaging effect on protein function or splicing",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BS4": {
         "class": "benign-strong",
         "definition": "Nonsegregation with disease",
         "definitionLong": "Lack of segregation in affected members of family (has caveat)",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP1": {
         "class": "benign-supporting",
         "definition": "Missense in gene where only truncating cause disease",
         "definitionLong": "Missense variant in a gene for which primarily truncating variants are known to cause disease",
         "category": "computational",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP2": {
         "class": "benign-supporting",
         "definition": "Observed in trans with a dominant variant",
         "definitionLong": "Observed in trans with a pathogenic variant for a fully penetrant dominant gene/disorder or observed in cis with a pathogenic variant in any inheritance pattern",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP3": {
         "class": "benign-supporting",
@@ -67,14 +67,14 @@
         "definition": "Found in case with an alternate cause",
         "definitionLong": "Variant found in a case with an alternate molecular basis for disease",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP6": {
         "class": "benign-supporting",
         "definition": "Reputable source w/out shared data = benign",
         "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evalutation",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP7": {
         "class": "benign-supporting",
@@ -88,14 +88,14 @@
         "definition": "Cosegregation with disease in multiple affected family members",
         "definitionLong": "Cosegregation with disease in multiple affected family members in a gene definitively known to cause disease",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PP2": {
         "class": "pathogenic-supporting",
         "definition": "Missense in gene with low rate of benign missense variants and path. missenses common",
         "definitionLong": "Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease",
         "category": "computational",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PP3": {
         "class": "pathogenic-supporting",
@@ -109,21 +109,21 @@
         "definition": "Patient's phenotype or FH highly specific for gene",
         "definitionLong": "Patient's phenotpye or family history is highly specific for a disease with a single genetic etiology",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PP5": {
         "class": "pathogenic-supporting",
         "definition": "Reputable source = pathogenic",
         "definitionLong": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform and independent evalutation",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PM1": {
         "class": "pathogenic-moderate",
         "definition": "Mutational hot spot or well-studied functional domain without benign variation",
         "definitionLong": "Located in a mutational hot spot and/or critical and well-established functional domain without benign variation",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PM2": {
         "class": "pathogenic-moderate",
@@ -137,7 +137,7 @@
         "definition": "For recessive disorders, detected in trans with a pathogenic variant",
         "definitionLong": "For recessive disorders, detected in trans with a pathogenic variant",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PM4": {
         "class": "pathogenic-moderate",
@@ -151,7 +151,7 @@
         "definition": "Novel missense change at an amino acid residue where a different pathogenic missense change has been seen before",
         "definitionLong": " Novel missense change at an amino acid residue where a different missense change determined to be pathogenic has been seen before",
         "category": "computational",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PM6": {
         "class": "pathogenic-moderate",
@@ -165,21 +165,21 @@
         "definition": "Same amino acid change as an established pathogenic variant",
         "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (caveat - changes impacting splicing)",
         "category": "computational",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PS2": {
         "class": "pathogenic-strong",
         "definition": "De novo (paternity and maternity confirmed)",
         "definitionLong": "De novo (both maternity and paternity confirmed) in a patient with the disease and no family history",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PS3": {
         "class": "pathogenic-strong",
         "definition": "Well-established functional studies show a deleterious effect",
         "definitionLong": "Well established in vitro or in vivo functional studies supportive of a damaging effect on the gene or gene product",
         "category": "functional",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "PS4": {
         "class": "pathogenic-strong",
@@ -193,6 +193,6 @@
         "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease",
         "definitionLong": "Null variant (nonsense, frameshift, cononical +/-1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
         "category": "computational",
-        "diseaseDependent": true
+        "diseaseDependent": false
     }
 }

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -74,7 +74,7 @@
         "definition": "Reputable source w/out shared data = benign",
         "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evaluation",
         "category": "segregation",
-        "diseaseDependent": true
+        "diseaseDependent": false
     },
     "BP7": {
         "class": "benign-supporting",
@@ -186,7 +186,7 @@
         "definition": "Prevalence in affecteds statistically increased over controls",
         "definitionLong": "The prevalence of the variant in affected individuals is significantly increased compared with the prevalence in controls",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "PVS1": {
         "class": "pathogenic-very-strong",

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -74,7 +74,7 @@
         "definition": "Reputable source w/out shared data = benign",
         "definitionLong": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evaluation",
         "category": "segregation",
-        "diseaseDependent": false
+        "diseaseDependent": true
     },
     "BP7": {
         "class": "benign-supporting",

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -163,7 +163,7 @@
     "PS1": {
         "class": "pathogenic-strong",
         "definition": "Same amino acid change as an established pathogenic variant",
-        "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (caveat - changes impacting splicing)",
+        "definitionLong": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change (has caveats)",
         "category": "computational",
         "diseaseDependent": true
     },
@@ -191,7 +191,7 @@
     "PVS1": {
         "class": "pathogenic-very-strong",
         "definition": "Predicted null variant in a gene where LOF is a known mechanism of disease",
-        "definitionLong": "Null variant (nonsense, frameshift, canonical +/- 1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (caveats - variants at 3' end, genes where LOF is not a known disease mechanism, splice variants that lead to exon skipping but rest of protein intact, caution in presence of multiple transcripts)",
+        "definitionLong": "Null variant (nonsense, frameshift, canonical +/- 1 or 2 splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease (has caveats)",
         "category": "computational",
         "diseaseDependent": true
     }

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -17,7 +17,8 @@ NOTE: disease dependency of criteria codes are in a state of flux right now. The
 dictate whether or not a criteria is disease-dependent is in ../mapping/evidence_code.json, but the
 code to deal with the associated form rendering and storing is here. If criteria codes need to have
 their disease dependency modified, edit evidence_code. To change or remove its behavior, edit here
-(search for 'diseaseCriteria', 'diseaseAssociated', 'diseaseDependent', and finally 'disease')
+(if re-enabling, search for 'DISEASE DEPENDENCY RESTRICTION' and read involved notes. For other tweaks,
+search for 'diseaseCriteria', 'diseaseAssociated', 'diseaseDependent', and finally 'disease')
 */
 
 // Form component to be re-used by various tabs
@@ -75,7 +76,8 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
         if (this.props.evidenceData) {
             this.setState({evidenceData: this.props.evidenceData, evidenceDataUpdated: this.props.evidenceDataUpdated});
         }
-        // ascertain which criteria code are disease dependent
+        // ascertain which criteria code are disease dependent - UNCOMMENT FOR DISEASE DEPENDENCY RESTRICTION
+        /*
         let tempDiseaseCriteria = [];
         this.props.criteria.map(criterion => {
             if (evidenceCodes[criterion].diseaseDependent) {
@@ -83,6 +85,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
             }
         });
         this.setState({diseaseCriteria: tempDiseaseCriteria});
+        */
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -211,6 +214,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
             flatInterpretation = curator.flatten(freshInterpretation);
             // lets do the disease check for saving criteria code here
             this.props.criteria.map(criterion => {
+                /*
                 if (evidenceCodes[criterion].diseaseDependent) {
                     // criteria is disease-dependent
                     if (flatInterpretation.disease && flatInterpretation.disease !== '') {
@@ -222,6 +226,9 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                     // criteria is not disease-dependent, so add it to list of criteria to
                     submittedCriteria.push(criterion);
                 }
+                */
+                // UNCOMMENT ABOVE + COMMENT LINE BELOW FOR DISEASE DEPENDENCY RESTRICTION
+                submittedCriteria.push(criterion);
             });
             // do hard-coded check for PM2 vs PS4
             if (interpretation.evaluations && interpretation.evaluations.length > 0) {
@@ -421,7 +428,7 @@ var evalFormNoteSectionWrapper = module.exports.evalFormNoteSectionWrapper = fun
                 return (
                     <span key={i}>
                         <strong>{criteria}:</strong> {evidenceCodes[criteria].definitionLong}
-                        {evidenceCodes[criteria].diseaseDependent ? <span><br /><span className="label label-warning pull-right">Disease dependent</span></span> : null}
+                        {evidenceCodes[criteria].diseaseDependent ? <span><br /><span className="label label-warning pull-right">Disease-specific</span></span> : null}
                         {i < criteriaList.length - 1 ? <span><br /><br /></span> : null}
                     </span>
                 );
@@ -450,11 +457,12 @@ var evalFormDropdownSectionWrapper = module.exports.evalFormDropdownSectionWrapp
 
 // helper function for evalFormDropdownSectionWrapper() to generate the dropdown for each criteria
 function evalFormValueDropdown(criteria) {
+    // ADD FOLLOWING LINE TO <INPUT> BELOW FOR DISEASE DEPENDENCY RESTRICTION
+    // inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated}
     return (
         <Input type="select" ref={criteria + "-status"} label={criteria + ":"} defaultValue="not-evaluated" handleChange={this.handleDropdownChange}
             error={this.getFormError(criteria + "-status")} clearError={this.clrFormErrors.bind(null, criteria + "-status")}
-            labelClassName="col-xs-3 control-label" wrapperClassName="col-xs-9" groupClassName="form-group"
-            inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated}>
+            labelClassName="col-xs-3 control-label" wrapperClassName="col-xs-9" groupClassName="form-group">
             <option value="not-evaluated">Not Evaluated</option>
             <option disabled="disabled"></option>
             <option value="met">Met</option>
@@ -488,10 +496,11 @@ var evalFormExplanationSectionWrapper = module.exports.evalFormExplanationSectio
 
 // helper function for evalFormExplanationSectionWrapper() to generate the explanation input for each criteria
 function evalFormExplanationDefaultInput(criteria, hidden) {
+    // ADD FOLLOWING LINE TO <INPUT> BELOW FOR DISEASE DEPENDENCY RESTRICTION
+    // inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated}
     return (
         <Input type="textarea" ref={criteria + "-explanation"} rows="3" label="Explanation:"
-            labelClassName="col-xs-4 control-label" wrapperClassName="col-xs-8" groupClassName={hidden ? "hidden" : "form-group"} handleChange={this.handleFormChange}
-            inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated} />
+            labelClassName="col-xs-4 control-label" wrapperClassName="col-xs-8" groupClassName={hidden ? "hidden" : "form-group"} handleChange={this.handleFormChange} />
     );
 }
 

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -427,7 +427,7 @@ var evalFormNoteSectionWrapper = module.exports.evalFormNoteSectionWrapper = fun
             {criteriaList.map((criteria, i) => {
                 return (
                     <span key={i}>
-                        <strong>{criteria}:</strong> {evidenceCodes[criteria].definitionLong}
+                        <strong>{criteria}:</strong> <span dangerouslySetInnerHTML={ { __html: evidenceCodes[criteria].definitionLong } }></span>
                         {evidenceCodes[criteria].diseaseDependent ? <span><br /><span className="label label-warning pull-right">Disease-specific</span></span> : null}
                         {i < criteriaList.length - 1 ? <span><br /><br /></span> : null}
                     </span>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -408,7 +408,7 @@ var evalFormSectionWrapper = module.exports.evalFormSectionWrapper = function(no
 // description and disease-dependency are ascertained from evidence_codes.json
 var evalFormNoteSectionWrapper = module.exports.evalFormNoteSectionWrapper = function(criteriaList) {
     return (
-        <p className="alert alert-info">
+        <p className="alert alert-info criteria-description">
             {criteriaList.map((criteria, i) => {
                 return (
                     <span key={i}>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -12,6 +12,14 @@ var FormMixin = form.FormMixin;
 var Input = form.Input;
 var InputMixin = form.InputMixin;
 
+/*
+NOTE: disease dependency of criteria codes are in a state of flux right now. The mapping to actually
+dictate whether or not a criteria is disease-dependent is in ../mapping/evidence_code.json, but the
+code to deal with the associated form rendering and storing is here. If criteria codes need to have
+their disease dependency modified, edit evidence_code. To change or remove its behavior, edit here
+(search for 'diseaseCriteria', 'diseaseAssociated', 'diseaseDependent', and finally 'disease')
+*/
+
 // Form component to be re-used by various tabs
 var CurationInterpretationForm = module.exports.CurationInterpretationForm = React.createClass({
     mixins: [RestMixin, FormMixin],

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1647,3 +1647,7 @@ dl.inline-dl {
         background-color: #fff;
     }
 }
+
+.criteria-description {
+    text-overflow: clip;
+}


### PR DESCRIPTION
#### Connects to #947:

* Disabled disease-dependent logic for rendering and saving data in `form.js`
* Updated form rendering to support HTML codes form json for descriptions
* Fixed typos in descriptions

Testing:

1. Load VCI, begin interpretation
2. Confirm that the correct criteria are marked as 'Disease-specific'
3. Confirm that disease-specific criteria are still available for editing and saving with no disease being associated to interpretation
3. Save interpretation with and without disease-specific tags, with and without disease associated to interpretation, and confirm that things work

#### Connects to #937:

Testing:

1. Load VCI and begin interpretation on Windows machine (Chrome, since FF login is broken)
2. Check PP3 (missense subtab) and PVS1 (lof subtab) and confirm that the text in the description box does not ellipsis.

![image](https://cloud.githubusercontent.com/assets/4326866/18066113/cde3b2fa-6deb-11e6-8bfe-fae6e0f43f14.png)
![image](https://cloud.githubusercontent.com/assets/4326866/18066137/dffa977e-6deb-11e6-8223-ce1c7a81189c.png)

#### Connects to #978:

Testing:

1. Load VCI and begin interpretation
2. Confirm that the 'Disease dependent' labels on the form description boxes now say 'Disease-specific'

![image](https://cloud.githubusercontent.com/assets/4326866/18291063/ee0e9130-743a-11e6-8254-2f5e261559ac.png)
