### PR TITLE
Connects to #942. ClinVar interpretation summary.

### DIFF
--- a/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
+++ b/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
@@ -5,6 +5,44 @@
 
 'use strict';
 
+// FIXME: Consoliate repetitive code that can be shared in different methods
+export function getClinvarInterpretations(xml) {
+    let interpretationSummary = {};
+    let xmlDoc = new DOMParser().parseFromString(xml, 'text/xml');
+    let ClinVarResult = xmlDoc.getElementsByTagName('ClinVarResult-Set')[0];
+    if (ClinVarResult) {
+        let VariationReport = ClinVarResult.getElementsByTagName('VariationReport')[0];
+        if (VariationReport) {
+            let ObservationList = VariationReport.getElementsByTagName('ObservationList')[0];
+            if (ObservationList) {
+                let ObservationNodes = ObservationList.getElementsByTagName('Observation');
+                if (ObservationNodes && ObservationNodes.length) {
+                    let ReviewStatus, Description, DateLastEvaluated, SubmissionCount;
+                    for (let node of ObservationNodes) {
+                        let ObservationType = node.getAttribute('ObservationType');
+                        if (ObservationType === 'primary') {
+                            SubmissionCount = node.getAttribute('SubmissionCount');
+                            ReviewStatus = node.getElementsByTagName('ReviewStatus')[0];
+                            let ClinicalSignificance = node.getElementsByTagName('ClinicalSignificance')[0];
+                            if (ClinicalSignificance) {
+                                DateLastEvaluated = ClinicalSignificance.getAttribute('DateLastEvaluated');
+                                Description = ClinicalSignificance.getElementsByTagName('Description')[0];
+                            }
+                        }
+                    }
+                    interpretationSummary = {
+                        'ReviewStatus': ReviewStatus.textContent,
+                        'ClinicalSignificance': Description.textContent,
+                        'DateLastEvaluated': DateLastEvaluated,
+                        'SubmissionCount': SubmissionCount
+                    };
+                }
+            }
+        }
+    }
+    return interpretationSummary;
+}
+
 export function getClinvarRCVs(xml) {
     // Make sure we have at least one RCV node to work with
     // Then put each RCV id into an array
@@ -16,12 +54,17 @@ export function getClinvarRCVs(xml) {
         if (VariationReport) {
             let ObservationList = VariationReport.getElementsByTagName('ObservationList')[0];
             if (ObservationList) {
-                let ObservationNode = ObservationList.getElementsByTagName('Observation')[0];
-                if (ObservationNode) {
-                    let RCV_Nodes = ObservationNode.getElementsByTagName('RCV');
-                    if (RCV_Nodes.length) {
-                        for(let RCV_Node of RCV_Nodes) {
-                            RCVs.push(RCV_Node.textContent);
+                let ObservationNodes = ObservationList.getElementsByTagName('Observation');
+                if (ObservationNodes && ObservationNodes.length) {
+                    for (let node of ObservationNodes) {
+                        let ObservationType = node.getAttribute('ObservationType');
+                        if (ObservationType === 'primary') {
+                            let RCV_Nodes = node.getElementsByTagName('RCV');
+                            if (RCV_Nodes.length) {
+                                for(let RCV_Node of RCV_Nodes) {
+                                    RCVs.push(RCV_Node.textContent);
+                                }
+                            }
                         }
                     }
                 }

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -15,7 +15,7 @@ var queryKeyValue = globals.queryKeyValue;
 var parseClinvar = require('../../libs/parse-resources').parseClinvar;
 import { getHgvsNotation } from './helpers/hgvs_notation';
 import { setPrimaryTranscript } from './helpers/primary_transcript';
-import { getClinvarRCVs, parseClinvarInterpretation } from './helpers/clinvar_interpretations';
+import { getClinvarInterpretations, getClinvarRCVs, parseClinvarInterpretation } from './helpers/clinvar_interpretations';
 
 var CurationInterpretationCriteria = require('./interpretation/criteria').CurationInterpretationCriteria;
 
@@ -38,6 +38,7 @@ var VariantCurationHub = React.createClass({
             ext_clinvarEutils: null,
             ext_clinVarEsearch: null,
             ext_clinVarRCV: null,
+            ext_clinvarInterpretationSummary: null,
             ext_myGeneInfo_MyVariant: null,
             ext_myGeneInfo_VEP: null,
             ext_ensemblGeneId: null,
@@ -87,7 +88,11 @@ var VariantCurationHub = React.createClass({
                     // Passing 'true' option to invoke 'mixin' function
                     // To extract more ClinVar data for 'Basic Information' tab
                     var variantData = parseClinvar(xml, true);
-                    this.setState({ext_clinvarEutils: variantData, loading_clinvarEutils: false});
+                    this.setState({
+                        ext_clinvarEutils: variantData,
+                        ext_clinvarInterpretationSummary: getClinvarInterpretations(xml),
+                        loading_clinvarEutils: false
+                    });
                     this.handleCodonEsearch(variantData);
                     let clinVarRCVs = getClinvarRCVs(xml);
                     return Promise.resolve(clinVarRCVs);
@@ -344,6 +349,7 @@ var VariantCurationHub = React.createClass({
                     ext_clinvarEutils={this.state.ext_clinvarEutils}
                     ext_clinVarEsearch={this.state.ext_clinVarEsearch}
                     ext_clinVarRCV={this.state.ext_clinVarRCV}
+                    ext_clinvarInterpretationSummary={this.state.ext_clinvarInterpretationSummary}
                     ext_ensemblGeneId={this.state.ext_ensemblGeneId}
                     ext_geneSynonyms={this.state.ext_geneSynonyms}
                     loading_clinvarEutils={this.state.loading_clinvarEutils}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -42,6 +42,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_clinvarEutils: React.PropTypes.object,
         ext_clinVarEsearch: React.PropTypes.object,
         ext_clinVarRCV: React.PropTypes.array,
+        ext_clinvarInterpretationSummary: React.PropTypes.object,
         ext_ensemblGeneId: React.PropTypes.string,
         ext_geneSynonyms: React.PropTypes.array,
         loading_clinvarEutils: React.PropTypes.bool,
@@ -65,6 +66,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_clinvarEutils: this.props.ext_clinvarEutils,
             ext_clinVarEsearch: this.props.ext_clinVarEsearch,
             ext_clinVarRCV: this.props.ext_clinVarRCV,
+            ext_clinvarInterpretationSummary: this.props.ext_clinvarInterpretationSummary,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
@@ -111,6 +113,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_clinVarRCV) {
             this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV});
+        }
+        if (nextProps.ext_clinvarInterpretationSummary) {
+            this.setState({ext_clinvarInterpretationSummary: nextProps.ext_clinvarInterpretationSummary});
         }
         if (nextProps.ext_ensemblGeneId) {
             this.setState({ext_ensemblGeneId: nextProps.ext_ensemblGeneId});
@@ -176,6 +181,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_clinVarRCV={this.state.ext_clinVarRCV}
+                            ext_clinvarInterpretationSummary={this.state.ext_clinvarInterpretationSummary}
                             loading_clinvarEutils={this.state.loading_clinvarEutils}
                             loading_clinvarRCV={this.state.loading_clinvarRCV}
                             loading_ensemblHgvsVEP={this.state.loading_ensemblHgvsVEP} />

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -25,6 +25,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
         ext_clinVarRCV: React.PropTypes.array,
+        ext_clinvarInterpretationSummary: React.PropTypes.object,
         loading_clinvarEutils: React.PropTypes.bool,
         loading_clinvarRCV: React.PropTypes.bool,
         loading_ensemblHgvsVEP: React.PropTypes.bool
@@ -42,6 +43,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             sequence_location: [],
             primary_transcript: {},
             clinVarRCV: [],
+            clinVarInterpretationSummary: {},
             hgvs_GRCh37: null,
             hgvs_GRCh38: null,
             hasHgvsGRCh37: false,
@@ -69,6 +71,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (this.props.ext_clinVarRCV) {
             this.setState({clinVarRCV: this.props.ext_clinVarRCV});
         }
+        if (this.props.ext_clinvarInterpretationSummary) {
+            this.setState({clinVarInterpretationSummary: this.props.ext_clinvarInterpretationSummary});
+        }
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -84,6 +89,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
         if (nextProps.ext_clinVarRCV) {
             this.setState({clinVarRCV: nextProps.ext_clinVarRCV});
+        }
+        if (nextProps.ext_clinvarInterpretationSummary) {
+            this.setState({clinVarInterpretationSummary: nextProps.ext_clinvarInterpretationSummary});
         }
         this.setState({
             loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
@@ -372,6 +380,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var GRCh38 = this.state.hgvs_GRCh38;
         var primary_transcript = this.state.primary_transcript;
         var clinVarRCV = this.state.clinVarRCV;
+        var clinVarInterpretationSummary = this.state.clinVarInterpretationSummary;
         var self = this;
 
         var links_38 = null;
@@ -400,21 +409,33 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                     <div className="panel-content-wrapper">
                         {this.state.loading_clinvarRCV ? showActivityIndicator('Retrieving data... ') : null}
                         {(clinVarRCV.length > 0) ?
-                            <table className="table">
-                                <thead>
-                                    <tr>
-                                        <th>Reference Accession</th>
-                                        <th>Review Status</th>
-                                        <th>Clinical Significance</th>
-                                        <th>Disease [Source]</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {clinVarRCV.map(function(item, i) {
-                                        return (self.renderClinvarInterpretations(item, i));
-                                    })}
-                                </tbody>
-                            </table>
+                            <div className="clinvar-interpretaions-content-wrapper">
+                                <div className="panel-body clearfix clinvar-interpretation-summary">
+                                    <dl className="inline-dl clearfix col-sm-6">
+                                        <dt>Review status:</dt><dd className="reviewStatus">{clinVarInterpretationSummary['ReviewStatus']}</dd>
+                                        <dt>Clinical significance:</dt><dd className="clinicalSignificance">{clinVarInterpretationSummary['ClinicalSignificance']}</dd>
+                                    </dl>
+                                    <dl className="inline-dl clearfix col-sm-6">
+                                        <dt>Last evaluated:</dt><dd className="dateLastEvaluated">{moment(clinVarInterpretationSummary['DateLastEvaluated']).format('MMM DD, YYYY')}</dd>
+                                        <dt>Number of submission(s):</dt><dd className="submissionCount">{clinVarInterpretationSummary['SubmissionCount']}</dd>
+                                    </dl>
+                                </div>
+                                <table className="table">
+                                    <thead>
+                                        <tr>
+                                            <th>Reference Accession</th>
+                                            <th>Review Status</th>
+                                            <th>Clinical Significance</th>
+                                            <th>Disease [Source]</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {clinVarRCV.map(function(item, i) {
+                                            return (self.renderClinvarInterpretations(item, i));
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
                             :
                             <div className="panel-body">
                                 <span>No data was found for this allele in ClinVar. <a href="http://www.ncbi.nlm.nih.gov/clinvar/" target="_blank">Search ClinVar</a> for this variant.</span>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -405,7 +405,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 </div>
 
                 <div className="panel panel-info datasource-clinvar-interpretaions">
-                    <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretations</h3></div>
+                    <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretation and Supporting Records</h3></div>
                     <div className="panel-content-wrapper">
                         {this.state.loading_clinvarRCV ? showActivityIndicator('Retrieving data... ') : null}
                         {(clinVarRCV.length > 0) ?

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1154,6 +1154,16 @@
                 }
             }
 
+            .basic-info .datasource-clinvar-interpretaions  {
+                .clinvar-interpretation-summary {
+                    border-bottom: solid 1px #ddd;
+
+                    .reviewStatus:first-letter {
+                        text-transform: capitalize;
+                    }
+                }
+            }
+
             .basic-info .datasource-clinvar-interpretaions .table th,
             .basic-info .datasource-clinvar-interpretaions .table td {
                 width: 16.67%;


### PR DESCRIPTION
**Technical notes:**
Adding method to parse the following selected ClinVar interpretation summary data:
- Review Status
- Clinical significance
- Last evaluated
- Number of submission(s)

As discussed with the curators, the conditions are not needed at the top of the table as they are already displayed individually for their respective RCVs in the table.

Example ClinVar variation:
http://www.ncbi.nlm.nih.gov/clinvar/variation/55847/

**Steps to test:**
1. Login and use 55847 at the variation selection interface.
2. On the Basic Info tab, expect to see the following interpretation data being displayed at the top of the ClinVar Interpretations table:
- Review Status
- Clinical significance
- Last evaluated
- Number of submission(s)