### PR TITLE
Connects to #935. Codon search changes.

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -240,7 +240,7 @@ var VariantCurationHub = React.createClass({
 
     // Method to fetch Gene-centric data from mygene.info
     // and pass the data object to child component
-    fetchMyGeneInfo: function(geneSymbol, geneId, source) {;
+    fetchMyGeneInfo: function(geneSymbol, geneId, source) {
         if (geneSymbol) {
             this.getRestData('/genes/' + geneSymbol).then(response => {
                 this.setState({ext_geneSynonyms: response.synonyms});

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -117,16 +117,17 @@ var VariantCurationHub = React.createClass({
                     this.setState({ext_myVariantInfo: response});
                     this.parseMyVariantInfo(response);
                     // check dbsnfp data for bustamante query
-                    var hgvsObj = {};
+                    let hgvsObj = {};
+                    hgvsObj.chrom = (response.chrom) ? response.chrom : null;
+                    hgvsObj.pos = (response.hg19.start) ? response.hg19.start : null;
                     if (response.dbnsfp) {
-                        hgvsObj.chrom = (response.dbnsfp.chrom) ? response.dbnsfp.chrom : null;
-                        hgvsObj.pos = (response.dbnsfp.hg19.start) ? response.dbnsfp.hg19.start : null;
                         hgvsObj.alt = (response.dbnsfp.alt) ? response.dbnsfp.alt : null;
                         return Promise.resolve(hgvsObj);
                     } else if (response.clinvar) {
-                        hgvsObj.chrom = (response.clinvar.chrom) ? response.clinvar.chrom : null;
-                        hgvsObj.pos = (response.clinvar.hg19.start) ? response.clinvar.hg19.start : null;
                         hgvsObj.alt = (response.clinvar.alt) ? response.clinvar.alt : null;
+                        return Promise.resolve(hgvsObj);
+                    } else if (response.dbsnp) {
+                        hgvsObj.alt = (response.dbsnp.alt) ? response.dbsnp.alt : null;
                         return Promise.resolve(hgvsObj);
                     }
                 }).then(data => {

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -276,9 +276,9 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             let computationObj = this.state.computationObj;
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.conservation.phylop7way = parseFloat(dbnsfp.phylo.p7way.vertebrate);
+            computationObj.conservation.phylop7way = (dbnsfp.phylo.p7way) ? parseFloat(dbnsfp.phylo.p7way.vertebrate) : parseFloat(dbnsfp.phylo.p100way.vertebrate);
             computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian);
-            computationObj.conservation.phastconsp7way = parseFloat(dbnsfp.phastcons['7way'].vertebrate);
+            computationObj.conservation.phastconsp7way = (dbnsfp.phastcons['7way']) ? parseFloat(dbnsfp.phastcons['7way'].vertebrate) : parseFloat(dbnsfp.phastcons['100way'].vertebrate);
             computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian);
             computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs);
             computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds);

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -126,6 +126,7 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
             alt_protein_change = stringArray[0] + num + stringArray[1].substr(0, 1);
         }
     }
+    // Set protein change property value
     if (protein_change) {
         variant.allele.ProteinChange = protein_change.textContent;
     } else if (alt_protein_change) {

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -107,8 +107,32 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     var geneNode = geneList.getElementsByTagName('Gene')[0];
     variant.gene.symbol = geneNode.getAttribute('Symbol');
     variant.gene.full_name = geneNode.getAttribute('FullName');
-    var protein_change = allele.getElementsByTagName('ProteinChange')[0];
-    variant.allele.ProteinChange = protein_change ? protein_change.textContent : null;
+    // Evaluate whether a variant has protein change
+    // First check whether te <ProteinChange> node exists. If not,
+    // then check whether the <HGVS> node with Type="HGVS, protein, RefSeq" attribute exists
+    const protein_change = allele.getElementsByTagName('ProteinChange')[0];
+    let alt_protein_change;
+    if (variant.RefSeqTranscripts.ProteinChangeList.length > 0) {
+        const changeAttr = variant.RefSeqTranscripts.ProteinChangeList[0].Change;
+        if (changeAttr.length) {
+            // Remove 'p.' from string value
+            let posStart = changeAttr.indexOf('.') + 1;
+            let newAttrValue = changeAttr.slice(posStart);
+            // Extract the numbers into a new string
+            let num = newAttrValue.match(/[0-9]+(?!.*[0-9])/);
+            // Separate groups of letters into arrays
+            let stringArray = newAttrValue.split(/[0-9]+(?!.*[0-9])/);
+            // Transform string into the format similar to common <ProteinChange> value
+            alt_protein_change = stringArray[0] + num + stringArray[1].substr(0, 1);
+        }
+    }
+    if (protein_change) {
+        variant.allele.ProteinChange = protein_change.textContent;
+    } else if (alt_protein_change) {
+        variant.allele.ProteinChange = alt_protein_change;
+    } else {
+        variant.allele.ProteinChange = null;
+    }
     // Parse <SequenceLocation> nodes
     var SequenceLocationNodes = allele.getElementsByTagName('SequenceLocation');
     if (SequenceLocationNodes) {


### PR DESCRIPTION
**Technical details:**
1. This PR primarily addresses the issue in which a ClinVar variant does not return the `<ProteinChange>` node in its XML data but has legit protein change (e.g. http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=17662). As such, we need to show the correct message in the "Other Variants in Same Codon" panel.
2. Certain dbnsfp object in the myvariant.info data return `phylo.p100way` and `phastcons.100way` fields (e.g. http://myvariant.info/v1/variant/chr14:g.23884860C%3ET) instead of `phylo.p7way` and `phastcons.7way` fields (e.g. http://myvariant.info/v1/variant/chr3:g.71019907G%3EA). I understand that myvariant.info is in the process of changing `p7way` to `p100way` for the predictors. Until they are finished, we need to account for both possibilities to extract the conservation analysis predictors data.
3. Certain variant in the myvariant.info data does not return the expected `dbnsfp` or `clinvar` objects for extracting the `alt` field in making `Bustamante` API call (e.g. http://myvariant.info/v1/variant/chr17:g.41276045_41276046del). As such, we are adding `dbsnp` as an additional fallback data source.

**Steps to test:**
1. Sign into VCI and use 17662 variant_id at the variation selection interface.
2. Proceed to the `Predictors` tab and expect to see the "The current variant is the only variant found in this codon in ClinVar" message in the "Other Variants in Same Codon" section, as well as there is no `MyVariant or Bustamante Fetch Error=: TypeError: Cannot read property 'chrom' of undefined(…)` error in the Chrome DevTools console.
3. Change to use 21134 and/or 36642 variant_ids. Expect to see the "The current variant is the only variant found in this codon in ClinVar" message on the `Predictors` tab as well as there is no `Cannot read property 'vertebrate' of undefined` error in the Chrome DevTools console.