### PR TITLE
Connects to #945. Associate Disease modal submit button spinner bugfix

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -220,6 +220,7 @@ var AssociateDisease = React.createClass({
                 });
             }).catch(e => {
                 // Some unexpected error happened
+                this.setState({submitResourceBusy: false});
                 parseAndLogError.bind(undefined, 'fetchedRequest');
             });
         }
@@ -227,6 +228,7 @@ var AssociateDisease = React.createClass({
 
     // Called when the modal 'Cancel' button is clicked
     cancelAction: function(e) {
+        this.setState({submitResourceBusy: false});
         this.props.closeModal();
     },
 


### PR DESCRIPTION
Testing:

1. Get to VCI
2. Attempt to associate disease that is not in db
3. Confirm that the Submit button is re-enabled after throwing the Orpha ID not found error

![image](https://cloud.githubusercontent.com/assets/4326866/18142987/dcdc5f2a-6f74-11e6-8c2e-5738e3d5272d.png)