### PR TITLE
Connects to #921. Consolidate Ensembl VEP fetch methods.

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -33,7 +33,6 @@ var VariantCurationHub = React.createClass({
             isLoadingComplete: false,
             ext_myVariantInfo: null,
             ext_bustamante: null,
-            ext_ensemblVEP: null,
             ext_ensemblVariation: null,
             ext_ensemblHgvsVEP: null,
             ext_clinvarEutils: null,
@@ -64,7 +63,6 @@ var VariantCurationHub = React.createClass({
             // ping out external resources (all async)
             this.fetchClinVarEutils(this.state.variantObj);
             this.fetchMyVariantInfoAndBustamante(this.state.variantObj);
-            this.fetchEnsemblVEP(this.state.variantObj);
             this.fetchEnsemblVariation(this.state.variantObj);
             this.fetchEnsemblHGVSVEP(this.state.variantObj);
         }).catch(function(e) {
@@ -136,22 +134,6 @@ var VariantCurationHub = React.createClass({
                     });
                 }).catch(function(e) {
                     console.log('MyVariant or Bustamante Fetch Error=: %o', e);
-                });
-            }
-        }
-    },
-
-    // Retrieve data from Ensembl VEP
-    fetchEnsemblVEP: function(variant) {
-        if (variant) {
-            // Extract only the number portion of the dbSNP id
-            var numberPattern = /\d+/g;
-            var rsid = (variant.dbSNPIds && variant.dbSNPIds.length > 0) ? variant.dbSNPIds[0].match(numberPattern) : null;
-            if (rsid) {
-                this.getRestData(this.props.href_url.protocol + external_url_map['EnsemblVEP'] + 'rs' + rsid + '?content-type=application/json').then(response => {
-                    this.setState({ext_ensemblVEP: response});
-                }).catch(function(e) {
-                    console.log('VEP Allele Frequency Fetch Error=: %o', e);
                 });
             }
         }
@@ -306,7 +288,6 @@ var VariantCurationHub = React.createClass({
                     ext_myGeneInfo={(this.state.ext_myGeneInfo_MyVariant) ? this.state.ext_myGeneInfo_MyVariant : this.state.ext_myGeneInfo_VEP}
                     ext_myVariantInfo={this.state.ext_myVariantInfo}
                     ext_bustamante={this.state.ext_bustamante}
-                    ext_ensemblVEP={this.state.ext_ensemblVEP}
                     ext_ensemblVariation={this.state.ext_ensemblVariation}
                     ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                     ext_clinvarEutils={this.state.ext_clinvarEutils}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -35,7 +35,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         updateInterpretationObj: React.PropTypes.func,
         ext_myVariantInfo: React.PropTypes.object,
         ext_bustamante: React.PropTypes.object,
-        ext_ensemblVEP: React.PropTypes.array,
         ext_ensemblVariation: React.PropTypes.object,
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
@@ -51,7 +50,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_myGeneInfo: this.props.ext_myGeneInfo,
             ext_myVariantInfo: this.props.ext_myVariantInfo,
             ext_bustamante: this.props.ext_bustamante,
-            ext_ensemblVEP: this.props.ext_ensemblVEP,
             ext_ensemblVariation: this.props.ext_ensemblVariation,
             ext_ensemblHgvsVEP: this.props.ext_ensemblHgvsVEP,
             ext_clinvarEutils: this.props.ext_clinvarEutils,
@@ -78,9 +76,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_bustamante) {
             this.setState({ext_bustamante: nextProps.ext_bustamante});
-        }
-        if (nextProps.ext_ensemblVEP) {
-            this.setState({ext_ensemblVEP: nextProps.ext_ensemblVEP});
         }
         if (nextProps.ext_ensemblVariation) {
             this.setState({ext_ensemblVariation: nextProps.ext_ensemblVariation});
@@ -151,7 +146,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <CurationInterpretationPopulation data={variant}
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
-                            ext_ensemblVEP={this.state.ext_ensemblVEP}
+                            ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_ensemblVariation={this.state.ext_ensemblVariation} />
                     </div>
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -53,7 +53,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         interpretation: React.PropTypes.object,
         updateInterpretationObj: React.PropTypes.func,
         ext_myVariantInfo: React.PropTypes.object,
-        ext_ensemblVEP: React.PropTypes.array,
+        ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_ensemblVariation: React.PropTypes.object
     },
 
@@ -111,9 +111,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             this.parseEspData(this.props.ext_myVariantInfo);
             this.calculateHighestMAF();
         }
-        if (this.props.ext_ensemblVEP) {
-            this.parseAlleleFrequencyData(this.props.ext_ensemblVEP);
-            this.parseGeneConstraintScores(this.props.ext_ensemblVEP);
+        if (this.props.ext_ensemblHgvsVEP) {
+            this.parseAlleleFrequencyData(this.props.ext_ensemblHgvsVEP);
+            this.parseGeneConstraintScores(this.props.ext_ensemblHgvsVEP);
             this.calculateHighestMAF();
         }
         if (this.props.ext_ensemblVariation) {
@@ -140,9 +140,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             this.parseEspData(nextProps.ext_myVariantInfo);
             this.calculateHighestMAF();
         }
-        if (nextProps.ext_ensemblVEP) {
-            this.parseAlleleFrequencyData(nextProps.ext_ensemblVEP);
-            this.parseGeneConstraintScores(nextProps.ext_ensemblVEP);
+        if (nextProps.ext_ensemblHgvsVEP) {
+            this.parseAlleleFrequencyData(nextProps.ext_ensemblHgvsVEP);
+            this.parseGeneConstraintScores(nextProps.ext_ensemblHgvsVEP);
             this.calculateHighestMAF();
         }
         if (nextProps.ext_ensemblVariation) {


### PR DESCRIPTION
**Technical details:**
Please have the Chrome DevTools console open while testing this PR.

**Steps to test:**
1. Login and use **55847** variant_id at the variation selection interface.
2. Proceed to the **Population** tab and expect to see allele frequency data being displayed at the top of the tab as expected.
3. Also expect to see **no** VEP data fetching/request errors originated from the `population.js`.