### PR TITLE
Connects to #923. Removed ExAC Constraint Score linkout on population tab.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -70,7 +70,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             hasExacData: false, // flag to display ExAC table
             hasTGenomesData: false,
             hasEspData: false, // flag to display ESP table
-            geneENSG: null,
             CILow: null,
             CIhigh: null,
             populationObj: {
@@ -118,7 +117,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
         if (this.props.ext_ensemblVEP) {
             this.parseAlleleFrequencyData(this.props.ext_ensemblVEP);
-            this.parseGeneConstraintScores(this.props.ext_ensemblVEP);
             this.calculateHighestMAF();
         }
         if (this.props.ext_ensemblVariation) {
@@ -147,7 +145,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
         if (nextProps.ext_ensemblVEP) {
             this.parseAlleleFrequencyData(nextProps.ext_ensemblVEP);
-            this.parseGeneConstraintScores(nextProps.ext_ensemblVEP);
             this.calculateHighestMAF();
         }
         if (nextProps.ext_ensemblVariation) {
@@ -204,14 +201,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         populationObj.exac._tot.af = typeof populationObj.exac._tot.af !== 'undefined' ? (isNaN(populationObj.exac._tot.af) ? null : populationObj.exac._tot.af) : parseFloat(response[0].colocated_variants[0].exac_adj_maf);
 
         this.setState({populationObj: populationObj});
-    },
-
-    // Get gene ENSG value to link out to Gene's page on ExAC, as temporary stop gap for displaying
-    // constraint scores (see #750)
-    parseGeneConstraintScores: function(response) {
-        if (response && response.length > 0 && response[0].transcript_consequences && response[0].transcript_consequences.length > 0) {
-            this.setState({geneENSG: response[0].transcript_consequences[0].gene_id});
-        }
     },
 
     // Method to assign ExAC population data to global population object
@@ -726,15 +715,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </dl>
                         </div>
                     </div>
-                    {this.state.geneENSG ?
-                        <div>
-                            <br />
-                            <h4>ExAC Constraint Score</h4>
-                            <div className="clearfix">
-                                <div className="bs-callout-content-container"><a href={external_url_map['ExACGene'] + this.state.geneENSG} target="_blank">View pLI in ExAC <i className="icon icon-external-link"></i></a></div>
-                            </div>
-                        </div>
-                    : null}
                 </div>
 
                 <PanelGroup accordion><Panel title="Population Criteria Evaluation" panelBodyClassName="panel-wide-content" open>


### PR DESCRIPTION
**Steps to test:**
1. Login and use 55847 variant_id at the variation selection interface.
2. Proceed to the Population tab and expect to see **no** ExAC Constraint Score linkout at the top of population tab.
3. Start a new interpretation and also expect to see **no** ExAC Constraint Score linkout at the top of population tab.