### PR TITLE
Connects to #927. Indel and haplotype variants.

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -88,6 +88,10 @@ var VariantCurationHub = React.createClass({
                     // Passing 'true' option to invoke 'mixin' function
                     // To extract more ClinVar data for 'Basic Information' tab
                     var variantData = parseClinvar(xml, true);
+                    // Won't show population/predictor data if variation type is 'Haplotype'
+                    if (variantData.clinvarVariationType && variantData.clinvarVariationType === 'Haplotype') {
+                        this.setState({ext_singleNucleotide: false});
+                    }
                     this.setState({ext_clinvarEutils: variantData, loading_clinvarEutils: false});
                     this.handleCodonEsearch(variantData);
                     let clinVarRCVs = getClinvarRCVs(xml);
@@ -217,6 +221,7 @@ var VariantCurationHub = React.createClass({
     },
 
     // Method to parse variant type
+    // Won't show population/predictor data if subject is not single nucleotide variant
     parseVariantType: function(variant) {
         if (variant) {
             // Reference to http://www.hgvs.org/mutnomen/recs-DNA.html
@@ -228,8 +233,12 @@ var VariantCurationHub = React.createClass({
             } else if (variant.hgvsNames.GRCh38) {
                 genomicHGVS = variant.hgvsNames.GRCh38;
             }
-
-            if (genomicHGVS) {
+            // Filter variant by its change type
+            // Look for the <VariantType> node value in first pass
+            // Then look into HGVS term for non-SNV type patterns
+            if (variant.variationType && variant.variationType !== 'single nucleotide variant') {
+                this.setState({ext_singleNucleotide: false});
+            } else if (genomicHGVS) {
                 ncGenomic = genomicHGVS.substring(genomicHGVS.indexOf(':'));
                 seqChangeTypes.forEach(type => {
                     if (ncGenomic.indexOf(type) > 0) {

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -220,7 +220,7 @@ var VariantCurationHub = React.createClass({
     parseVariantType: function(variant) {
         if (variant) {
             // Reference to http://www.hgvs.org/mutnomen/recs-DNA.html
-            let seqChangeTypes = ['del', 'dup', 'ins', 'indels'];
+            let seqChangeTypes = ['del', 'dup', 'ins', 'indels', 'inv', 'con'];
             let genomicHGVS, ncGenomic;
 
             if (variant.hgvsNames.GRCh37) {

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -229,9 +229,9 @@ var VariantCurationHub = React.createClass({
             let seqChangeTypes = ['del', 'dup', 'ins', 'indels', 'inv', 'con'];
             let genomicHGVS, ncGenomic;
 
-            if (variant.hgvsNames.GRCh37) {
+            if (variant.hgvsNames && variant.hgvsNames.GRCh37) {
                 genomicHGVS = variant.hgvsNames.GRCh37;
-            } else if (variant.hgvsNames.GRCh38) {
+            } else if (variant.hgvsNames && variant.hgvsNames.GRCh38) {
                 genomicHGVS = variant.hgvsNames.GRCh38;
             }
             // Filter variant by its change type

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -41,6 +41,7 @@ var VariantCurationHub = React.createClass({
             ext_myGeneInfo_VEP: null,
             ext_ensemblGeneId: null,
             ext_geneSynonyms: null,
+            ext_singleNucleotide: true,
             loading_clinvarEutils: true,
             loading_clinvarEsearch: true,
             loading_clinvarRCV: true,
@@ -71,6 +72,7 @@ var VariantCurationHub = React.createClass({
             this.fetchMyVariantInfoAndBustamante(this.state.variantObj);
             this.fetchEnsemblVariation(this.state.variantObj);
             this.fetchEnsemblHGVSVEP(this.state.variantObj);
+            this.parseVariantType(this.state.variantObj);
         }).catch(function(e) {
             console.log('FETCH CLINVAR ERROR=: %o', e);
         });
@@ -214,6 +216,30 @@ var VariantCurationHub = React.createClass({
         }
     },
 
+    // Method to parse variant type
+    parseVariantType: function(variant) {
+        if (variant) {
+            // Reference to http://www.hgvs.org/mutnomen/recs-DNA.html
+            let seqChangeTypes = ['del', 'dup', 'ins', 'indels'];
+            let genomicHGVS, ncGenomic;
+
+            if (variant.hgvsNames.GRCh37) {
+                genomicHGVS = variant.hgvsNames.GRCh37;
+            } else if (variant.hgvsNames.GRCh38) {
+                genomicHGVS = variant.hgvsNames.GRCh38;
+            }
+
+            if (genomicHGVS) {
+                ncGenomic = genomicHGVS.substring(genomicHGVS.indexOf(':'));
+                seqChangeTypes.forEach(type => {
+                    if (ncGenomic.indexOf(type) > 0) {
+                        this.setState({ext_singleNucleotide: false});
+                    }
+                });
+            }
+        }
+    },
+
     // Method to parse Entrez gene symbol and id from myvariant.info
     parseMyVariantInfo: function(myVariantInfo) {
         let geneSymbol, geneId;
@@ -339,6 +365,7 @@ var VariantCurationHub = React.createClass({
                     ext_clinVarRCV={this.state.ext_clinVarRCV}
                     ext_ensemblGeneId={this.state.ext_ensemblGeneId}
                     ext_geneSynonyms={this.state.ext_geneSynonyms}
+                    ext_singleNucleotide={this.state.ext_singleNucleotide}
                     loading_clinvarEutils={this.state.loading_clinvarEutils}
                     loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                     loading_clinvarRCV={this.state.loading_clinvarRCV}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -42,6 +42,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_clinVarRCV: React.PropTypes.array,
         ext_ensemblGeneId: React.PropTypes.string,
         ext_geneSynonyms: React.PropTypes.array,
+        ext_singleNucleotide: React.PropTypes.bool,
         loading_clinvarEutils: React.PropTypes.bool,
         loading_clinvarEsearch: React.PropTypes.bool,
         loading_clinvarRCV: React.PropTypes.bool,
@@ -65,6 +66,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinVarRCV: this.props.ext_clinVarRCV,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
+            ext_singleNucleotide: this.props.ext_singleNucleotide,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch,
             loading_clinvarRCV: this.props.loading_clinvarRCV,
@@ -115,6 +117,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
         }
         this.setState({
+            ext_singleNucleotide: nextProps.ext_singleNucleotide,
             loading_myGeneInfo: nextProps.loading_myGeneInfo,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
             loading_bustamante: nextProps.loading_bustamante,
@@ -177,6 +180,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_ensemblVariation={this.state.ext_ensemblVariation}
+                            ext_singleNucleotide={this.state.ext_singleNucleotide}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_ensemblVariation={this.state.loading_ensemblVariation} />
                     </div>
@@ -189,6 +193,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_bustamante={this.state.ext_bustamante}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
+                            ext_singleNucleotide={this.state.ext_singleNucleotide}
                             loading_bustamante={this.state.loading_bustamante}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch} />

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -480,7 +480,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             </tbody>
                                         </table>
                                         :
-                                        <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                        <div className="panel-body"><span>No predictor data found for this allele.</span></div>
                                     }
                                     </div>
                                 }
@@ -515,7 +515,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             </tbody>
                                         </table>
                                         :
-                                        <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                        <div className="panel-body"><span>No predictor data found for this allele.</span></div>
                                     }
                                     </div>
                                 }

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -459,24 +459,30 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
                             <div className="panel-content-wrapper">
                                 {this.state.loading_bustamante ? showActivityIndicator('Retrieving data... ') : null}
-                                {clingenPred ?
-                                    <table className="table">
-                                        <thead>
-                                            <tr>
-                                                <th>Source</th>
-                                                <th>Score Range</th>
-                                                <th>Score</th>
-                                                <th>Prediction</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {clingenPredStatic._order.map(key => {
-                                                return (this.renderClingenPredRow(key, clingenPred, clingenPredStatic));
-                                            })}
-                                        </tbody>
-                                    </table>
+                                {!singleNucleotide ?
+                                    <div className="panel-body"><span>These predictors only return data for missense variants.</span></div>
                                     :
-                                    <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                    <div>
+                                    {clingenPred ?
+                                        <table className="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>Source</th>
+                                                    <th>Score Range</th>
+                                                    <th>Score</th>
+                                                    <th>Prediction</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {clingenPredStatic._order.map(key => {
+                                                    return (this.renderClingenPredRow(key, clingenPred, clingenPredStatic));
+                                                })}
+                                            </tbody>
+                                        </table>
+                                        :
+                                        <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                    }
+                                    </div>
                                 }
                             </div>
                         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -74,6 +74,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         ext_myVariantInfo: React.PropTypes.object,
         ext_bustamante: React.PropTypes.object,
         ext_clinVarEsearch: React.PropTypes.object,
+        ext_singleNucleotide: React.PropTypes.bool,
         loading_bustamante: React.PropTypes.bool,
         loading_myVariantInfo: React.PropTypes.bool,
         loading_clinvarEsearch: React.PropTypes.bool
@@ -114,6 +115,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             },
             computationObjDiff: null,
             computationObjDiffFlag: false,
+            ext_singleNucleotide: this.props.ext_singleNucleotide,
             loading_bustamante: this.props.loading_bustamante,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch
@@ -165,6 +167,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             this.compareExternalDatas(this.state.computationObj, nextProps.interpretation.evaluations);
         }
         this.setState({
+            ext_singleNucleotide: nextProps.ext_singleNucleotide,
             loading_bustamante: nextProps.loading_bustamante,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
             loading_clinvarEsearch: nextProps.loading_clinvarEsearch
@@ -405,6 +408,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         var clingenPred = (this.state.computationObj && this.state.computationObj.clingen) ? this.state.computationObj.clingen : null;
         var codon = (this.state.codonObj) ? this.state.codonObj : null;
         var computationObjDiffFlag = this.state.computationObjDiffFlag;
+        var singleNucleotide = this.state.ext_singleNucleotide;
 
         var variant = this.props.data;
         var gRCh38 = null;
@@ -484,24 +488,30 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                             <div className="panel-content-wrapper">
                                 {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                                {this.state.hasOtherPredData ?
-                                    <table className="table">
-                                        <thead>
-                                            <tr>
-                                                <th>Source</th>
-                                                <th>Score Range</th>
-                                                <th>Score</th>
-                                                <th>Prediction</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {otherPredStatic._order.map(key => {
-                                                return (this.renderOtherPredRow(key, otherPred, otherPredStatic));
-                                            })}
-                                        </tbody>
-                                    </table>
+                                {!singleNucleotide ?
+                                    <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
                                     :
-                                    <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                    <div>
+                                    {this.state.hasOtherPredData ?
+                                        <table className="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>Source</th>
+                                                    <th>Score Range</th>
+                                                    <th>Score</th>
+                                                    <th>Prediction</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {otherPredStatic._order.map(key => {
+                                                    return (this.renderOtherPredRow(key, otherPred, otherPredStatic));
+                                                })}
+                                            </tbody>
+                                        </table>
+                                        :
+                                        <div className="panel-body"><span>No predictors found for this allele.</span></div>
+                                    }
+                                    </div>
                                 }
                             </div>
                         </div>
@@ -513,22 +523,28 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             </div>
                             <div className="panel-content-wrapper">
                                 {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                                {this.state.hasConservationData ?
-                                    <table className="table">
-                                        <thead>
-                                            <tr>
-                                                <th>Source</th>
-                                                <th>Score</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {conservationStatic._order.map(key => {
-                                                return (this.renderConservationRow(key, conservation, conservationStatic));
-                                            })}
-                                        </tbody>
-                                    </table>
+                                {!singleNucleotide ?
+                                    <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
                                     :
-                                    <div className="panel-body"><span>No conservation analysis data found for this allele.</span></div>
+                                    <div>
+                                    {this.state.hasConservationData ?
+                                        <table className="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>Source</th>
+                                                    <th>Score</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {conservationStatic._order.map(key => {
+                                                    return (this.renderConservationRow(key, conservation, conservationStatic));
+                                                })}
+                                            </tbody>
+                                        </table>
+                                        :
+                                        <div className="panel-body"><span>No conservation analysis data found for this allele.</span></div>
+                                    }
+                                    </div>
                                 }
                             </div>
                         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -635,8 +635,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render 1000 Genomes population table header content
-    renderTGenomesHeader: function(hasTGenomesData, loading_ensemblVariation, tGenomes) {
-        if (hasTGenomesData && !loading_ensemblVariation) {
+    renderTGenomesHeader: function(hasTGenomesData, loading_ensemblVariation, tGenomes, singleNucleotide) {
+        if (hasTGenomesData && !loading_ensemblVariation && singleNucleotide) {
             const variantTGenomes = tGenomes._extra.name + ' ' + tGenomes._extra.var_class;
             const linkoutEnsembl = external_url_map['EnsemblPopulationPage'] + tGenomes._extra.name;
             return (
@@ -655,8 +655,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render ESP population table header content
-    renderEspHeader: function(hasEspData, loading_myVariantInfo, esp) {
-        if (hasEspData && !loading_myVariantInfo) {
+    renderEspHeader: function(hasEspData, loading_myVariantInfo, esp, singleNucleotide) {
+        if (hasEspData && !loading_myVariantInfo && singleNucleotide) {
             const variantEsp = esp._extra.rsid + '; ' + esp._extra.chrom + '.' + esp._extra.hg19_start + '; Alleles ' + esp._extra.ref + '>' + esp._extra.alt;
             const linkoutEsp = dbxref_prefix_map['ESP_EVS'] + 'searchBy=rsID&target=' + esp._extra.rsid + '&x=0&y=0';
             return (
@@ -780,7 +780,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </div>
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">
-                            {this.renderTGenomesHeader(this.state.hasTGenomesData, this.state.loading_ensemblVariation, tGenomes)}
+                            {this.renderTGenomesHeader(this.state.hasTGenomesData, this.state.loading_ensemblVariation, tGenomes, singleNucleotide)}
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_ensemblVariation ? showActivityIndicator('Retrieving data... ') : null}
@@ -817,7 +817,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </div>
                     <div className="panel panel-info datasource-ESP">
                         <div className="panel-heading">
-                            {this.renderEspHeader(this.state.hasEspData, this.state.loading_myVariantInfo, esp)}
+                            {this.renderEspHeader(this.state.hasEspData, this.state.loading_myVariantInfo, esp, singleNucleotide)}
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -56,6 +56,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         ext_myVariantInfo: React.PropTypes.object,
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_ensemblVariation: React.PropTypes.object,
+        ext_singleNucleotide: React.PropTypes.bool,
         loading_myVariantInfo: React.PropTypes.bool,
         loading_ensemblVariation: React.PropTypes.bool
     },
@@ -99,6 +100,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             },
             populationObjDiff: null,
             populationObjDiffFlag: false,
+            ext_singleNucleotide: this.props.ext_singleNucleotide,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_ensemblVariation: this.props.loading_ensemblVariation
         };
@@ -155,6 +157,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             this.compareExternalDatas(this.state.populationObj, nextProps.interpretation.evaluations);
         }
         this.setState({
+            ext_singleNucleotide: nextProps.ext_singleNucleotide,
             loading_ensemblVariation: nextProps.loading_ensemblVariation,
             loading_myVariantInfo: nextProps.loading_myVariantInfo
         });
@@ -681,6 +684,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             esp = this.state.populationObj && this.state.populationObj.esp ? this.state.populationObj.esp : null; // Get ESP data from global population object
         var desiredCI = this.state.populationObj && this.state.populationObj.desiredCI ? this.state.populationObj.desiredCI : CI_DEFAULT;
         var populationObjDiffFlag = this.state.populationObjDiffFlag;
+        var singleNucleotide = this.state.ext_singleNucleotide;
 
         return (
             <div className="variant-interpretation population">
@@ -739,29 +743,35 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {this.state.hasExacData ?
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Population</th>
-                                            <th>Allele Count</th>
-                                            <th>Allele Number</th>
-                                            <th>Number of Homozygotes</th>
-                                            <th>Allele Frequency</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {exacStatic._order.map(key => {
-                                            return (this.renderExacRow(key, exac, exacStatic));
-                                        })}
-                                    </tbody>
-                                    <tfoot>
-                                        {this.renderExacRow('_tot', exac, exacStatic, 'Total', 'count')}
-                                    </tfoot>
-                                </table>
+                            {!singleNucleotide ?
+                                <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
                                 :
-                                <div className="panel-body">
-                                    <span>No population data was found for this allele in ExAC. <a href={this.renderExacLinkout(this.props.ext_myVariantInfo)} target="_blank">Search ExAC</a> for this variant.</span>
+                                <div>
+                                {this.state.hasExacData ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Population</th>
+                                                <th>Allele Count</th>
+                                                <th>Allele Number</th>
+                                                <th>Number of Homozygotes</th>
+                                                <th>Allele Frequency</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {exacStatic._order.map(key => {
+                                                return (this.renderExacRow(key, exac, exacStatic));
+                                            })}
+                                        </tbody>
+                                        <tfoot>
+                                            {this.renderExacRow('_tot', exac, exacStatic, 'Total', 'count')}
+                                        </tfoot>
+                                    </table>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No population data was found for this allele in ExAC. <a href={this.renderExacLinkout(this.props.ext_myVariantInfo)} target="_blank">Search ExAC</a> for this variant.</span>
+                                    </div>
+                                }
                                 </div>
                             }
                         </div>
@@ -801,30 +811,36 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {this.state.hasEspData ?
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Population</th>
-                                            <th colSpan="2">Allele Count</th>
-                                            <th colSpan="3">Genotype Count</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {espStatic._order.map(key => {
-                                            return (this.renderEspRow(key, esp, espStatic));
-                                        })}
-                                        {this.renderEspRow('_tot', esp, espStatic, 'All Allele', 'count')}
-                                    </tbody>
-                                    <tfoot>
-                                        <tr className="count">
-                                            <td colSpan="6">Average Sample Read Depth: {esp._extra.avg_sample_read}</td>
-                                        </tr>
-                                    </tfoot>
-                                </table>
+                            {!singleNucleotide ?
+                                <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
                                 :
-                                <div className="panel-body">
-                                    <span>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']} target="_blank">Search ESP</a> for this variant.</span>
+                                <div>
+                                {this.state.hasEspData ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Population</th>
+                                                <th colSpan="2">Allele Count</th>
+                                                <th colSpan="3">Genotype Count</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {espStatic._order.map(key => {
+                                                return (this.renderEspRow(key, esp, espStatic));
+                                            })}
+                                            {this.renderEspRow('_tot', esp, espStatic, 'All Allele', 'count')}
+                                        </tbody>
+                                        <tfoot>
+                                            <tr className="count">
+                                                <td colSpan="6">Average Sample Read Depth: {esp._extra.avg_sample_read}</td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No population data was found for this allele in ESP. <a href={external_url_map['ESPHome']} target="_blank">Search ESP</a> for this variant.</span>
+                                    </div>
+                                }
                                 </div>
                             }
                         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -410,13 +410,13 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render external ExAC linkout when no ExAC population data found
-    renderExacLinkout: function(response) {
+    renderExacLinkout: function(response, singleNucleotide) {
         let exacLink;
         // If no ExAC population data, construct external linkout for one of the following:
         // 1) clinvar/cadd data found & the variant type is substitution
         // 2) clinvar/cadd data found & the variant type is NOT substitution
         // 3) no data returned by myvariant.info
-        if (response) {
+        if (response && singleNucleotide) {
             let chrom = response.chrom,
                 pos = response.hg19.start,
                 regionStart = parseInt(response.hg19.start) - 30,
@@ -615,8 +615,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render ExAC population table header content
-    renderExacHeader: function(hasExacData, loading_myVariantInfo, exac) {
-        if (hasExacData && !loading_myVariantInfo) {
+    renderExacHeader: function(hasExacData, loading_myVariantInfo, exac, singleNucleotide) {
+        if (hasExacData && !loading_myVariantInfo && singleNucleotide) {
             const variantExac = exac._extra.chrom + ':' + exac._extra.pos + ' ' + exac._extra.ref + '/' + exac._extra.alt;
             const linkoutExac = 'http:' + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt;
             return (
@@ -739,12 +739,14 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     : null}
                     <div className="panel panel-info datasource-ExAC">
                         <div className="panel-heading">
-                            {this.renderExacHeader(this.state.hasExacData, this.state.loading_myVariantInfo, exac)}
+                            {this.renderExacHeader(this.state.hasExacData, this.state.loading_myVariantInfo, exac, singleNucleotide)}
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                             {!singleNucleotide ?
-                                <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
+                                <div className="panel-body">
+                                    <span>Data is currently only returned for single nucleotide variants. <a href={this.renderExacLinkout(this.props.ext_myVariantInfo)} target="_blank">Search ExAC</a> for this variant.</span>
+                                </div>
                                 :
                                 <div>
                                 {this.state.hasExacData ?
@@ -782,25 +784,33 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_ensemblVariation ? showActivityIndicator('Retrieving data... ') : null}
-                            {this.state.hasTGenomesData ?
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Population</th>
-                                            <th colSpan="2">Allele Frequency (count)</th>
-                                            <th colSpan="3">Genotype Frequency (count)</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {this.renderTGenomesRow('_tot', tGenomes, tGenomesStatic, 'ALL')}
-                                        {tGenomesStatic._order.map(key => {
-                                            return (this.renderTGenomesRow(key, tGenomes, tGenomesStatic));
-                                        })}
-                                    </tbody>
-                                </table>
-                                :
+                            {!singleNucleotide ?
                                 <div className="panel-body">
-                                    <span>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']} target="_blank">Search 1000 Genomes</a> for this variant.</span>
+                                    <span>Data is currently only returned for single nucleotide variants. <a href={external_url_map['1000GenomesHome']} target="_blank">Search 1000 Genomes</a> for this variant.</span>
+                                </div>
+                                :
+                                <div>
+                                {this.state.hasTGenomesData ?
+                                    <table className="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Population</th>
+                                                <th colSpan="2">Allele Frequency (count)</th>
+                                                <th colSpan="3">Genotype Frequency (count)</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {this.renderTGenomesRow('_tot', tGenomes, tGenomesStatic, 'ALL')}
+                                            {tGenomesStatic._order.map(key => {
+                                                return (this.renderTGenomesRow(key, tGenomes, tGenomesStatic));
+                                            })}
+                                        </tbody>
+                                    </table>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No population data was found for this allele in 1000 Genomes. <a href={external_url_map['1000GenomesHome']} target="_blank">Search 1000 Genomes</a> for this variant.</span>
+                                    </div>
+                                }
                                 </div>
                             }
                         </div>
@@ -812,7 +822,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                             {!singleNucleotide ?
-                                <div className="panel-body"><span>Data is currently only returned for single nucleotide variants.</span></div>
+                                <div className="panel-body">
+                                    <span>Data is currently only returned for single nucleotide variants. <a href={external_url_map['ESPHome']} target="_blank">Search ESP</a> for this variant.</span>
+                                </div>
                                 :
                                 <div>
                                 {this.state.hasEspData ?

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -16,8 +16,30 @@ function parseClinvar(xml, extended){
             // Get the ID (just in case) and Preferred Title
             variant.clinvarVariantId = $VariationReport.getAttribute('VariationID');
             variant.clinvarVariantTitle = $VariationReport.getAttribute('VariationName');
+            // FIXME: Need to handle 'Haplotype' variant which has multiple alleles
+            // e.g. http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=7901
             var $Allele = $VariationReport.getElementsByTagName('Allele')[0];
             if ($Allele) {
+                // Parse <VariantType> node under <Allele>
+                let $variationType = $Allele.getElementsByTagName('VariantType')[0];
+                if ($variationType) {
+                    variant.variationType = $variationType.textContent;
+                }
+                // Parse <MolecularConsequence> node under <MolecularConsequenceList>
+                let $MolecularConsequenceListNode = $Allele.getElementsByTagName('MolecularConsequenceList')[0];
+                let $MolecularConsequenceNodes = [];
+                variant.molecularConsequenceList = [];
+                if ($MolecularConsequenceListNode) {
+                    $MolecularConsequenceNodes = $MolecularConsequenceListNode.getElementsByTagName('MolecularConsequence');
+                    for(let node of $MolecularConsequenceNodes) {
+                        let molecularItem = {
+                            "hgvsName": node.getAttribute('HGVS'),
+                            "term": node.getAttribute('Function'),
+                            "soId": node.getAttribute('SOid')
+                        };
+                        variant.molecularConsequenceList.push(molecularItem);
+                    }
+                }
                 var $HGVSlist_raw = $Allele.getElementsByTagName('HGVSlist')[0];
                 if ($HGVSlist_raw) {
                     variant.hgvsNames = {};
@@ -44,7 +66,7 @@ function parseClinvar(xml, extended){
                 }
                 // Call to extract more ClinVar data from XML response
                 if (extended) {
-                    parseClinvarExtended(variant, $Allele, $HGVSlist_raw, $VariationReport);
+                    parseClinvarExtended(variant, $Allele, $HGVSlist_raw, $VariationReport, $MolecularConsequenceNodes);
                 }
             }
         }
@@ -53,7 +75,7 @@ function parseClinvar(xml, extended){
 }
 
 // Function to extract more ClinVar data than what the db stores
-function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
+function parseClinvarExtended(variant, allele, hgvs_list, dataset, molecularConsequenceNodes) {
     variant.RefSeqTranscripts = {};
     variant.gene = {};
     variant.allele = {};
@@ -63,11 +85,12 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset) {
     variant.RefSeqTranscripts.NucleotideChangeList = [];
     variant.RefSeqTranscripts.MolecularConsequenceList = [];
     variant.RefSeqTranscripts.ProteinChangeList = [];
+    // Get the 'VariationType' attribute in <VariationReport> node
+    // Not to be confused with the <VariantType> node under <Allele>
+    variant.clinvarVariationType = dataset.getAttribute('VariationType');
     // Parse <MolecularConsequence> nodes
-    var MolecularConsequenceList = allele.getElementsByTagName('MolecularConsequenceList')[0];
-    if (MolecularConsequenceList) {
-        var MolecularConsequence = MolecularConsequenceList.getElementsByTagName('MolecularConsequence');
-        for(let n of MolecularConsequence) {
+    if (molecularConsequenceNodes) {
+        for(let n of molecularConsequenceNodes) {
             // Used for transcript tables on "Basic Information" tab in VCI
             // HGVS property for mapping to transcripts with matching HGVS names
             // SOid and Function properties for UI display


### PR DESCRIPTION
**Technical details:**
This PR primarily implements the UIs to display the "Data is currently only returned for single nucleotide variants" message in the tables on the "Population" and "Predictors" tabs (rather than trying to display data), when the user-selected variant is not a single nucleotide variant.

**Please use the following IDs while testing different use cases:**
duplication - Variant ID 17677
deletion - Variant ID 55555
deletion/insertion - Variant ID 179355
insertion - Variant ID 37401
inversion - Variant ID 242209
haplotypes - Variant IDs 7901 and 14180

**Steps to test:**
1. Login and use one of the IDs given above at the variation selection interface.
2. Proceed to the **"Population"** tab and expect to see the _"Data is currently only returned for single nucleotide variants. Search *** for this variant."_ message in the 3 tables.
3. Proceed to the **"Predictors"** tab and expect to see the _"Data is currently only returned for single nucleotide variants."_ message in the "Other Predictors" and "Conservation Analysis" tables, and the _"These predictors only return data for missense variants."_ message in the "ClinGen Predictors" table.