### PR TITLE
Connects to #951. Interpretation history text wrapping

### DIFF
--- a/src/clincoded/static/components/variant_central/record_curator.js
+++ b/src/clincoded/static/components/variant_central/record_curator.js
@@ -87,7 +87,7 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                                     <div key={i}>
                                                         <span className="my-interpretation">
                                                             {(item.interpretation_disease) ? item.interpretation_disease + ', ' : null}
-                                                            {item.interpretation_status}
+                                                            {item.interpretation_status + ' '}
                                                             (last edited {moment(item.last_modified).format('YYYY MMM DD, h:mm a')})
                                                         </span>
                                                         {(item.uuid === interpretationUuid) ?
@@ -112,7 +112,7 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                                         <span className="other-interpretation">
                                                             {otherInterpretations[0].submitted_by.title + ', '}
                                                             {(otherInterpretations[0].interpretation_disease !== '') ? otherInterpretations[0].interpretation_disease + ', ' : null}
-                                                            {otherInterpretations[0].interpretation_status + ', '}
+                                                            {otherInterpretations[0].interpretation_status + ' '}
                                                             (last edited {moment(otherInterpretations[0].last_modified).format('YYYY MMM DD, h:mm a')})
                                                         </span>
                                                     </div>

--- a/src/clincoded/static/components/variant_central/record_curator.js
+++ b/src/clincoded/static/components/variant_central/record_curator.js
@@ -81,13 +81,13 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                 <div className="current-user-interpretations">
                                     <dl className="inline-dl clearfix">
                                         <dt>My interpretations:</dt>
-                                        <dd>
+                                        <dd className="fullWidth">
                                             {myInterpretations.map(function(item, i) {
                                                 return (
                                                     <div key={i}>
                                                         <span className="my-interpretation">
                                                             {(item.interpretation_disease) ? item.interpretation_disease + ', ' : null}
-                                                            {item.interpretation_status},&nbsp;
+                                                            {item.interpretation_status}
                                                             (last edited {moment(item.last_modified).format('YYYY MMM DD, h:mm a')})
                                                         </span>
                                                         {(item.uuid === interpretationUuid) ?
@@ -105,7 +105,7 @@ var CurationRecordCurator = module.exports.CurationRecordCurator = React.createC
                                     <dl className="inline-dl clearfix">
                                         <dt>Other interpretations:</dt>
                                         <br />
-                                        <dd>
+                                        <dd className="fullWidth">
                                             {otherInterpretations.map(function(item, i) {
                                                 return (
                                                     <div key={i}>

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1571,6 +1571,10 @@
 }
 
 dl.inline-dl {
+    dd.fullWidth {
+        width: 100%;
+    }
+
     dt.dtFormLabel {
         line-height: 4.5;
     }


### PR DESCRIPTION
Testing:

1. Get to VCI
2. Start interpretation
3. Switch accounts and repeat steps 1 and 2
4. Confirm that the text on the 'Other Interpretations' section does not wrap prematurely

![image](https://cloud.githubusercontent.com/assets/4326866/18144742/fd1d000c-6f7c-11e6-8f74-67406ea03a51.png)

Other change:

* Interpretation lists should not have a comma before the '(last edited' text begins