### PR TITLE
Connects to #933. Connects to #922. Splicing table.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -548,7 +548,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 <thead>
                                     <tr>
                                         <th>Source</th>
-                                        <th>5&#x00027; or 3&#x00027;</th>
+                                        <th>5' or 3'</th>
                                         <th>Score Range</th>
                                         <th>Score</th>
                                     </tr>
@@ -559,7 +559,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -575,7 +575,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -594,7 +594,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -610,7 +610,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -737,7 +737,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 <thead>
                                     <tr>
                                         <th>Source</th>
-                                        <th>5&#x00027; or 3&#x00027;</th>
+                                        <th>5' or 3'</th>
                                         <th>Score Range</th>
                                         <th>Score</th>
                                     </tr>
@@ -748,7 +748,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -764,7 +764,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -783,7 +783,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -799,7 +799,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -548,7 +548,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 <thead>
                                     <tr>
                                         <th>Source</th>
-                                        <th>5' or 3'</th>
+                                        <th>5&#x00027; or 3&#x00027;</th>
                                         <th>Score Range</th>
                                         <th>Score</th>
                                     </tr>
@@ -559,7 +559,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -575,7 +575,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -594,7 +594,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -610,7 +610,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -737,7 +737,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 <thead>
                                     <tr>
                                         <th>Source</th>
-                                        <th>5' or 3'</th>
+                                        <th>5&#x00027; or 3&#x00027;</th>
                                         <th>Score Range</th>
                                         <th>Score</th>
                                     </tr>
@@ -748,7 +748,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -764,7 +764,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -783,7 +783,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td rowSpan="3" className="row-span">5&#x00027;</td>
                                         <td>[0-12]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>
@@ -799,7 +799,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                     </tr>
                                     <tr>
                                         <td>MaxEntScan</td>
-                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td rowSpan="3" className="row-span">3&#x00027;</td>
                                         <td>[0-16]</td>
                                         <td><span className="wip">IN PROGRESS</span></td>
                                     </tr>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -724,6 +724,103 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </div>
                             </div>
                         : null}
+                        <div className="panel panel-info datasource-splice">
+                            <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
+                            <div className="panel-body">
+                                <span className="pull-right">
+                                    <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">See data in MaxEntScan <i className="icon icon-external-link"></i></a>
+                                    <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">See data in NNSPLICE <i className="icon icon-external-link"></i></a>
+                                    <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">See data in HumanSplicingFinder <i className="icon icon-external-link"></i></a>
+                                </span>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Source</th>
+                                        <th>5' or 3'</th>
+                                        <th>Score Range</th>
+                                        <th>Score</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th colSpan="4">WT Sequence</th>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td>[0-12]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>HumanSplicingFinder</td>
+                                        <td>[0-100]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td>[0-16]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>HumanSplicingFinder</td>
+                                        <td>[0-100]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <th colSpan="4">Variant Sequence</th>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="3" className="row-span">5'</td>
+                                        <td>[0-12]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>HumanSplicingFinder</td>
+                                        <td>[0-100]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>MaxEntScan</td>
+                                        <td rowSpan="3" className="row-span">3'</td>
+                                        <td>[0-16]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>NNSPLICE</td>
+                                        <td>[0-1]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>HumanSplicingFinder</td>
+                                        <td>[0-100]</td>
+                                        <td><span className="wip">IN PROGRESS</span></td>
+                                    </tr>
+                                </tbody>
+                                <tfoot>
+                                    <tr>
+                                        <td colSpan="4">Average Change to Nearest Splice Site: <span className="splice-avg-change wip">IN PROGRESS</span></td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
                     </Panel></PanelGroup>
                 </div>
                 : null}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1442,7 +1442,11 @@
         padding-bottom: 12px;
 
         .pull-right a {
-            margin-left: 20px;
+            display: inline-block;
+
+            &:not(:last-child) {
+            margin-right: 20px;
+        }
         }
     }
 }


### PR DESCRIPTION
**Technical details:**
1. The static "Splice Site Predictors" table is duplicated and placed under the "Silent & Intron" sub-tab.
2. Fixed the wrapping issue for the external link icon next to **HumanSplicingFinder** in the static "Splice Site Predictors" table.

**Steps to test:**
1. Login and use **12345** at the variant selection interface.
2. Proceed to the **Predictors** tab. Expect to see that the external link icon next to **HumanSplicingFinder** is no longer wrapped to the next line in the static "Splice Site Predictors" table under the "Missense" sub-tab.
3. Click on the "Silent & Intron" sub-tab. Expect to see the same static "Splice Site Predictors" table and without the wrapping issue for the external link icon next to **HumanSplicingFinder**.