### PR TITLE
Connects to #963. Connects to #965. Change location and text of section complete checkboxes

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -134,7 +134,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('predictors')} aria-selected={this.state.selectedTab == 'predictors'}>Predictors {completedSections.indexOf('predictors') > -1 ? <span>&#10003;</span> : null}</li>
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('experimental')} aria-selected={this.state.selectedTab == 'experimental'}>Experimental {completedSections.indexOf('experimental') > -1 ? <span>&#10003;</span> : null}</li>
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('segregation-case')} aria-selected={this.state.selectedTab == 'segregation-case'}>Segregation/Case {completedSections.indexOf('segregation-case') > -1 ? <span>&#10003;</span> : null}</li>
-                        <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('gene-centric')} aria-selected={this.state.selectedTab == 'gene-centric'}>Gene-centric {completedSections.indexOf('gene-centric') > -1 ? <span>&#10003;</span> : null}</li>
+                        <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('gene-centric')} aria-selected={this.state.selectedTab == 'gene-centric'}>Gene-centric</li>
                     </ul>
 
                     {this.state.selectedTab == '' || this.state.selectedTab == 'basic-info' ?

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -413,9 +413,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
 
         return (
             <div className="variant-interpretation computational">
-                {this.state.interpretation ?
-                    <CompleteSection interpretation={this.state.interpretation} tabName="predictors" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
                 <ul className="vci-tabs-header tab-label-list vci-subtabs" role="tablist">
                     <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('missense')} aria-selected={this.state.selectedSubtab == 'missense'}>Missense</li>
                     <li className="tab-label col-sm-3" role="tab" onClick={() => this.handleSubtabSelect('lof')} aria-selected={this.state.selectedSubtab == 'lof'}>Loss of Function</li>
@@ -778,6 +775,10 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         : null}
                     </Panel></PanelGroup>
                 </div>
+                : null}
+
+                {this.state.interpretation ?
+                    <CompleteSection interpretation={this.state.interpretation} tabName="predictors" updateInterpretationObj={this.props.updateInterpretationObj} />
                 : null}
 
                 {renderDataCredit('myvariant')}

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -70,6 +70,10 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                         </div>
                     : null}
                 </Panel></PanelGroup>
+
+                {this.state.interpretation ?
+                    <CompleteSection interpretation={this.state.interpretation} tabName="experimental" updateInterpretationObj={this.props.updateInterpretationObj} />
+                : null}
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -43,9 +43,6 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
     render: function() {
         return (
             <div className="variant-interpretation functional">
-                {this.state.interpretation ?
-                    <CompleteSection interpretation={this.state.interpretation} tabName="experimental" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
                 <PanelGroup accordion><Panel title="Hotspot or functional domain" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                         <div className="row">

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -90,10 +90,6 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
 
         return (
             <div className="variant-interpretation gene-specific">
-                {this.state.interpretation ?
-                    <CompleteSection interpretation={this.state.interpretation} tabName="gene-centric" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
-
                 <div className="panel panel-info datasource-constraint-scores">
                     <div className="panel-heading"><h3 className="panel-title">ExAC Constraint Scores<a href="#credit-mygene" className="credit-mygene" title="MyGene.info"><span>MyGene</span></a></h3></div>
                     {(myGeneInfo && myGeneInfo.exac) ?

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -627,9 +627,6 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
         return (
             <div className="variant-interpretation population">
-                {this.state.interpretation ?
-                    <CompleteSection interpretation={this.state.interpretation} tabName="population" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
                 <div className="bs-callout bs-callout-info clearfix">
                     <h4>Highest Minor Allele Frequency</h4>
                     <div className="clearfix">
@@ -804,6 +801,10 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                     }
                 </Panel></PanelGroup>
+
+                {this.state.interpretation ?
+                    <CompleteSection interpretation={this.state.interpretation} tabName="population" updateInterpretationObj={this.props.updateInterpretationObj} />
+                : null}
 
                 {renderDataCredit('myvariant')}
 

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -43,9 +43,6 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
     render: function() {
         return (
             <div className="variant-interpretation segregation">
-                {this.state.interpretation ?
-                    <CompleteSection interpretation={this.state.interpretation} tabName="segregation-case" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
                 <PanelGroup accordion><Panel title="Observed in healthy adult(s)" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?
                         <div className="row">
@@ -149,6 +146,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                 </Panel></PanelGroup>
+
+                {this.state.interpretation ?
+                    <CompleteSection interpretation={this.state.interpretation} tabName="segregation-case" updateInterpretationObj={this.props.updateInterpretationObj} />
+                : null}
             </div>
         );
     }

--- a/src/clincoded/static/components/variant_central/interpretation/shared/complete_section.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/complete_section.js
@@ -10,6 +10,13 @@ var FormMixin = form.FormMixin;
 var Input = form.Input;
 var InputMixin = form.InputMixin;
 
+var tabNames = {
+    'population': 'Population',
+    'predictors': 'Predictors',
+    'experimental': 'Experimental',
+    'segregation-case': 'Segregation/Case'
+};
+
 // Recursive function to compare oldObj against newObj and its key:values. Creates diffObj that shares the keys (full-depth) with newObj,
 // but with values of true or false depending on whether or not oldObj's values for that key matches newValue's. A value of true means that
 // the key:value is different. Also creates diffObjFlag that keeps track of whether or not there is any change in the diffObj. A value of true
@@ -70,10 +77,10 @@ var CompleteSection = module.exports.CompleteSection = React.createClass({
     },
 
     render: function() {
-        var checked = this.state.interpretation.completed_sections && this.state.interpretation.completed_sections.indexOf(this.props.tabName) > -1 ? true : false;
+        let checked = this.state.interpretation.completed_sections && this.state.interpretation.completed_sections.indexOf(this.props.tabName) > -1 ? true : false;
         return (
             <div className="alert alert-warning section-complete-bar">
-                Set this evidence category as complete <input type="checkbox" onChange={this.setCompleteSection} disabled={this.state.submitBusy} checked={checked} /> {this.state.submitBusy ? <i className="icon icon-spin icon-cog"></i> : null}
+                The evaluations on the {tabNames[this.props.tabName]} tab have been reviewed to my satisfaction (<i>optional</i>) <input type="checkbox" onChange={this.setCompleteSection} disabled={this.state.submitBusy} checked={checked} /> {this.state.submitBusy ? <i className="icon icon-spin icon-cog"></i> : null}
             </div>
         );
     }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -562,7 +562,7 @@
     }
 
     .section-complete-bar {
-        margin: 0 -15px 15px -15px;
+        margin: 0 -15px 0 -15px;
         padding-top: 3px;
         padding-bottom: 9px;
         border-left: 0;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1115,6 +1115,7 @@
         .tab-panel {
             border: solid 1px #1b75bc;
             padding: 15px;
+            margin-bottom: 10px;
             clear: both;
 
             ul, li {


### PR DESCRIPTION
#### Connects to #963 
Testing:

1. Get to VCI, begin interpretation
2. Confirm that the 'complete section' checkbox prompts are moved to the bottom, below the data tables and forms, but before the external resource crediting lines
3. Confirm that the text for each prompt is correct for each tab

![image](https://cloud.githubusercontent.com/assets/4326866/18218537/136f5660-7118-11e6-8e32-11ea34903a6f.png)
![image](https://cloud.githubusercontent.com/assets/4326866/18218539/1d3271d2-7118-11e6-9de1-9ee4e69c1789.png)
![image](https://cloud.githubusercontent.com/assets/4326866/18218543/23fe99e6-7118-11e6-97de-93ace49b10a8.png)
![image](https://cloud.githubusercontent.com/assets/4326866/18218546/2a85f4d0-7118-11e6-9309-63c8e7677520.png)


#### Connects to #965 
Testing:

1. Get to VCI, begin interpretation
2. Confirm that the gene-centric tab does not have the complete section checkbox prompt