### PR TITLE
Connects to #997 kl edit schema for summary

### DIFF
--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -94,6 +94,11 @@
                 "title": "TabName",
                 "type": "string"
             }
+        },
+        "markAsProvisional": {
+            "title": "Mark As Provisional Interpretation",
+            "description": "A flag to mark the interpretation status as Provisional",
+            "type": "boolean"
         }
     },
     "columns": {

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -97,7 +97,7 @@
         },
         "markAsProvisional": {
             "title": "Mark As Provisional Interpretation",
-            "description": "A flag to mark the interpretation status as Provisional",
+            "description": "Flag to mark interpretation status as Provisional",
             "type": "boolean"
         }
     },

--- a/src/clincoded/schemas/provisional_variant.json
+++ b/src/clincoded/schemas/provisional_variant.json
@@ -20,26 +20,12 @@
         "autoClassification": {
             "title": "Classification",
             "description": "Classification calculated from combinbed criteria.",
-            "type": "string",
-            "enum": [
-                "Pathogenic",
-                "Likely pathogenic",
-                "Benign",
-                "Likely benign",
-                "Uncertain significance"
-            ]
+            "type": "string"
         },
         "alteredClassification": {
             "title": "Altered Classification",
             "description": "Classification altered by user",
-            "type": "string",
-            "enum": [
-                "Pathogenic",
-                "Likely pathogenic",
-                "Benign",
-                "Likely benign",
-                "Uncertain significance"
-            ]
+            "type": "string"
         },
         "reason": {
             "title": "Reasons",

--- a/src/clincoded/tests/data/inserts/interpretation.json
+++ b/src/clincoded/tests/data/inserts/interpretation.json
@@ -26,7 +26,7 @@
         "provisional_variant": [
             "a9886cb9-cea3-4372-8d2b-845563b47b1f"
         ],
-        "markAsProvisional": true,
+        "markAsProvisional": false,
         "disease": "788e024f-16a6-11e5-a0b5-60f81dc5b05a",
         "transcripts": [
             "8f1b7cb9-e798-412d-adf4-cbe140998407"

--- a/src/clincoded/tests/data/inserts/interpretation.json
+++ b/src/clincoded/tests/data/inserts/interpretation.json
@@ -26,6 +26,7 @@
         "provisional_variant": [
             "a9886cb9-cea3-4372-8d2b-845563b47b1f"
         ],
+        "markAsProvisional": true,
         "disease": "788e024f-16a6-11e5-a0b5-60f81dc5b05a",
         "transcripts": [
             "8f1b7cb9-e798-412d-adf4-cbe140998407"

--- a/src/clincoded/tests/data/inserts/provisional_variant.json
+++ b/src/clincoded/tests/data/inserts/provisional_variant.json
@@ -1,7 +1,7 @@
 [
     {
         "uuid": "a9886cb9-cea3-4372-8d2b-845563b47b1f",
-        "autoClassification": "Likely pathogenic",
+        "autoClassification": "Uncertain sigificant - conflict evidence",
         "alteredClassification": "Pathogenic",
         "reason": "some reasons here",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",

--- a/src/clincoded/tests/data/inserts/provisional_variant.json
+++ b/src/clincoded/tests/data/inserts/provisional_variant.json
@@ -1,7 +1,7 @@
 [
     {
         "uuid": "a9886cb9-cea3-4372-8d2b-845563b47b1f",
-        "autoClassification": "Uncertain sigificant - conflict evidence",
+        "autoClassification": "Uncertain significant - conflict evidence",
         "alteredClassification": "Pathogenic",
         "reason": "some reasons here",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",

--- a/src/clincoded/tests/data/inserts/provisional_variant.json
+++ b/src/clincoded/tests/data/inserts/provisional_variant.json
@@ -1,7 +1,7 @@
 [
     {
         "uuid": "a9886cb9-cea3-4372-8d2b-845563b47b1f",
-        "autoClassification": "Uncertain significant - conflict evidence",
+        "autoClassification": "Uncertain significance - conflicting evidence",
         "alteredClassification": "Pathogenic",
         "reason": "some reasons here",
         "submitted_by": "e49d01a5-51f7-4a32-ba0e-b2a71684e4aa",


### PR DESCRIPTION
This PR has schema changes for summary page. There is no change at UI or logic involved.

**Code Changes**
 1. Add a non-required data property `markAsProvisional` in file `src/clincoded/schemas/interpretation.json`.
 2. Remove `enum` from property `autoClassification` and property `autoClassification`in file `src/clincoded/schemas/provisional_variant.json` to allow taking new type of classification.
 3. Edit test data files `src/clincoded/tests/data/inserts/interpretation.json` and `src/clincoded/tests/data/inserts/provisional_variant.json` to match the schema changes.

**Test**
* Go to [http://localhost:6543/interpretations/b3e105b5-d08a-4520-9305-c1419d9027d4/](http://localhost:6543/interpretations/b3e105b5-d08a-4520-9305-c1419d9027d4/) and expect top see `"markAsProvisional": false,` in the interpretation object as below.
![screen shot 2016-09-14 at 4 15 06 pm](https://cloud.githubusercontent.com/assets/9206696/18533251/75056b8a-7a96-11e6-8c8d-73d082a9d09f.png)

* Go to [http://localhost:6543/provisional-variant/a9886cb9-cea3-4372-8d2b-845563b47b1f/](http://localhost:6543/provisional-variant/a9886cb9-cea3-4372-8d2b-845563b47b1f/) and expect to see `"autoClassification": "Uncertain significance - conflicting evidence",` in provisional_variant object as below.
![screen shot 2016-09-14 at 4 17 08 pm](https://cloud.githubusercontent.com/assets/9206696/18533300/c58f7cd0-7a96-11e6-8d91-89bff10b2952.png)

**End of Test**