### PR TITLE
Connects #973 kl snp warning

### DIFF
--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -87,7 +87,7 @@ var SelectVariant = React.createClass({
                                     : null}
                                 </div>
                                 <div className="row">
-                                    <div className="alert alert-customized">
+                                    <div className="alert alert-danger">
                                         Note: <strong>This version of the interface currently supports SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs.
                                     </div>
                                     <div className="alert alert-info">

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -62,6 +62,34 @@ var SelectVariant = React.createClass({
                             {!this.state.variantLoaded ?
                             <div>
                                 <div className="row">
+                                    <Input type="select" ref="variantIdType" label="Select Variant by ID type"
+                                        labelClassName="col-sm-5 col-md-4 control-label" value={this.state.variantIdType} wrapperClassName="col-sm-7 col-md-8" groupClassName="form-group"
+                                        defaultValue="select" handleChange={this.handleChange} inputDisabled={this.state.variantLoaded}>
+                                        <option value="select" disabled>Select</option>
+                                        <option value="none" disabled></option>
+                                        <option value="ClinVar Variation ID">ClinVar Variation ID</option>
+                                        <option value="ClinGen Allele Registry ID (CA ID)">ClinGen Allele Registry ID (CA ID)</option>
+                                    </Input>
+                                    <p className="col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4 input-note-below-no-bottom"><strong>Note:</strong> Select ID type based on above instructions. Use the ClinVar VariationID whenever possible.</p>
+                                    {this.state.variantIdType == "ClinVar Variation ID" ?
+                                    <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
+                                        <AddResourceId resourceType="clinvar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
+                                            buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
+                                            modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    </div>
+                                    : null}
+                                    {this.state.variantIdType == "ClinGen Allele Registry ID (CA ID)" ?
+                                    <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
+                                        <AddResourceId resourceType="car" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
+                                            buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
+                                            modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
+                                    </div>
+                                    : null}
+                                </div>
+                                <div className="row">
+                                    <div className="alert alert-danger">
+                                        Note: <strong>This version of the interface currently supports SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs.
+                                    </div>
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />
                                         <ol className="instructions">
@@ -79,31 +107,6 @@ var SelectVariant = React.createClass({
                                         When registering your allele in the ClinGen Allele Registry, please use a <strong>GRCh37</strong> HGVS term in order to retrieve all available evidence for the allele. For an rsID, you can us the <a href={external_url_map['mutalyzerSnpConverter']}>SNP Converter</a> functionality of <a href={external_url_map['mutalyzer']}>Mutalyzer</a> to retrieve the GRCh37 genomic HGVS term.
                                     </div>
                                 </div>
-                                <div className="row">
-                                    <Input type="select" ref="variantIdType" label="Select Variant by ID type"
-                                        labelClassName="col-sm-5 col-md-4 control-label" value={this.state.variantIdType} wrapperClassName="col-sm-7 col-md-8" groupClassName="form-group"
-                                        defaultValue="select" handleChange={this.handleChange} inputDisabled={this.state.variantLoaded}>
-                                        <option value="select" disabled>Select</option>
-                                        <option value="none" disabled></option>
-                                        <option value="ClinVar Variation ID">ClinVar Variation ID</option>
-                                        <option value="ClinGen Allele Registry ID (CA ID)">ClinGen Allele Registry ID (CA ID)</option>
-                                    </Input>
-                                    <p className="col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4 input-note-below-no-bottom"><strong>Note:</strong> Select ID type based on above instructions. Use the ClinVar VariationID whenever possible.</p>
-                                </div>
-                            </div>
-                            : null}
-                            {this.state.variantIdType == "ClinVar Variation ID" ?
-                            <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="clinvar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
-                                    buttonText={this.state.variantData ? "Edit ClinVar ID" : "Add ClinVar ID" } initialFormValue={this.state.variantData && this.state.variantData.clinvarVariantId}
-                                    modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
-                            </div>
-                            : null}
-                            {this.state.variantIdType == "ClinGen Allele Registry ID (CA ID)" ?
-                            <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
-                                <AddResourceId resourceType="car" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}
-                                    buttonText={this.state.variantData ? "Edit CA ID" : "Add CA ID" } initialFormValue={this.state.variantData && this.state.variantData.carVariantId}
-                                    modalButtonText="Save and View Evidence" updateParentForm={this.updateVariantData} buttonOnly={true} />
                             </div>
                             : null}
                         </Form>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -87,7 +87,7 @@ var SelectVariant = React.createClass({
                                     : null}
                                 </div>
                                 <div className="row">
-                                    <div className="alert alert-danger">
+                                    <div className="alert alert-customized">
                                         Note: <strong>This version of the interface currently supports SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs.
                                     </div>
                                     <div className="alert alert-info">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1656,7 +1656,3 @@ dl.inline-dl {
         background-color: #fff;
     }
 }
-
-.alert-customized {
-    border: dashed 1px #d9534f;
-}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1656,3 +1656,7 @@ dl.inline-dl {
         background-color: #fff;
     }
 }
+
+.alert-customized {
+    border: dashed 1px #d9534f;
+}


### PR DESCRIPTION
**This PR modifies UI of variant selection page. Changes are:**
 1. Move data selection box to the top of page.
 2. Add a new warning note under the box.

**Functionality of variant selection is not changed.**

**Related code changes are in file `src/clincoded/static/components/select_variant.js`. They are:**
 1. Relocate `<Input>` element.
 2. Add a `<div>` element with bootstrap classes "alert alert-danger" for warning note.

**Test Steps**
 * Start VCI, expect to see variant selection page as:
![screen shot 2016-09-13 at 9 38 07 am](https://cloud.githubusercontent.com/assets/9206696/18482686/fb680356-7995-11e6-825b-400cb2f430e8.png)
 * Select "ClinVar Variant ID" and click `Add Variant ID` button. In `ClinVar Variant` module , enter variant id "12345", click `Retrieve from ClinVar` button and then click `Save and View Evidence` button. Expect to see all  buttons functioning as before.

**End of Test**