### PR TITLE
Connects to #946. ClinVar variant no genomic info.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -345,6 +345,20 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         return url;
     },
 
+    // Function to render message for ClinVar Primary transcript table
+    // when no transcript data is found
+    renderClinvarTranscriptMessage: function(clinvarId) {
+        if (clinvarId) {
+            return (
+                <span>No ClinVar Primary Transcript was found for ClinVar VariationID <a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinvarId} target="_blank">{clinvarId}</a>.</span>
+            );
+        } else {
+            return (
+                <span>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</span>
+            );
+        }
+    },
+
     render: function() {
         var clinvar_id = this.state.clinvar_id;
         var car_id = this.state.car_id;
@@ -436,7 +450,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             </tbody>
                         </table>
                         :
-                        <table className="table"><tbody><tr><td>No ClinVar Primary Transcript was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
+                        <div className="panel-body">{self.renderClinvarTranscriptMessage(clinvar_id)}</div>
                     }
                 </div>
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -156,12 +156,16 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // Get the primary RefSeq transcript from VEP response
         let ensemblTranscripts = this.state.ensembl_transcripts;
         let transcript = {},
+            neucleotide_hgvs,
             exon = '--',
             protein_hgvs = '--',
             SO_id_term = '--';
         let result = nucleotide_change.find((n) => str.indexOf(n.AccessionVersion) > -1);
-        if (result && molecular_consequence.length) {
-            let item = molecular_consequence.find((x) => x.HGVS === result.HGVS);
+        if (result) {
+            neucleotide_hgvs = result.HGVS;
+        }
+        if (neucleotide_hgvs && molecular_consequence.length) {
+            let item = molecular_consequence.find((x) => x.HGVS === neucleotide_hgvs);
             // 'SO_terms' is defined via requiring external mapping file
             if (item) {
                 let found = SO_terms.find((entry) => entry.SO_id === item.SOid);
@@ -175,7 +179,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // Filter RefSeq transcripts by 'source' and 'hgvsc' flags
         ensemblTranscripts.forEach(refseqTranscript => {
             if (refseqTranscript.source === 'RefSeq') {
-                if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === result.HGVS) {
+                if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === neucleotide_hgvs) {
                     exon = refseqTranscript.exon ? refseqTranscript.exon : '--';
                     protein_hgvs = refseqTranscript.hgvsp ? refseqTranscript.hgvsp : '--';
                 }
@@ -183,7 +187,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         });
         // Set transcript object properties
         transcript = {
-            "nucleotide": result.HGVS,
+            "nucleotide": neucleotide_hgvs,
             "exon": exon,
             "protein": protein_hgvs,
             "molecular": SO_id_term
@@ -404,7 +408,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info">
                     <div className="panel-heading"><h3 className="panel-title">ClinVar Primary Transcript</h3></div>
-                    {(clinvar_id && primary_transcript) ?
+                    {(primary_transcript && primary_transcript.nucleotide) ?
                         <table className="table">
                             <thead>
                                 <tr>
@@ -417,7 +421,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <tbody>
                                 <tr>
                                     <td className="hgvs-term">
-                                        <span className="title-ellipsis">{(primary_transcript) ? primary_transcript.nucleotide : '--'}</span>
+                                        <span className="title-ellipsis">{primary_transcript.nucleotide}</span>
                                     </td>
                                     <td>
                                         {primary_transcript.exon}
@@ -426,13 +430,13 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                         {primary_transcript.protein}
                                     </td>
                                     <td>
-                                        {(primary_transcript) ? primary_transcript.molecular : '--'}
+                                        {primary_transcript.molecular}
                                     </td>
                                 </tr>
                             </tbody>
                         </table>
                         :
-                        <table className="table"><tbody><tr><td>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
+                        <table className="table"><tbody><tr><td>No ClinVar Primary Transcript was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
                     }
                 </div>
 

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -156,16 +156,16 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // Get the primary RefSeq transcript from VEP response
         let ensemblTranscripts = this.state.ensembl_transcripts;
         let transcript = {},
-            neucleotide_hgvs,
+            nucleotide_hgvs,
             exon = '--',
             protein_hgvs = '--',
             SO_id_term = '--';
         let result = nucleotide_change.find((n) => str.indexOf(n.AccessionVersion) > -1);
         if (result) {
-            neucleotide_hgvs = result.HGVS;
+            nucleotide_hgvs = result.HGVS;
         }
-        if (neucleotide_hgvs && molecular_consequence.length) {
-            let item = molecular_consequence.find((x) => x.HGVS === neucleotide_hgvs);
+        if (nucleotide_hgvs && molecular_consequence.length) {
+            let item = molecular_consequence.find((x) => x.HGVS === nucleotide_hgvs);
             // 'SO_terms' is defined via requiring external mapping file
             if (item) {
                 let found = SO_terms.find((entry) => entry.SO_id === item.SOid);
@@ -179,7 +179,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // Filter RefSeq transcripts by 'source' and 'hgvsc' flags
         ensemblTranscripts.forEach(refseqTranscript => {
             if (refseqTranscript.source === 'RefSeq') {
-                if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === neucleotide_hgvs) {
+                if (refseqTranscript.hgvsc && refseqTranscript.hgvsc === nucleotide_hgvs) {
                     exon = refseqTranscript.exon ? refseqTranscript.exon : '--';
                     protein_hgvs = refseqTranscript.hgvsp ? refseqTranscript.hgvsp : '--';
                 }
@@ -187,7 +187,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         });
         // Set transcript object properties
         transcript = {
-            "nucleotide": neucleotide_hgvs,
+            "nucleotide": nucleotide_hgvs,
             "exon": exon,
             "protein": protein_hgvs,
             "molecular": SO_id_term


### PR DESCRIPTION
**Technical details:**
Some ClinVar variants may have no NC genomic information nor the NM transcripts (e.g. neucleotide change), such as http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=91723. When the ClinVar variant has no NM transcript, it stalls other scripts because currently the VCI assumes the presence of at least one NM transcript in a ClinVar variant. As such, changes are added to work around this issue so that other scripts are still executed.

**Steps to test:**
1. Login and use variant_id **91723** as the variation selection interface.
2. Proceed to the Basic Info tab and expect to see the "_No ClinVar Primary Transcript was found for ClinVar VariationID 91723."_ message being displayed in the **ClinVar Primary Transcript** table. Also expect to see RCV data being displayed in the **ClinVar Interpretations** table.
3. Proceed to the **Predictors** tab and expect to see the "_Additional ClinVar variants found in the same codon: 2"_ message being displayed in the **Other Variants in Same Codon** panel.