### PR TITLE
Connects to #925. Adding activity indicator.

### DIFF
--- a/src/clincoded/static/components/activity_indicator.js
+++ b/src/clincoded/static/components/activity_indicator.js
@@ -1,0 +1,18 @@
+// # Activity Indicator Helper Method
+// # Parameters: message string while loading data
+// # Usage: showActivityIndicator('Loading... ')
+// # Dependency: None
+
+'use strict';
+import React from 'react';
+
+export function showActivityIndicator(message) {
+    return (
+		<div className="activity-indicator overlay-wrapper">
+			<div className="overlay-content">
+				{message}
+				<i className="icon icon-spin icon-circle-o-notch"></i>
+			</div>
+		</div>
+    );
+}

--- a/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
+++ b/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
@@ -32,7 +32,7 @@ export function getClinvarRCVs(xml) {
 }
 
 // Method to parse conditions data for the most recent version of individual RCV accession
-export function parseClinvarInterpretation(RCV, result) {
+export function parseClinvarInterpretation(result) {
     // Define 'interpretation' object model
     let interpretation = {
         'RCV': '',
@@ -48,6 +48,8 @@ export function parseClinvarInterpretation(RCV, result) {
         if (ClinVarSet) {
             let ReferenceClinVarAssertion = ClinVarSet.getElementsByTagName('ReferenceClinVarAssertion')[0];
             if (ReferenceClinVarAssertion) {
+                // Get clinvar accession if <ReferenceClinVarAssertion> node is found
+                let ClinVarAccession = ReferenceClinVarAssertion.getElementsByTagName('ClinVarAccession')[0];
                 // Get clinical significance description if <ReferenceClinVarAssertion> node is found
                 let ClinicalSignificance = ReferenceClinVarAssertion.getElementsByTagName('ClinicalSignificance')[0];
                 if (ClinicalSignificance) {
@@ -55,7 +57,7 @@ export function parseClinvarInterpretation(RCV, result) {
                     let ReviewStatus = ClinicalSignificance.getElementsByTagName('ReviewStatus')[0];
                     let Description = ClinicalSignificance.getElementsByTagName('Description')[0];
                     // Set 'RCV' and 'clinicalSignificance' property values of the 'interpretation' object
-                    interpretation['RCV'] = RCV;
+                    interpretation['RCV'] = ClinVarAccession.getAttribute('Acc');
                     interpretation['reviewStatus'] = ReviewStatus.textContent;
                     interpretation['clinicalSignificance'] = Description.textContent;
                 }

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -97,18 +97,24 @@ var VariantCurationHub = React.createClass({
                     // parse associated disease and clinical significance for each id
                     if (RCVs.length) {
                         let clinvarInterpretations = [];
+                        let Urls = [];
                         for (let RCV of RCVs.values()) {
-                            this.getRestDataXml(this.props.href_url.protocol + external_url_map['ClinVarEfetch'] + '&rettype=clinvarset&id=' + RCV).then(result => {
-                                let clinvarInterpretation = parseClinvarInterpretation(RCV, result);
+                            Urls.push(this.props.href_url.protocol + external_url_map['ClinVarEfetch'] + '&rettype=clinvarset&id=' + RCV);
+                        }
+                        return this.getRestDatasXml(Urls).then(xml => {
+                            xml.forEach(result => {
+                                let clinvarInterpretation = parseClinvarInterpretation(result);
                                 clinvarInterpretations.push(clinvarInterpretation);
                                 this.setState({ext_clinVarRCV: clinvarInterpretations});
-                            }).catch(err => {
-                                this.setState({loading_clinvarRCV: false});
-                                console.log('ClinVarEfetch for RCV Error=: %o', err);
                             });
-                        }
+                            this.setState({loading_clinvarRCV: false});
+                        }).catch(err => {
+                            this.setState({loading_clinvarRCV: false});
+                            console.log('ClinVarEfetch for RCV Error=: %o', err);
+                        });
+                    } else {
+                        this.setState({loading_clinvarRCV: false});
                     }
-                    this.setState({loading_clinvarRCV: false});
                 }).catch(err => {
                     this.setState({
                         loading_clinvarEutils: false,

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -135,8 +135,9 @@ var VariantCurationHub = React.createClass({
                     this.getRestData('https:' + external_url_map['Bustamante'] + data.chrom + '/' + data.pos + '/' + data.alt + '/').then(result => {
                         this.setState({ext_bustamante: result});
                     });
-                }).catch(function(e) {
-                    console.log('MyVariant or Bustamante Fetch Error=: %o', e);
+                }).catch(err => {
+                    this.setState({isClinVarLoading: false});
+                    console.log('MyVariant or Bustamante Fetch Error=: %o', err);
                 });
             }
         }

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -95,16 +95,15 @@ var VariantCurationHub = React.createClass({
                                 let clinvarInterpretation = parseClinvarInterpretation(RCV, result);
                                 clinvarInterpretations.push(clinvarInterpretation);
                                 this.setState({ext_clinVarRCV: clinvarInterpretations});
-                            }).catch(function(e) {
+                            }).catch(err => {
                                 this.setState({isClinVarLoading: false});
-                                console.log('ClinVarEfetch for RCV Error=: %o', e);
+                                console.log('ClinVarEfetch for RCV Error=: %o', err);
                             });
                         }
                         this.setState({isClinVarLoading: false});
-                        console.log('this.state.isClinVarLoading is === ' + this.state.isClinVarLoading);
                     }
-                }).catch(function(e) {
-                    console.log('ClinVarEutils Fetch Error=: %o', e);
+                }).catch(err => {
+                    console.log('ClinVarEutils Fetch Error=: %o', err);
                 });
             }
         }

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -89,6 +89,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_ensemblHgvsVEP) {
             this.setState({ext_ensemblHgvsVEP: nextProps.ext_ensemblHgvsVEP});
+            if (!nextProps.ext_clinVarRCV) {
+                this.setState({isClinVarLoading: nextProps.isClinVarLoading});
+            }
         }
         if (nextProps.ext_clinvarEutils) {
             this.setState({ext_clinvarEutils: nextProps.ext_clinvarEutils});

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -42,7 +42,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_clinVarEsearch: React.PropTypes.object,
         ext_clinVarRCV: React.PropTypes.array,
         ext_ensemblGeneId: React.PropTypes.string,
-        ext_geneSynonyms: React.PropTypes.array
+        ext_geneSynonyms: React.PropTypes.array,
+        isClinVarLoading: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -59,6 +60,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinVarRCV: this.props.ext_clinVarRCV,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
+            isClinVarLoading: this.props.isClinVarLoading,
             //remember current tab/subtab so user will land on that tab when interpretation starts
             selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('tab', this.props.href_url.href)) > -1 ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info') : 'basic-info')  : 'basic-info'),
         };
@@ -95,7 +97,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             this.setState({ext_clinVarEsearch: nextProps.ext_clinVarEsearch});
         }
         if (nextProps.ext_clinVarRCV) {
-            this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV});
+            this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV, isClinVarLoading: nextProps.isClinVarLoading});
         }
         if (nextProps.ext_ensemblGeneId) {
             this.setState({ext_ensemblGeneId: nextProps.ext_ensemblGeneId});
@@ -143,7 +145,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
-                            ext_clinVarRCV={this.state.ext_clinVarRCV} />
+                            ext_clinVarRCV={this.state.ext_clinVarRCV}
+                            isClinVarLoading={this.state.isClinVarLoading} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'population' ?

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -43,7 +43,14 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_clinVarRCV: React.PropTypes.array,
         ext_ensemblGeneId: React.PropTypes.string,
         ext_geneSynonyms: React.PropTypes.array,
-        isClinVarLoading: React.PropTypes.bool
+        loading_clinvarEutils: React.PropTypes.bool,
+        loading_clinvarEsearch: React.PropTypes.bool,
+        loading_clinvarRCV: React.PropTypes.bool,
+        loading_ensemblHgvsVEP: React.PropTypes.bool,
+        loading_ensemblVariation: React.PropTypes.bool,
+        loading_myVariantInfo: React.PropTypes.bool,
+        loading_myGeneInfo: React.PropTypes.bool,
+        loading_bustamante: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -60,7 +67,14 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinVarRCV: this.props.ext_clinVarRCV,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
-            isClinVarLoading: this.props.isClinVarLoading,
+            loading_clinvarEutils: this.props.loading_clinvarEutils,
+            loading_clinvarEsearch: this.props.loading_clinvarEsearch,
+            loading_clinvarRCV: this.props.loading_clinvarRCV,
+            loading_ensemblHgvsVEP: this.props.loading_ensemblHgvsVEP,
+            loading_ensemblVariation: this.props.loading_ensemblVariation,
+            loading_myVariantInfo: this.props.loading_myVariantInfo,
+            loading_myGeneInfo: this.props.loading_myGeneInfo,
+            loading_bustamante: this.props.loading_bustamante,
             //remember current tab/subtab so user will land on that tab when interpretation starts
             selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('tab', this.props.href_url.href)) > -1 ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info') : 'basic-info')  : 'basic-info'),
         };
@@ -89,9 +103,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_ensemblHgvsVEP) {
             this.setState({ext_ensemblHgvsVEP: nextProps.ext_ensemblHgvsVEP});
-            if (!nextProps.ext_clinVarRCV) {
-                this.setState({isClinVarLoading: nextProps.isClinVarLoading});
-            }
         }
         if (nextProps.ext_clinvarEutils) {
             this.setState({ext_clinvarEutils: nextProps.ext_clinvarEutils});
@@ -100,7 +111,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             this.setState({ext_clinVarEsearch: nextProps.ext_clinVarEsearch});
         }
         if (nextProps.ext_clinVarRCV) {
-            this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV, isClinVarLoading: nextProps.isClinVarLoading});
+            this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV});
         }
         if (nextProps.ext_ensemblGeneId) {
             this.setState({ext_ensemblGeneId: nextProps.ext_ensemblGeneId});
@@ -108,6 +119,16 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         if (nextProps.ext_geneSynonyms) {
             this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
         }
+        this.setState({
+            loading_myGeneInfo: nextProps.loading_myGeneInfo,
+            loading_myVariantInfo: nextProps.loading_myVariantInfo,
+            loading_bustamante: nextProps.loading_bustamante,
+            loading_ensemblVariation: nextProps.loading_ensemblVariation,
+            loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
+            loading_clinvarEutils: nextProps.loading_clinvarEutils,
+            loading_clinvarEsearch: nextProps.loading_clinvarEsearch,
+            loading_clinvarRCV: nextProps.loading_clinvarRCV
+        });
     },
 
     // set selectedTab to whichever tab the user switches to, and update the address accordingly
@@ -149,7 +170,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_clinVarRCV={this.state.ext_clinVarRCV}
-                            isClinVarLoading={this.state.isClinVarLoading} />
+                            loading_clinvarEutils={this.state.loading_clinvarEutils}
+                            loading_clinvarRCV={this.state.loading_clinvarRCV}
+                            loading_ensemblHgvsVEP={this.state.loading_ensemblHgvsVEP} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'population' ?
@@ -158,7 +181,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
                             ext_ensemblVEP={this.state.ext_ensemblVEP}
-                            ext_ensemblVariation={this.state.ext_ensemblVariation} />
+                            ext_ensemblVariation={this.state.ext_ensemblVariation}
+                            loading_myVariantInfo={this.state.loading_myVariantInfo}
+                            loading_ensemblVariation={this.state.loading_ensemblVariation} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'predictors' ?
@@ -168,7 +193,10 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
                             ext_bustamante={this.state.ext_bustamante}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
-                            ext_clinVarEsearch={this.state.ext_clinVarEsearch} />
+                            ext_clinVarEsearch={this.state.ext_clinVarEsearch}
+                            loading_bustamante={this.state.loading_bustamante}
+                            loading_myVariantInfo={this.state.loading_myVariantInfo}
+                            loading_clinvarEsearch={this.state.loading_clinvarEsearch} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'experimental' ?
@@ -189,7 +217,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myGeneInfo={this.state.ext_myGeneInfo}
                             ext_ensemblGeneId={this.state.ext_ensemblGeneId}
-                            ext_geneSynonyms={this.state.ext_geneSynonyms} />
+                            ext_geneSynonyms={this.state.ext_geneSynonyms}
+                            loading_myGeneInfo={this.state.loading_myGeneInfo} />
                     </div>
                     : null}
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -46,8 +46,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             hasHgvsGRCh38: false,
             gene_symbol: null,
             uniprot_id: null,
-            hasRefseqData: false,
-            hasEnsemblData: false,
             isClinVarLoading: this.props.isClinVarLoading
         };
     },
@@ -58,7 +56,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
         if (this.props.ext_ensemblHgvsVEP) {
             this.setState({
-                hasEnsemblData: true,
                 ensembl_transcripts: this.props.ext_ensemblHgvsVEP[0].transcript_consequences
             });
         }
@@ -76,10 +73,10 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
         // update data based on api call results
         if (nextProps.ext_ensemblHgvsVEP) {
-            this.setState({
-                hasEnsemblData: true,
-                ensembl_transcripts: nextProps.ext_ensemblHgvsVEP[0].transcript_consequences
-            });
+            this.setState({ensembl_transcripts: nextProps.ext_ensemblHgvsVEP[0].transcript_consequences});
+            if (!nextProps.ext_clinVarRCV) {
+                this.setState({isClinVarLoading: nextProps.isClinVarLoading});
+            }
         }
         if (nextProps.ext_clinvarEutils) {
             this.parseClinVarEutils(nextProps.ext_clinvarEutils);
@@ -87,13 +84,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (nextProps.ext_clinVarRCV) {
             this.setState({clinVarRCV: nextProps.ext_clinVarRCV, isClinVarLoading: nextProps.isClinVarLoading});
         }
-    },
-
-    componentWillUnmount: function() {
-        this.setState({
-            hasRefseqData: false,
-            hasEnsemblData: false
-        });
     },
 
     componentDidUpdate: function(prevProps, prevState) {
@@ -139,7 +129,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
     parseClinVarEutils: function(variantData) {
         this.setState({
-            hasRefseqData: true,
             nucleotide_change: variantData.RefSeqTranscripts.NucleotideChangeList,
             protein_change: variantData.RefSeqTranscripts.ProteinChangeList,
             molecular_consequence: variantData.RefSeqTranscripts.MolecularConsequenceList,

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -13,6 +13,7 @@ var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 
 import { renderDataCredit } from './shared/credit';
+import { showActivityIndicator } from '../../activity_indicator';
 
 // Display the curator data of the curation data
 var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasicInfo = React.createClass({
@@ -23,7 +24,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         href_url: React.PropTypes.object,
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
-        ext_clinVarRCV: React.PropTypes.array
+        ext_clinVarRCV: React.PropTypes.array,
+        isClinVarLoading: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -45,7 +47,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             gene_symbol: null,
             uniprot_id: null,
             hasRefseqData: false,
-            hasEnsemblData: false
+            hasEnsemblData: false,
+            isClinVarLoading: this.props.isClinVarLoading
         };
     },
 
@@ -82,7 +85,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             this.parseClinVarEutils(nextProps.ext_clinvarEutils);
         }
         if (nextProps.ext_clinVarRCV) {
-            this.setState({clinVarRCV: nextProps.ext_clinVarRCV});
+            this.setState({clinVarRCV: nextProps.ext_clinVarRCV, isClinVarLoading: nextProps.isClinVarLoading});
         }
     },
 
@@ -381,25 +384,30 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info datasource-clinvar-interpretaions">
                     <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretations</h3></div>
-                    {(clinVarRCV.length > 0) ?
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Reference Accession</th>
-                                    <th>Review Status</th>
-                                    <th>Clinical Significance</th>
-                                    <th>Disease [Source]</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {clinVarRCV.map(function(item, i) {
-                                    return (self.renderClinvarInterpretations(item, i));
-                                })}
-                            </tbody>
-                        </table>
-                        :
-                        <table className="table"><tbody><tr><td>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.isClinVarLoading ? showActivityIndicator('Retrieving data... ') : null}
+                        {(clinVarRCV.length > 0) ?
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Reference Accession</th>
+                                        <th>Review Status</th>
+                                        <th>Clinical Significance</th>
+                                        <th>Disease [Source]</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {clinVarRCV.map(function(item, i) {
+                                        return (self.renderClinvarInterpretations(item, i));
+                                    })}
+                                </tbody>
+                            </table>
+                            :
+                            <div className="panel-body">
+                                <span>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</span>
+                            </div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info">

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -25,7 +25,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
         ext_clinVarRCV: React.PropTypes.array,
-        isClinVarLoading: React.PropTypes.bool
+        loading_clinvarEutils: React.PropTypes.bool,
+        loading_clinvarRCV: React.PropTypes.bool,
+        loading_ensemblHgvsVEP: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -46,7 +48,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             hasHgvsGRCh38: false,
             gene_symbol: null,
             uniprot_id: null,
-            isClinVarLoading: this.props.isClinVarLoading
+            loading_clinvarEutils: this.props.loading_clinvarEutils,
+            loading_clinvarRCV: this.props.loading_clinvarRCV,
+            loading_ensemblHgvsVEP: this.props.loading_ensemblHgvsVEP
         };
     },
 
@@ -74,16 +78,18 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         // update data based on api call results
         if (nextProps.ext_ensemblHgvsVEP) {
             this.setState({ensembl_transcripts: nextProps.ext_ensemblHgvsVEP[0].transcript_consequences});
-            if (!nextProps.ext_clinVarRCV) {
-                this.setState({isClinVarLoading: nextProps.isClinVarLoading});
-            }
         }
         if (nextProps.ext_clinvarEutils) {
             this.parseClinVarEutils(nextProps.ext_clinvarEutils);
         }
         if (nextProps.ext_clinVarRCV) {
-            this.setState({clinVarRCV: nextProps.ext_clinVarRCV, isClinVarLoading: nextProps.isClinVarLoading});
+            this.setState({clinVarRCV: nextProps.ext_clinVarRCV});
         }
+        this.setState({
+            loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
+            loading_clinvarEutils: nextProps.loading_clinvarEutils,
+            loading_clinvarRCV: nextProps.loading_clinvarRCV
+        });
     },
 
     componentDidUpdate: function(prevProps, prevState) {
@@ -374,7 +380,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 <div className="panel panel-info datasource-clinvar-interpretaions">
                     <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretations</h3></div>
                     <div className="panel-content-wrapper">
-                        {this.state.isClinVarLoading ? showActivityIndicator('Retrieving data... ') : null}
+                        {this.state.loading_clinvarRCV ? showActivityIndicator('Retrieving data... ') : null}
                         {(clinVarRCV.length > 0) ?
                             <table className="table">
                                 <thead>
@@ -401,36 +407,41 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
 
                 <div className="panel panel-info">
                     <div className="panel-heading"><h3 className="panel-title">ClinVar Primary Transcript</h3></div>
-                    {(clinvar_id && primary_transcript) ?
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Nucleotide Change</th>
-                                    <th>Exon</th>
-                                    <th>Protein Change</th>
-                                    <th>Molecular Consequence</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td className="hgvs-term">
-                                        <span className="title-ellipsis">{(primary_transcript) ? primary_transcript.nucleotide : '--'}</span>
-                                    </td>
-                                    <td>
-                                        {primary_transcript.exon}
-                                    </td>
-                                    <td>
-                                        {primary_transcript.protein}
-                                    </td>
-                                    <td>
-                                        {(primary_transcript) ? primary_transcript.molecular : '--'}
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        :
-                        <table className="table"><tbody><tr><td>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</td></tr></tbody></table>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_clinvarEutils ? showActivityIndicator('Retrieving data... ') : null}
+                        {(clinvar_id && primary_transcript) ?
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Nucleotide Change</th>
+                                        <th>Exon</th>
+                                        <th>Protein Change</th>
+                                        <th>Molecular Consequence</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td className="hgvs-term">
+                                            <span className="title-ellipsis">{(primary_transcript) ? primary_transcript.nucleotide : '--'}</span>
+                                        </td>
+                                        <td>
+                                            {primary_transcript.exon}
+                                        </td>
+                                        <td>
+                                            {primary_transcript.protein}
+                                        </td>
+                                        <td>
+                                            {(primary_transcript) ? primary_transcript.molecular : '--'}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            :
+                            <div className="panel-body">
+                                <span>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</span>
+                            </div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info">
@@ -439,25 +450,30 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <span className="help-note panel-subtitle pull-right"><i className="icon icon-asterisk"></i> Canonical transcript</span>
                         </h3>
                     </div>
-                    {(this.state.hasHgvsGRCh38 && GRCh38) ?
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Nucleotide Change</th>
-                                    <th>Exon</th>
-                                    <th>Protein Change</th>
-                                    <th>Molecular Consequence</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {ensembl_data.map(function(item, i) {
-                                    return (self.renderRefSeqEnsemblTranscripts(item, i, 'RefSeq'));
-                                })}
-                            </tbody>
-                        </table>
-                        :
-                        <table className="table"><tbody><tr><td>No data was found for this allele in RefSeq. <a href="http://www.ncbi.nlm.nih.gov/refseq/" target="_blank">Search RefSeq</a> for this variant.</td></tr></tbody></table>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_ensemblHgvsVEP ? showActivityIndicator('Retrieving data... ') : null}
+                        {(this.state.hasHgvsGRCh38 && GRCh38) ?
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Nucleotide Change</th>
+                                        <th>Exon</th>
+                                        <th>Protein Change</th>
+                                        <th>Molecular Consequence</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {ensembl_data.map(function(item, i) {
+                                        return (self.renderRefSeqEnsemblTranscripts(item, i, 'RefSeq'));
+                                    })}
+                                </tbody>
+                            </table>
+                            :
+                            <div className="panel-body">
+                                <span>No data was found for this allele in RefSeq. <a href="http://www.ncbi.nlm.nih.gov/refseq/" target="_blank">Search RefSeq</a> for this variant.</span>
+                            </div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info">
@@ -466,25 +482,30 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                             <span className="help-note panel-subtitle pull-right"><i className="icon icon-asterisk"></i> Canonical transcript</span>
                         </h3>
                     </div>
-                    {(this.state.hasHgvsGRCh38 && GRCh38) ?
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>Nucleotide Change</th>
-                                    <th>Exon</th>
-                                    <th>Protein Change</th>
-                                    <th>Molecular Consequence</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {ensembl_data.map(function(item, i) {
-                                    return (self.renderRefSeqEnsemblTranscripts(item, i, 'Ensembl'));
-                                })}
-                            </tbody>
-                        </table>
-                        :
-                         <table className="table"><tbody><tr><td>No data was found for this allele in Ensembl. <a href="http://www.ensembl.org/Homo_sapiens/Info/Index" target="_blank">Search Ensembl</a> for this variant.</td></tr></tbody></table>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_ensemblHgvsVEP ? showActivityIndicator('Retrieving data... ') : null}
+                        {(this.state.hasHgvsGRCh38 && GRCh38) ?
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Nucleotide Change</th>
+                                        <th>Exon</th>
+                                        <th>Protein Change</th>
+                                        <th>Molecular Consequence</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {ensembl_data.map(function(item, i) {
+                                        return (self.renderRefSeqEnsemblTranscripts(item, i, 'Ensembl'));
+                                    })}
+                                </tbody>
+                            </table>
+                            :
+                            <div className="panel-body">
+                                <span>No data was found for this allele in Ensembl. <a href="http://www.ensembl.org/Homo_sapiens/Info/Index" target="_blank">Search Ensembl</a> for this variant.</span>
+                            </div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -22,6 +22,7 @@ var form = require('../../../libs/bootstrap/form');
 var externalLinks = require('./shared/externalLinks');
 
 import { renderDataCredit } from './shared/credit';
+import { showActivityIndicator } from '../../activity_indicator';
 
 var PanelGroup = panel.PanelGroup;
 var Panel = panel.Panel;
@@ -72,7 +73,10 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         href_url: React.PropTypes.object,
         ext_myVariantInfo: React.PropTypes.object,
         ext_bustamante: React.PropTypes.object,
-        ext_clinVarEsearch: React.PropTypes.object
+        ext_clinVarEsearch: React.PropTypes.object,
+        loading_bustamante: React.PropTypes.bool,
+        loading_myVariantInfo: React.PropTypes.bool,
+        loading_clinvarEsearch: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -109,7 +113,10 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 }
             },
             computationObjDiff: null,
-            computationObjDiffFlag: false
+            computationObjDiffFlag: false,
+            loading_bustamante: this.props.loading_bustamante,
+            loading_myVariantInfo: this.props.loading_myVariantInfo,
+            loading_clinvarEsearch: this.props.loading_clinvarEsearch
         };
     },
 
@@ -154,10 +161,14 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             codonObj.symbol = nextProps.ext_clinVarEsearch.vci_symbol;
             this.setState({codonObj: codonObj});
         }
-
         if (nextProps.interpretation && nextProps.interpretation.evaluations) {
             this.compareExternalDatas(this.state.computationObj, nextProps.interpretation.evaluations);
         }
+        this.setState({
+            loading_bustamante: nextProps.loading_bustamante,
+            loading_myVariantInfo: nextProps.loading_myVariantInfo,
+            loading_clinvarEsearch: nextProps.loading_clinvarEsearch
+        });
     },
 
     componentWillUnmount: function() {
@@ -443,100 +454,87 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </p>
                             </div>
                         : null}
-                        {clingenPred ?
-                            <div className="panel panel-info datasource-clingen">
-                                <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Source</th>
-                                            <th>Score Range</th>
-                                            <th>Score</th>
-                                            <th>Prediction</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {clingenPredStatic._order.map(key => {
-                                            return (this.renderClingenPredRow(key, clingenPred, clingenPredStatic));
-                                        })}
-                                    </tbody>
-                                </table>
+                        <div className="panel panel-info datasource-clingen">
+                            <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
+                            <div className="panel-content-wrapper">
+                                {this.state.loading_bustamante ? showActivityIndicator('Retrieving data... ') : null}
+                                {clingenPred ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Source</th>
+                                                <th>Score Range</th>
+                                                <th>Score</th>
+                                                <th>Prediction</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {clingenPredStatic._order.map(key => {
+                                                return (this.renderClingenPredRow(key, clingenPred, clingenPredStatic));
+                                            })}
+                                        </tbody>
+                                    </table>
+                                    :
+                                    <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                }
                             </div>
-                        :
-                            <div className="panel panel-info datasource-clingen">
-                                <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <td>No predictors were found for this allele.</td>
-                                        </tr>
-                                    </thead>
-                                </table>
+                        </div>
+                        <div className="panel panel-info datasource-other">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Other Predictors
+                                    <a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a>
+                                </h3>
                             </div>
-                        }
-
-                        {this.state.hasOtherPredData ?
-                            <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a></h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Source</th>
-                                            <th>Score Range</th>
-                                            <th>Score</th>
-                                            <th>Prediction</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {otherPredStatic._order.map(key => {
-                                            return (this.renderOtherPredRow(key, otherPred, otherPredStatic));
-                                        })}
-                                    </tbody>
-                                </table>
+                            <div className="panel-content-wrapper">
+                                {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
+                                {this.state.hasOtherPredData ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Source</th>
+                                                <th>Score Range</th>
+                                                <th>Score</th>
+                                                <th>Prediction</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {otherPredStatic._order.map(key => {
+                                                return (this.renderOtherPredRow(key, otherPred, otherPredStatic));
+                                            })}
+                                        </tbody>
+                                    </table>
+                                    :
+                                    <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                }
                             </div>
-                        :
-                            <div className="panel panel-info datasource-other">
-                                <div className="panel-heading"><h3 className="panel-title">Other Predictors<a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a></h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <td>No predictors were found for this allele.</td>
-                                        </tr>
-                                    </thead>
-                                </table>
+                        </div>
+                        <div className="panel panel-info datasource-conservation">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Conservation Analysis
+                                    <a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a>
+                                </h3>
                             </div>
-                        }
-
-                        {this.state.hasConservationData ?
-                            <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a></h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Source</th>
-                                            <th>Score</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {conservationStatic._order.map(key => {
-                                            return (this.renderConservationRow(key, conservation, conservationStatic));
-                                        })}
-                                    </tbody>
-                                </table>
+                            <div className="panel-content-wrapper">
+                                {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
+                                {this.state.hasConservationData ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Source</th>
+                                                <th>Score</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {conservationStatic._order.map(key => {
+                                                return (this.renderConservationRow(key, conservation, conservationStatic));
+                                            })}
+                                        </tbody>
+                                    </table>
+                                    :
+                                    <div className="panel-body"><span>No conservation analysis data found for this allele.</span></div>
+                                }
                             </div>
-                        :
-                            <div className="panel panel-info datasource-conservation">
-                                <div className="panel-heading"><h3 className="panel-title">Conservation Analysis<a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a></h3></div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <td>No conservation analysis data was found for this allele.</td>
-                                        </tr>
-                                    </thead>
-                                </table>
-                            </div>
-                        }
-
+                        </div>
                         <div className="panel panel-info datasource-splice">
                             <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
                             <div className="panel-body">
@@ -659,8 +657,11 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     <PanelGroup accordion><Panel title="Other Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
                         <div className="panel panel-info datasource-clinvar">
                             <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
-                            <div className="panel-body">
-                                {this.renderVariantCodon(variant, codon)}
+                            <div className="panel-content-wrapper">
+                                {this.state.loading_clinvarEsearch ? showActivityIndicator('Retrieving data... ') : null}
+                                <div className="panel-body">
+                                    {this.renderVariantCodon(variant, codon)}
+                                </div>
                             </div>
                         </div>
                         {(this.props.data && this.state.interpretation) ?

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -276,9 +276,9 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             let computationObj = this.state.computationObj;
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.conservation.phylop7way = parseFloat(dbnsfp.phylo.p7way.vertebrate);
+            computationObj.conservation.phylop7way = (dbnsfp.phylo.p7way) ? parseFloat(dbnsfp.phylo.p7way.vertebrate) : parseFloat(dbnsfp.phylo.p100way.vertebrate);
             computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian);
-            computationObj.conservation.phastconsp7way = parseFloat(dbnsfp.phastcons['7way'].vertebrate);
+            computationObj.conservation.phastconsp7way = (dbnsfp.phastcons['7way']) ? parseFloat(dbnsfp.phastcons['7way'].vertebrate) : parseFloat(dbnsfp.phastcons['100way'].vertebrate);
             computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian);
             computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs);
             computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds);

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -10,6 +10,7 @@ var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
 
 import { renderDataCredit } from './shared/credit';
+import { showActivityIndicator } from '../../activity_indicator';
 
 // Display the curator data of the curation data
 var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGeneSpecific = React.createClass({
@@ -22,7 +23,8 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
         href_url: React.PropTypes.object,
         ext_myGeneInfo: React.PropTypes.object,
         ext_ensemblGeneId: React.PropTypes.string,
-        ext_geneSynonyms: React.PropTypes.array
+        ext_geneSynonyms: React.PropTypes.array,
+        loading_myGeneInfo: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -31,7 +33,8 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
             interpretation: this.props.interpretation,
             ext_myGeneInfo: this.props.ext_myGeneInfo,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
-            ext_geneSynonyms: this.props.ext_geneSynonyms
+            ext_geneSynonyms: this.props.ext_geneSynonyms,
+            loading_myGeneInfo: this.props.loading_myGeneInfo
         };
     },
 
@@ -47,6 +50,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
         if (nextProps.ext_geneSynonyms) {
             this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
         }
+        this.setState({loading_myGeneInfo: nextProps.loading_myGeneInfo});
     },
 
     // Method to render constraint scores table
@@ -95,109 +99,125 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                 : null}
 
                 <div className="panel panel-info datasource-constraint-scores">
-                    <div className="panel-heading"><h3 className="panel-title">ExAC Constraint Scores<a href="#credit-mygene" className="credit-mygene" title="MyGene.info"><span>MyGene</span></a></h3></div>
-                    {(myGeneInfo && myGeneInfo.exac) ?
-                        <table className="table">
-                            <thead>
-                                <tr>
-                                    <th>&nbsp;</th>
-                                    <th>pLI</th>
-                                    <th>pRec</th>
-                                    <th>pNull</th>
-                                </tr>
-                            </thead>
+                    <div className="panel-heading">
+                        <h3 className="panel-title">ExAC Constraint Scores
+                            <a href="#credit-mygene" className="credit-mygene" title="MyGene.info"><span>MyGene</span></a>
+                        </h3>
+                    </div>
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_myGeneInfo ? showActivityIndicator('Retrieving data... ') : null}
+                        {(myGeneInfo && myGeneInfo.exac) ?
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>&nbsp;</th>
+                                        <th>pLI</th>
+                                        <th>pRec</th>
+                                        <th>pNull</th>
+                                    </tr>
+                                </thead>
 
-                            {this.renderConstraintScores(myGeneInfo)}
+                                {this.renderConstraintScores(myGeneInfo)}
 
-                            <tfoot>
-                                <tr className="footnote">
-                                    <td colSpan="4">
-                                        <dl className="inline-dl clearfix">
-                                            <dt>pLI:</dt><dd>the probability of being loss-of-function intolerant (intolerant of both heterozygous and homozygous LOF variants)</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>pRec:</dt><dd>the probability of being intolerant of homozygous, but not heterozygous LOF variants</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>pNull:</dt><dd>the probability of being tolerant of both heterozygous and homozygous LOF variants</dd>
-                                        </dl>
-                                    </td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                        :
-                        <div className="panel-body"><span>No ExAC constraint scores found for this variant.</span></div>
-                    }
+                                <tfoot>
+                                    <tr className="footnote">
+                                        <td colSpan="4">
+                                            <dl className="inline-dl clearfix">
+                                                <dt>pLI:</dt><dd>the probability of being loss-of-function intolerant (intolerant of both heterozygous and homozygous LOF variants)</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>pRec:</dt><dd>the probability of being intolerant of homozygous, but not heterozygous LOF variants</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>pNull:</dt><dd>the probability of being tolerant of both heterozygous and homozygous LOF variants</dd>
+                                            </dl>
+                                        </td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                            :
+                            <div className="panel-body"><span>No ExAC constraint scores found for this variant.</span></div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info datasource-clinvar">
                     <div className="panel-heading"><h3 className="panel-title">Other ClinVar Variants in Same Gene</h3></div>
-                    <div className="panel-body">
-                        {(myGeneInfo) ?
-                            <a href={external_url_map['ClinVar'] + '?term=' + myGeneInfo.symbol + '%5Bgene%5D'}
-                                target="_blank">Search ClinVar for variants in this gene <i className="icon icon-external-link"></i></a>
-                            :
-                            <span>No other variants found in this gene at ClinVar.</span>
-                        }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_myGeneInfo ? showActivityIndicator('Retrieving data... ') : null}
+                        <div className="panel-body">
+                            {(myGeneInfo) ?
+                                <a href={external_url_map['ClinVar'] + '?term=' + myGeneInfo.symbol + '%5Bgene%5D'}
+                                    target="_blank">Search ClinVar for variants in this gene <i className="icon icon-external-link"></i></a>
+                                :
+                                <span>No other variants found in this gene at ClinVar.</span>
+                            }
+                        </div>
                     </div>
                 </div>
 
                 <div className="panel panel-info datasource-gene-resources">
                     <div className="panel-heading"><h3 className="panel-title">Gene Resources</h3></div>
-                    {(myGeneInfo) ?
-                        <div className="panel-body">
-                            <dl className="inline-dl clearfix">
-                                <dt>HGNC</dt>
-                                <dd>
-                                    Symbol: <a href={external_url_map['HGNC'] + myGeneInfo.HGNC} target="_blank">{myGeneInfo.symbol}</a><br/>
-                                    Approved Name: {myGeneInfo.name}<br/>
-                                    {(geneSynonyms) ?
-                                        <span>Synonyms: {geneSynonyms.join(', ')}</span>
-                                    : null}
-                                </dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>Entrez Gene:</dt>
-                                <dd><a href={dbxref_prefix_map['GeneID'] + myGeneInfo.entrezgene.toString()} target="_blank">{myGeneInfo.entrezgene}</a></dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>Ensembl:</dt>
-                                <dd><a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a></dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>GeneCards:</dt>
-                                <dd><a href={dbxref_prefix_map['HGNC'] + myGeneInfo.symbol} target="_blank">{myGeneInfo.symbol}</a></dd>
-                            </dl>
-                        </div>
-                        :
-                        <div className="panel-body"><span>No gene resources found for this gene.</span></div>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_myGeneInfo ? showActivityIndicator('Retrieving data... ') : null}
+                        {(myGeneInfo) ?
+                            <div className="panel-body">
+                                <dl className="inline-dl clearfix">
+                                    <dt>HGNC</dt>
+                                    <dd>
+                                        Symbol: <a href={external_url_map['HGNC'] + myGeneInfo.HGNC} target="_blank">{myGeneInfo.symbol}</a><br/>
+                                        Approved Name: {myGeneInfo.name}<br/>
+                                        {(geneSynonyms) ?
+                                            <span>Synonyms: {geneSynonyms.join(', ')}</span>
+                                        : null}
+                                    </dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Entrez Gene:</dt>
+                                    <dd><a href={dbxref_prefix_map['GeneID'] + myGeneInfo.entrezgene.toString()} target="_blank">{myGeneInfo.entrezgene}</a></dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Ensembl:</dt>
+                                    <dd><a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a></dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>GeneCards:</dt>
+                                    <dd><a href={dbxref_prefix_map['HGNC'] + myGeneInfo.symbol} target="_blank">{myGeneInfo.symbol}</a></dd>
+                                </dl>
+                            </div>
+                            :
+                            <div className="panel-body"><span>No gene resources found for this gene.</span></div>
+                        }
+                    </div>
                 </div>
 
                 <div className="panel panel-info datasource-protein-resources">
                     <div className="panel-heading"><h3 className="panel-title">Protein Resources</h3></div>
-                    {(myGeneInfo && myGeneInfo.uniprot['Swiss-Prot']) ?
-                        <div className="panel-body">
-                            <dl className="inline-dl clearfix">
-                                <dt>UniProtKB:</dt>
-                                <dd><a href={dbxref_prefix_map['UniProtKB'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">{myGeneInfo.uniprot['Swiss-Prot']}</a></dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>Domains:</dt>
-                                <dd><a href={external_url_map['InterPro'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">InterPro</a></dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>Structure:</dt>
-                                <dd><a href={external_url_map['PDBe'] + '?uniprot_accession:(' + myGeneInfo.uniprot['Swiss-Prot'] + ')'} target="_blank">PDBe</a></dd>
-                            </dl>
-                            <dl className="inline-dl clearfix">
-                                <dt>Gene Ontology (Function/Process/Cellular Component):</dt>
-                                <dd><a href={external_url_map['AmiGO2'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">AmiGO2</a> | <a href={external_url_map['QuickGO'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">QuickGO</a></dd>
-                            </dl>
-                        </div>
-                        :
-                        <div className="panel-body"><span>No protein resources found for this gene.</span></div>
-                    }
+                    <div className="panel-content-wrapper">
+                        {this.state.loading_myGeneInfo ? showActivityIndicator('Retrieving data... ') : null}
+                        {(myGeneInfo && myGeneInfo.uniprot['Swiss-Prot']) ?
+                            <div className="panel-body">
+                                <dl className="inline-dl clearfix">
+                                    <dt>UniProtKB:</dt>
+                                    <dd><a href={dbxref_prefix_map['UniProtKB'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">{myGeneInfo.uniprot['Swiss-Prot']}</a></dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Domains:</dt>
+                                    <dd><a href={external_url_map['InterPro'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">InterPro</a></dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Structure:</dt>
+                                    <dd><a href={external_url_map['PDBe'] + '?uniprot_accession:(' + myGeneInfo.uniprot['Swiss-Prot'] + ')'} target="_blank">PDBe</a></dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Gene Ontology (Function/Process/Cellular Component):</dt>
+                                    <dd><a href={external_url_map['AmiGO2'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">AmiGO2</a> | <a href={external_url_map['QuickGO'] + myGeneInfo.uniprot['Swiss-Prot']} target="_blank">QuickGO</a></dd>
+                                </dl>
+                            </div>
+                            :
+                            <div className="panel-body"><span>No protein resources found for this gene.</span></div>
+                        }
+                    </div>
                 </div>
 
                 {renderDataCredit('mygene')}

--- a/src/clincoded/static/scss/clincoded/modules/_activity_indicator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_activity_indicator.scss
@@ -10,7 +10,7 @@
     background-color: #fff;
     color: #000;
     position: absolute;
-    text-align: center;
+    text-align: left;
     z-index: 999;
 
     &:before {
@@ -23,7 +23,7 @@
     .overlay-content {
         display: inline-block;
         font-weight: bold;
-        padding: 8px 0;
+        padding: 8px 12px;
         position: relative;
         vertical-align: middle;
     }

--- a/src/clincoded/static/scss/clincoded/modules/_activity_indicator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_activity_indicator.scss
@@ -1,0 +1,30 @@
+.panel-content-wrapper {
+    position: relative;
+}
+
+.activity-indicator.overlay-wrapper {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #fff;
+    color: #000;
+    position: absolute;
+    text-align: center;
+    z-index: 999;
+
+    &:before {
+        content: '';
+        display: inline-block;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+    .overlay-content {
+        display: inline-block;
+        font-weight: bold;
+        padding: 8px 0;
+        position: relative;
+        vertical-align: middle;
+    }
+}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1135,6 +1135,10 @@
                 }
             }
 
+            .panel-content-wrapper .table {
+                margin-bottom: 0;
+            }
+
             .basic-info .table th,
             .basic-info .table td {
                 width: 25%;

--- a/src/clincoded/static/scss/fontawesome/_icons.scss
+++ b/src/clincoded/static/scss/fontawesome/_icons.scss
@@ -482,7 +482,7 @@
 //.#{$fa-css-prefix}-life-saver:before,
 //.#{$fa-css-prefix}-support:before,
 //.#{$fa-css-prefix}-life-ring:before { content: $fa-var-life-ring; }
-//.#{$fa-css-prefix}-circle-o-notch:before { content: $fa-var-circle-o-notch; }
+.#{$fa-css-prefix}-circle-o-notch:before { content: $fa-var-circle-o-notch; }
 //.#{$fa-css-prefix}-ra:before,
 //.#{$fa-css-prefix}-rebel:before { content: $fa-var-rebel; }
 //.#{$fa-css-prefix}-ge:before,

--- a/src/clincoded/static/scss/style.scss
+++ b/src/clincoded/static/scss/style.scss
@@ -60,6 +60,7 @@
 @import "clincoded/modules/form";
 @import "clincoded/modules/curator";
 @import "clincoded/modules/table";
+@import "clincoded/modules/activity_indicator";
 
 // Utility classes - Bootstrap 3, keep last
 @import "bootstrap/utilities";


### PR DESCRIPTION
**Technical details:**
1. Added a stateless activity indicator method that can be re-used, along with its own CSS module.
2. The downside of this activity indicator implementation is that it requires the parent DOM element (new or existing) to have `position: relative;` CSS property.
3. The activity indicator has been applied to the tables that are dependent on fetched data for the Basic Info, Population, Predictors, and Gene-centric tabs.

**Steps to test:**
1. Login and use **17662** and/or **21134** variant_id at the variation selection interface.
2. Upon being redirected to the Basic Info tab, expect to see the display of the activity indicators in each table until the data starts being rendered. Particularly for the ClinVar Interpretations table, the "No data was found..." message shouldn't be visible prior to the rendering of RCV data.
3. Proceed to other tabs and refresh the page. Expect to see the consistent behavior of the activity indicator throughout different tables.
4. For testing a variant without any RCVs, try **CA501097** and expect to see the display of the "No data was found..." message in the ClinVar Interpretations table on the Basic Info tab.