### PR TITLE
Connects to #954. Ability to associate PMID in VCI

### DIFF
--- a/src/clincoded/schemas/curatorHistory.json
+++ b/src/clincoded/schemas/curatorHistory.json
@@ -41,7 +41,8 @@
                 "pathogenicity",
                 "provisionalClassification",
                 "variant",
-                "interpretation"
+                "interpretation",
+                "extra_evidence"
             ]
         },
         "hidden": {

--- a/src/clincoded/schemas/external_evidence.json
+++ b/src/clincoded/schemas/external_evidence.json
@@ -1,0 +1,67 @@
+{
+    "title": "external_evidence",
+    "id": "/profiles/external_evidence.json",
+    "description": "External evidence group for a VCI interpretation",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "identifyingProperties": ["uuid"],
+    "additionalProperties": false,
+    "mixinProperties": [
+        { "$ref": "mixins.json#/schema_version" },
+        { "$ref": "mixins.json#/uuid" },
+        { "$ref": "mixins.json#/submitted" },
+        { "$ref": "mixins.json#/standard_status" }
+    ],
+    "properties": {
+        "schema_version": {
+            "default": "1"
+        },
+        "variant": {
+            "title": "Variant",
+            "description": "Variant associated with external evidence",
+            "type": "string",
+            "linkTo": "variant"
+        },
+        "category": {
+            "title": "Category",
+            "description": "Category the external evidence is in",
+            "type": "string"
+        },
+        "subcategory": {
+            "title": "Subcategory",
+            "description": "Subcategory the external evidence is in",
+            "type": "string"
+        },
+        "articles": {
+            "title": "List of articles",
+            "descripton": "List of articles part of this external evidence group",
+            "type": "array",
+            "default": [],
+            "items": {
+                "title": "Article",
+                "description": "Article",
+                "type": "string",
+                "linkTo": "article"
+            }
+        },
+        "description": {
+            "title": "Description",
+            "description": "Description for external evidence",
+            "type": "string"
+        }
+    },
+    "columns": {
+        "description": {
+            "title": "Description",
+            "type": "string"
+        },
+        "submitted_by.title": {
+            "title": "Curator",
+            "type": "string"
+        },
+        "date_created": {
+            "title": "Date/Time",
+            "type": "string"
+        }
+    }
+}

--- a/src/clincoded/schemas/extra_evidence.json
+++ b/src/clincoded/schemas/extra_evidence.json
@@ -4,7 +4,7 @@
     "description": "Extra evidence group for a VCI interpretation",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
-    "required": ["variant"],
+    "required": ["variant", "evidenceDescription"],
     "identifyingProperties": ["uuid"],
     "additionalProperties": false,
     "mixinProperties": [
@@ -45,7 +45,7 @@
                 "linkTo": "article"
             }
         },
-        "description": {
+        "evidenceDescription": {
             "title": "Description",
             "description": "Description for external evidence",
             "type": "string"
@@ -57,7 +57,7 @@
         }
     },
     "columns": {
-        "description": {
+        "evidenceDescription": {
             "title": "Description",
             "type": "string"
         },

--- a/src/clincoded/schemas/extra_evidence.json
+++ b/src/clincoded/schemas/extra_evidence.json
@@ -49,6 +49,11 @@
             "title": "Description",
             "description": "Description for external evidence",
             "type": "string"
+        },
+        "experimentalType": {
+            "title": "Experimental Type",
+            "description": "Experimental Type",
+            "type": "string"
         }
     },
     "columns": {

--- a/src/clincoded/schemas/extra_evidence.json
+++ b/src/clincoded/schemas/extra_evidence.json
@@ -1,9 +1,10 @@
 {
-    "title": "external_evidence",
-    "id": "/profiles/external_evidence.json",
-    "description": "External evidence group for a VCI interpretation",
+    "title": "extra_evidence",
+    "id": "/profiles/extra_evidence.json",
+    "description": "Extra evidence group for a VCI interpretation",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
+    "required": ["variant"],
     "identifyingProperties": ["uuid"],
     "additionalProperties": false,
     "mixinProperties": [
@@ -34,7 +35,7 @@
         },
         "articles": {
             "title": "List of articles",
-            "descripton": "List of articles part of this external evidence group",
+            "description": "List of articles part of this external evidence group",
             "type": "array",
             "default": [],
             "items": {

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -100,14 +100,14 @@
             "description": "Flag to mark interpretation status as Provisional",
             "type": "boolean"
         },
-        "externalEvidenceList": {
-            "title": "External Evidence",
-            "description": "List of external evidence objects",
+        "extra_evidence_list": {
+            "title": "Extra Evidence",
+            "description": "List of extra evidence objects",
             "type": "array",
             "items": {
-                "title": "externalEvidence",
+                "title": "extra_evidence",
                 "type": "string",
-                "linkTo": "external_evidence"
+                "linkTo": "extra_evidence"
             }
         }
     },

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -99,6 +99,16 @@
             "title": "Mark As Provisional Interpretation",
             "description": "Flag to mark interpretation status as Provisional",
             "type": "boolean"
+        },
+        "externalEvidenceList": {
+            "title": "External Evidence",
+            "description": "List of external evidence objects",
+            "type": "array",
+            "items": {
+                "title": "externalEvidence",
+                "type": "string",
+                "linkTo": "external_evidence"
+            }
         }
     },
     "columns": {

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -384,6 +384,17 @@ function pubmedValidateForm() {
             }
         }
     }
+    // valid if parent object is evidence list (VCI) and input isn't already associated with it
+    if (valid && this.props.parentObj && this.props.parentObj['@type'] && this.props.parentObj['@type'][0] == 'evidenceList') {
+        for (var j = 0; j < this.props.parentObj.evidenceList.length; j++) {
+            if (this.props.parentObj.evidenceList[j].articles[0].pmid == formInput) {
+                valid = false;
+                this.setFormErrors('resourceId', 'This article has already been associated with this evidence group');
+                this.setState({submitBusy: false});
+                break;
+            }
+        }
+    }
     return valid;
 }
 function pubmedQueryResource() {

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -81,7 +81,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
     // renders the main Add/Edit button
     buttonRender: function() {
         return (
-            <span className={"inline-button-wrapper button-push" + (this.props.buttonWrapperClass ? " " + this.props.buttonWrapperClass : "")}>
+            <span className={"inline-button-wrapper" + (this.props.buttonWrapperClass ? " " + this.props.buttonWrapperClass : "")}>
                 <Modal title={this.state.txtModalTitle} className="input-inline" modalClass="modal-default">
                     <a className={"btn btn-default" + (this.props.buttonClass ? " " + this.props.buttonClass : "") + (this.props.disabled ? " disabled" : "")}
                         modal={<AddResourceIdModal resourceType={this.props.resourceType} initialFormValue={this.props.initialFormValue} modalButtonText={this.props.modalButtonText}
@@ -115,7 +115,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
                 <div className="form-group">
                     <span className="col-sm-5 control-label">{this.props.labelVisible ? this.props.label : null}</span>
                     <span className="col-sm-7">
-                        <div className={"inline-button-wrapper button-push" + (this.props.wrapperClass ? " " + this.props.wrapperClass : "")}>
+                        <div className={"inline-button-wrapper" + (this.props.wrapperClass ? " " + this.props.wrapperClass : "")}>
                             {this.buttonRender()}
                             {this.props.clearButtonRender && this.props.initialFormValue ?
                                 this.clearButtonRender()

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -384,7 +384,8 @@ function pubmedValidateForm() {
             }
         }
     }
-    // valid if parent object is evidence list (VCI) and input isn't already associated with it
+    // valid if parent object is evidence list (VCI) and input isn't already associated with it - final behavior TBD
+    /*
     if (valid && this.props.parentObj && this.props.parentObj['@type'] && this.props.parentObj['@type'][0] == 'evidenceList') {
         for (var j = 0; j < this.props.parentObj.evidenceList.length; j++) {
             if (this.props.parentObj.evidenceList[j].articles[0].pmid == formInput) {
@@ -394,7 +395,7 @@ function pubmedValidateForm() {
                 break;
             }
         }
-    }
+    }*/
     return valid;
 }
 function pubmedQueryResource() {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1837,9 +1837,9 @@ function flattenInterpretation(interpretation) {
         });
     }
 
-    if (interpretation.external_evidence_list && interpretation.external_evidence_list.length) {
-        flat.external_evidence_list = interpretation.external_evidence_list.map(function(external_evidence) {
-            return external_evidence['@id'];
+    if (interpretation.extra_evidence_list && interpretation.extra_evidence_list.length) {
+        flat.extra_evidence_list = interpretation.extra_evidence_list.map(function(extra_evidence) {
+            return extra_evidence['@id'];
         });
     }
 

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -465,7 +465,8 @@ var PmidSummary = module.exports.PmidSummary = React.createClass({
     propTypes: {
         article: React.PropTypes.object, // Article object to display
         displayJournal: React.PropTypes.bool, // T to display article journal
-        pmidLinkout: React.PropTypes.bool // T to display pmid linkout
+        pmidLinkout: React.PropTypes.bool, // T to display pmid linkout
+        className: React.PropTypes.string
     },
 
     render: function() {
@@ -480,7 +481,7 @@ var PmidSummary = module.exports.PmidSummary = React.createClass({
             }
 
             return (
-                <p>
+                <p className={this.props.className}>
                     {this.props.displayJournal ? authorsAll : authors}
                     {article.title + ' '}
                     {this.props.displayJournal ? <i>{article.journal + '. '}</i> : null}

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1837,6 +1837,12 @@ function flattenInterpretation(interpretation) {
         });
     }
 
+    if (interpretation.external_evidence_list && interpretation.external_evidence_list.length) {
+        flat.external_evidence_list = interpretation.external_evidence_list.map(function(external_evidence) {
+            return external_evidence['@id'];
+        });
+    }
+
     return flat;
 }
 

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -85,9 +85,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
     componentWillReceiveProps: function(nextProps) {
         // this block is for handling props and states when props (external data) is updated after the initial load/rendering
         // when props are updated, update the parent interpreatation object, if applicable
-        if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
-            this.setState({interpretation: nextProps.interpretation});
-        }
+        this.setState({interpretation: nextProps.interpretation});
         if (nextProps.ext_myGeneInfo) {
             this.setState({ext_myGeneInfo: nextProps.ext_myGeneInfo});
         }

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -5,15 +5,12 @@ var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var vciFormHelper = require('./shared/form');
+var extraEvidence = require('./shared/extra_evidence');
 var CurationInterpretationForm = vciFormHelper.CurationInterpretationForm;
 var CompleteSection = require('./shared/complete_section').CompleteSection;
-var add_external_resource = require('../../add_external_resource');
-var AddResourceId = add_external_resource.AddResourceId;
 
 var panel = require('../../../libs/bootstrap/panel');
 var form = require('../../../libs/bootstrap/form');
-var curator = require('../../curator');
-var PmidSummary = curator.PmidSummary;
 
 var PanelGroup = panel.PanelGroup;
 var Panel = panel.Panel;
@@ -46,55 +43,6 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
         this.setState({interpretation: nextProps.interpretation});
     },
 
-    updatePmid: function(article) {
-        this.setState({pmid: article.pmid});
-    },
-
-    updateInterpretationPmids: function() {
-        this.setState({submitBusy: true}); // Save button pressed; disable it and start spinner
-        let flatInterpretation = null;
-        let freshInterpretation = null;
-
-        this.getRestData('/interpretation/' + this.state.interpretation.uuid).then(interpretation => {
-            freshInterpretation = interpretation;
-            flatInterpretation = curator.flatten(freshInterpretation);
-
-            let extra_evidence = {
-                variant: this.state.interpretation.variant['@id'],
-                category: 'experimental',
-                subcategory: 'experimental-studies',
-                articles: [this.state.pmid],
-                description: 'N/A'
-            };
-
-            return this.postRestData('/extra-evidence/', extra_evidence).then(result => {
-                if (!flatInterpretation.extra_evidence_list) {
-                    flatInterpretation.extra_evidence_list = [];
-                }
-
-                flatInterpretation.extra_evidence_list.push(result['@graph'][0]['@id']);
-
-                return this.putRestData('/interpretation/' + this.state.interpretation.uuid, flatInterpretation).then(data => {
-                    return Promise.resolve(data['@graph'][0]);
-                });
-            });
-        }).then(interpretation => {
-            this.setState({submitBusy: false});
-            this.props.updateInterpretationObj();
-        });
-    },
-
-    renderInterpretationExtraEvidence: function(extra_evidence) {
-        return (
-            <tr key={extra_evidence.subcategory + '_' + extra_evidence.articles[0].pmid}>
-                <td><PmidSummary article={extra_evidence.articles[0]} displayJournal /></td>
-                <td>{extra_evidence.description}</td>
-                <td>Edit | Delete</td>
-            </tr>
-
-        );
-    },
-
     render: function() {
         return (
             <div className="variant-interpretation functional">
@@ -123,37 +71,8 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                     : null}
 
                     {this.state.interpretation ?
-                        <div className="panel panel-info">
-                            <div className="panel-heading"><h3 className="panel-title">PubMed Evidence</h3></div>
-                            <div className="panel-content-wrapper">
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Article</th>
-                                            <th>Description</th>
-                                            <th></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {this.state.interpretation.extra_evidence_list ?
-                                            this.state.interpretation.extra_evidence_list.map(extra_evidence => {
-                                                if (extra_evidence.subcategory === 'experimental-studies') {
-                                                    return (this.renderInterpretationExtraEvidence(extra_evidence));
-                                                }
-                                            })
-                                        : null}
-                                        <tr>
-                                            <td colSpan="3">
-                                                <AddResourceId resourceType="pubmed"
-                                                    protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} buttonText="Add New PMID" modalButtonText="Add Article" updateParentForm={this.updatePmid} buttonOnly={true} />
-                                                {this.state.pmid}
-                                                <span onClick={this.updateInterpretationPmids}>Update</span>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
+                        <extraEvidence.ExtraEvidenceTable category="experimental" subcategory="experimental-studies" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
 

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -70,7 +70,8 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="experimental" subcategory="experimental-studies" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="experimental" subcategory="experimental-studies"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Experimental Studies)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -69,8 +69,7 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                             </div>
                         </div>
                     : null}
-
-                    {this.state.interpretation ?
+                    {(this.props.data && this.state.interpretation) ?
                         <extraEvidence.ExtraEvidenceTable category="experimental" subcategory="experimental-studies" href_url={this.props.href_url}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -89,6 +89,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="segreagtion-data" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title={<h4><i>de novo</i> occurrence</h4>} panelBodyClassName="panel-wide-content" open>
@@ -101,6 +105,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
+                    : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="de-novo" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
 
@@ -115,6 +123,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="allele-data" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Alternate mechanism for disease" panelBodyClassName="panel-wide-content" open>
@@ -128,6 +140,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="alternate-mechanism" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Specificity of phenotype" panelBodyClassName="panel-wide-content" open>
@@ -140,6 +156,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
+                    : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="specificity-of-phenotype" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
 

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -55,8 +55,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
-
-                    {this.state.interpretation ?
+                    {(this.props.data && this.state.interpretation) ?
                         <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="observed-in-healthy" href_url={this.props.href_url}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
@@ -73,8 +72,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
-
-                    {this.state.interpretation ?
+                    {(this.props.data && this.state.interpretation) ?
                         <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="case-control" href_url={this.props.href_url}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -5,6 +5,7 @@ var moment = require('moment');
 var globals = require('../../globals');
 var RestMixin = require('../../rest').RestMixin;
 var vciFormHelper = require('./shared/form');
+var extraEvidence = require('./shared/extra_evidence');
 var CurationInterpretationForm = vciFormHelper.CurationInterpretationForm;
 var CompleteSection = require('./shared/complete_section').CompleteSection;
 
@@ -54,6 +55,11 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             </div>
                         </div>
                     : null}
+
+                    {this.state.interpretation ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="observed-in-healthy" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Case-control" panelBodyClassName="panel-wide-content" open>
@@ -66,6 +72,11 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
+                    : null}
+
+                    {this.state.interpretation ?
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="case-control" href_url={this.props.href_url}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
 

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -56,7 +56,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="observed-in-healthy" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="observed-in-healthy"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Observed in healthy adult(s))</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -73,7 +74,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="case-control" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="case-control"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Case-control)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -90,7 +92,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="segreagtion-data" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="segreagtion-data"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Segregation data)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -107,7 +110,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="de-novo" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="de-novo"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (<i>de novo</i> occurrence)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -124,7 +128,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="allele-data" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="allele-data"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Allele Data (<i>cis/trans</i>))</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -141,7 +146,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="alternate-mechanism" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="alternate-mechanism"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Alternate mechanism for disease)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>
@@ -158,7 +164,8 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         </div>
                     : null}
                     {(this.props.data && this.state.interpretation) ?
-                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="specificity-of-phenotype" href_url={this.props.href_url}
+                        <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="specificity-of-phenotype"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Specificity of phenotype)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
                 </Panel></PanelGroup>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -39,6 +39,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             updateMsg: null,
             tempEvidence: null,
             editEvidenceId: null,
+            descriptionInput: null,
             editDescriptionInput: null,
             interpretation: this.props.interpretation // parent interpretation object
         };
@@ -54,7 +55,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
     },
 
     updateTempEvidence: function(article) {
-        this.setState({tempEvidence: article});
+        this.setState({tempEvidence: article, descriptionInput: null});
     },
 
     submitForm: function(e) {
@@ -90,7 +91,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 });
             });
         }).then(interpretation => {
-            this.setState({submitBusy: false, tempEvidence: null});
+            this.setState({submitBusy: false, tempEvidence: null, descriptionInput: null});
             this.props.updateInterpretationObj();
         }).catch(error => {
             this.setState({submitBusy: false, tempEvidence: null, updateMsg: <span className="text-danger">Something went wrong while trying to save this evidence!</span>});
@@ -100,7 +101,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
 
     cancelAddEvidenceButton: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-        this.setState({tempEvidence: null});
+        this.setState({tempEvidence: null, descriptionInput: null});
     },
 
     editEvidenceButton: function(index) {
@@ -171,6 +172,10 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 </td>
             </tr>
         );
+    },
+
+    handleDescriptionChange: function(ref, e) {
+        this.setState({descriptionInput: this.refs[ref].getValue()});
     },
 
     handleEditDescriptionChange: function(ref, e) {
@@ -252,7 +257,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                                     <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
                                                         buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
                                                     <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
-                                                        submitBusy={this.state.submitBusy} inputDisabled={this.state.diseaseCriteria && this.state.diseaseCriteria.length == this.props.criteria.length && !this.state.diseaseAssociated} />
+                                                        submitBusy={this.state.submitBusy} inputDisabled={!(this.state.descriptionInput && this.state.descriptionInput.length > 0)} />
                                                     {this.state.updateMsg ?
                                                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                                                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -20,6 +20,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
     mixins: [RestMixin, FormMixin, CuratorHistory],
 
     propTypes: {
+        tableName: React.PropTypes.object, // table name as HTML object
         category: React.PropTypes.string, // category (usually the tab) the evidence is part of
         subcategory: React.PropTypes.string, // subcategory (usually the panel) the evidence is part of
         href_url: React.PropTypes.object, // href_url object
@@ -269,7 +270,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
 
         return (
             <div className="panel panel-info">
-                <div className="panel-heading"><h3 className="panel-title">PubMed Evidence</h3></div>
+                <div className="panel-heading"><h3 className="panel-title">{this.props.tableName}</h3></div>
                 <div className="panel-content-wrapper">
                     <table className="table">
                         {relevantEvidenceList.length > 0 ?

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -79,7 +79,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 category: this.props.category,
                 subcategory: this.props.subcategory,
                 articles: [this.state.tempEvidence.pmid],
-                description: this.refs['description'].getValue()
+                evidenceDescription: this.refs['description'].getValue()
             };
 
             return this.postRestData('/extra-evidence/', extra_evidence).then(result => {
@@ -142,7 +142,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             category: this.props.category,
             subcategory: this.props.subcategory,
             articles: [this.refs['edit-pmid'].getValue()],
-            description: this.refs['edit-description'].getValue()
+            evidenceDescription: this.refs['edit-description'].getValue()
         };
 
         this.putRestData(this.refs['edit-target'].getValue(), extra_evidence).then(result => {
@@ -172,7 +172,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             category: this.props.category,
             subcategory: this.props.subcategory,
             articles: [evidence.articles[0]['@id']],
-            description: evidence.description,
+            evidenceDescription: evidence.description,
             status: 'deleted'
         };
 
@@ -209,7 +209,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
         return (
             <tr key={extra_evidence.uuid}>
                 <td className="col-md-5"><PmidSummary article={extra_evidence.articles[0]} pmidLinkout /></td>
-                <td className="col-md-5">{extra_evidence.description}</td>
+                <td className="col-md-5">{extra_evidence.evidenceDescription}</td>
                 <td className="col-md-2">
                     <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence.articles[0].pmid)}>Edit</button>
                     <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Delete" submitBusy={this.state.deleteBusy}
@@ -237,7 +237,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                     <Form submitHandler={this.submitEditForm} formClassName="form-horizontal form-std">
                         <Input type="text" ref="edit-target" value={extra_evidence['@id']} inputDisabled={true} groupClassName="hidden" />
                         <Input type="text" ref="edit-pmid" value={extra_evidence.articles[0].pmid} inputDisabled={true} groupClassName="hidden" />
-                        <Input type="textarea" ref="edit-description" rows="2" label="Evidence:" value={extra_evidence.description} defaultValue={extra_evidence.description}
+                        <Input type="textarea" ref="edit-description" rows="2" label="Evidence:" value={extra_evidence.evidenceDescription} defaultValue={extra_evidence.evidenceDescription}
                             labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" handleChange={this.handleDescriptionChange} />
                         <div className="clearfix">
                             <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel Edit</button>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -293,8 +293,12 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                             <tr>
                                 <td colSpan="3">
                                     {!this.state.tempEvidence ?
-                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} wrapperClass="pull-right" buttonClass="btn-primary"
-                                        buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
+                                        <span>
+                                            <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} buttonClass="btn-primary"
+                                                buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
+
+                                            &nbsp;&nbsp;Select "Add PMID" to curate and save a piece of evidence from a published article.
+                                        </span>
                                     : null}
                                     {this.state.tempEvidence ?
                                         <div>
@@ -304,9 +308,9 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                                 <Input type="textarea" ref="description" rows="2" label="Evidence:" handleChange={this.handleDescriptionChange}
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
                                                 <div className="clearfix">
-                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>
-                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
+                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} buttonClass="btn-info"
                                                         buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
+                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>
                                                     <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
                                                         submitBusy={this.state.submitBusy} inputDisabled={!(this.state.descriptionInput && this.state.descriptionInput.length > 0)} />
                                                     {this.state.updateMsg ?

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -237,17 +237,17 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                     : null}
                                     {this.state.tempEvidence ?
                                         <div>
-                                            <PmidSummary article={this.state.tempEvidence} className="alert alert-info col-xs-offset-4" pmidLinkout />
+                                            <PmidSummary article={this.state.tempEvidence} className="alert alert-info" pmidLinkout />
 
                                             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                                                 <Input type="textarea" ref="description" rows="2" label="Evidence:"
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
                                                 <div className="curation-submit clearfix">
+                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel</button>
+                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
+                                                        buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
                                                     <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
                                                         submitBusy={this.state.submitBusy} inputDisabled={this.state.diseaseCriteria && this.state.diseaseCriteria.length == this.props.criteria.length && !this.state.diseaseAssociated} />
-                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right" buttonClass="btn-info"
-                                                        buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
-                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel Edit</button>
                                                     {this.state.updateMsg ?
                                                         <div className="submit-info pull-right">{this.state.updateMsg}</div>
                                                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -1,0 +1,261 @@
+'use strict';
+var React = require('react');
+var _ = require('underscore');
+var moment = require('moment');
+var form = require('../../../../libs/bootstrap/form');
+var RestMixin = require('../../../rest').RestMixin;
+var curator = require('../../../curator');
+var PmidSummary = curator.PmidSummary;
+var CuratorHistory = require('../../../curator_history');
+var add_external_resource = require('../../../add_external_resource');
+var AddResourceId = add_external_resource.AddResourceId;
+
+var Form = form.Form;
+var FormMixin = form.FormMixin;
+var Input = form.Input;
+var InputMixin = form.InputMixin;
+
+/*
+NOTE: disease dependency of criteria codes are in a state of flux right now. The mapping to actually
+dictate whether or not a criteria is disease-dependent is in ../mapping/evidence_code.json, but the
+code to deal with the associated form rendering and storing is here. If criteria codes need to have
+their disease dependency modified, edit evidence_code. To change or remove its behavior, edit here
+(if re-enabling, search for 'DISEASE DEPENDENCY RESTRICTION' and read involved notes. For other tweaks,
+search for 'diseaseCriteria', 'diseaseAssociated', 'diseaseDependent', and finally 'disease')
+*/
+
+// Form component to be re-used by various tabs
+var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
+    mixins: [RestMixin, FormMixin, CuratorHistory],
+
+    propTypes: {
+        category: React.PropTypes.string,
+        subcategory: React.PropTypes.string,
+        href_url: React.PropTypes.object,
+        interpretation: React.PropTypes.object, // parent interpretation object
+        updateInterpretationObj: React.PropTypes.func // function from index.js; this function will pass the updated interpretation object back to index.js
+    },
+
+    contextTypes: {
+        fetch: React.PropTypes.func // Function to perform a search
+    },
+
+    getInitialState: function() {
+        return {
+            submitBusy: false, // spinner for Save button
+            editBusy: false, // spinner for Edit button
+            removeBusy: false, // spinner for Remove button
+            updateMsg: null,
+            tempEvidence: null,
+            editEvidenceId: null,
+            editDescriptionInput: null,
+            interpretation: this.props.interpretation // parent interpretation object
+        };
+    },
+
+    componentDidMount: function() {
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        if (nextProps.interpretation) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
+    },
+
+    updateTempEvidence: function(article) {
+        this.setState({tempEvidence: article});
+    },
+
+    submitForm: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({submitBusy: true, updateMsg: null}); // Save button pressed; disable it and start spinner
+
+        // Save all form values from the DOM.
+        this.saveAllFormValues();
+
+        let flatInterpretation = null;
+        let freshInterpretation = null;
+
+        this.getRestData('/interpretation/' + this.state.interpretation.uuid).then(interpretation => {
+            freshInterpretation = interpretation;
+            flatInterpretation = curator.flatten(freshInterpretation);
+
+            let extra_evidence = {
+                variant: this.state.interpretation.variant['@id'],
+                category: this.props.category,
+                subcategory: this.props.subcategory,
+                articles: [this.state.tempEvidence.pmid],
+                description: this.refs['description'].getValue()
+            };
+
+            return this.postRestData('/extra-evidence/', extra_evidence).then(result => {
+                if (!flatInterpretation.extra_evidence_list) {
+                    flatInterpretation.extra_evidence_list = [];
+                }
+                flatInterpretation.extra_evidence_list.push(result['@graph'][0]['@id']);
+
+                return this.putRestData('/interpretation/' + this.state.interpretation.uuid, flatInterpretation).then(data => {
+                    return Promise.resolve(data['@graph'][0]);
+                });
+            });
+        }).then(interpretation => {
+            this.setState({submitBusy: false, tempEvidence: null});
+            this.props.updateInterpretationObj();
+        }).catch(error => {
+            this.setState({submitBusy: false, tempEvidence: null});
+            console.log(error);
+        });
+    },
+
+    submitEditForm: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({editBusy: true, updateMsg: null}); // Save button pressed; disable it and start spinner
+
+        // Save all form values from the DOM.
+        this.saveAllFormValues();
+
+        let extra_evidence = {
+            variant: this.state.interpretation.variant['@id'],
+            category: this.props.category,
+            subcategory: this.props.subcategory,
+            articles: [this.refs['edit-pmid'].getValue()],
+            description: this.refs['edit-description'].getValue()
+        };
+
+        this.putRestData(this.refs['edit-target'].getValue(), extra_evidence).then(result => {
+            this.setState({editBusy: false, editEvidenceId: null, editDescriptionInput: null});
+            this.props.updateInterpretationObj();
+        }).catch(error => {
+            this.setState({editBusy: false, editEvidenceId: null, editDescriptionInput: null});
+            console.log(error);
+        });
+    },
+
+    editEvidenceButton: function(index) {
+        this.setState({editEvidenceId: index, editDescriptionInput: null});
+    },
+
+    cancelEditEvidenceButton: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({editEvidenceId: null, editDescriptionInput: null});
+    },
+
+    removeEvidence: function(id) {
+        this.setState({removeBusy: true});
+        let flatInterpretation = null;
+        let freshInterpretation = null;
+
+        this.getRestData('/interpretation/' + this.state.interpretation.uuid).then(interpretation => {
+            freshInterpretation = interpretation;
+            flatInterpretation = curator.flatten(freshInterpretation);
+
+            flatInterpretation.extra_evidence_list.splice(flatInterpretation.extra_evidence_list.indexOf(id), 1);
+
+            return this.putRestData('/interpretation/' + this.state.interpretation.uuid, flatInterpretation).then(data => {
+                return Promise.resolve(data['@graph'][0]);
+            });
+        }).then(interpretation => {
+            this.setState({removeBusy: false});
+            this.props.updateInterpretationObj();
+        }).catch(error => {
+            this.setState({removeBusy: false});
+            console.log(error);
+        });
+    },
+
+    renderInterpretationExtraEvidence: function(extra_evidence) {
+        return (
+            <tr key={extra_evidence.subcategory + '_' + extra_evidence.articles[0].pmid}>
+                <td className="col-md-5"><PmidSummary article={extra_evidence.articles[0]} pmidLinkout /></td>
+                <td className="col-md-5">{extra_evidence.description}</td>
+                <td className="col-md-2">
+                    <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence.articles[0].pmid)}>Edit</button>
+                    <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Remove" submitBusy={this.state.removeBusy}
+                        clickHandler={() => this.removeEvidence(extra_evidence['@id'])} />
+                </td>
+            </tr>
+        );
+    },
+
+    handleEditDescriptionChange: function(ref, e) {
+        this.setState({editDescriptionInput: this.refs[ref].getValue()});
+    },
+
+    renderInterpretationExtraEvidenceEdit: function(extra_evidence) {
+        return (
+            <tr key={extra_evidence.subcategory + '_' + extra_evidence.articles[0].pmid}>
+                <td colSpan="3">
+                    <PmidSummary article={extra_evidence.articles[0]} className="alert alert-info" pmidLinkout />
+                    <Form submitHandler={this.submitEditForm} formClassName="form-horizontal form-std">
+                        <Input type="text" ref="edit-target" value={extra_evidence['@id']} inputDisabled={true} groupClassName="hidden" />
+                        <Input type="text" ref="edit-pmid" value={extra_evidence.articles[0].pmid} inputDisabled={true} groupClassName="hidden" />
+                        <Input type="textarea" ref="edit-description" rows="2" label="Description:" value={extra_evidence.description} defaultValue={extra_evidence.description}
+                            labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" handleChange={this.handleEditDescriptionChange} />
+                        <div className="curation-submit clearfix">
+                            <button className="btn btn-info pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel Edit</button>
+                            <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Edit"
+                                submitBusy={this.state.editBusy} inputDisabled={!(this.state.editDescriptionInput && this.state.editDescriptionInput.length > 0)} />
+                            {this.state.updateMsg ?
+                                <div className="submit-info pull-right">{this.state.updateMsg}</div>
+                            : null}
+                        </div>
+                    </Form>
+                </td>
+            </tr>
+        );
+    },
+
+
+    render: function() {
+        return (
+            <div className="panel panel-info">
+                <div className="panel-heading"><h3 className="panel-title">PubMed Evidence</h3></div>
+                <div className="panel-content-wrapper">
+                    <table className="table">
+                        <thead>
+                            <tr>
+                                <th>Article</th>
+                                <th>Description</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.state.interpretation.extra_evidence_list ?
+                                this.state.interpretation.extra_evidence_list.map(extra_evidence => {
+                                    if (extra_evidence.subcategory === this.props.subcategory) {
+                                        return (this.state.editEvidenceId === extra_evidence.articles[0].pmid
+                                            ? this.renderInterpretationExtraEvidenceEdit(extra_evidence)
+                                            : this.renderInterpretationExtraEvidence(extra_evidence));
+                                    }
+                                })
+                            : null}
+                            <tr>
+                                <td colSpan="3">
+                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation}
+                                        buttonText={this.state.tempEvidence ? "Edit PMID" : "Add PMID"} modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
+                                    {this.state.tempEvidence ?
+                                        <div>
+                                            <PmidSummary article={this.state.tempEvidence} className="alert alert-info col-xs-offset-4" pmidLinkout />
+
+                                            <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
+                                                <Input type="textarea" ref="description" rows="2" label="Description:"
+                                                    labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
+                                                <div className="curation-submit clearfix">
+                                                    <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
+                                                        submitBusy={this.state.submitBusy} inputDisabled={this.state.diseaseCriteria && this.state.diseaseCriteria.length == this.props.criteria.length && !this.state.diseaseAssociated} />
+                                                    {this.state.updateMsg ?
+                                                        <div className="submit-info pull-right">{this.state.updateMsg}</div>
+                                                    : null}
+                                                </div>
+                                            </Form>
+                                        </div>
+                                    : null}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        );
+    }
+});

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -217,6 +217,10 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 }
             });
         }
+        let parentObj = {
+            '@type': ['evidenceList'],
+            'evidenceList': relevantEvidenceList
+        };
 
         return (
             <div className="panel panel-info">
@@ -243,7 +247,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                             <tr>
                                 <td colSpan="3">
                                     {!this.state.tempEvidence ?
-                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right" buttonClass="btn-primary"
+                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} wrapperClass="pull-right" buttonClass="btn-primary"
                                         buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
                                     : null}
                                     {this.state.tempEvidence ?
@@ -255,7 +259,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
                                                 <div className="curation-submit clearfix">
                                                     <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>
-                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
+                                                    <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
                                                         buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
                                                     <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"
                                                         submitBusy={this.state.submitBusy} inputDisabled={!(this.state.descriptionInput && this.state.descriptionInput.length > 0)} />

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -175,11 +175,12 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
     },
 
     handleDescriptionChange: function(ref, e) {
-        this.setState({descriptionInput: this.refs[ref].getValue()});
-    },
+        if (ref === 'description') {
+            this.setState({descriptionInput: this.refs[ref].getValue()});
+        } else if (ref === 'edit-description') {
+            this.setState({editDescriptionInput: this.refs[ref].getValue()});
+        }
 
-    handleEditDescriptionChange: function(ref, e) {
-        this.setState({editDescriptionInput: this.refs[ref].getValue()});
     },
 
     renderInterpretationExtraEvidenceEdit: function(extra_evidence) {
@@ -191,7 +192,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                         <Input type="text" ref="edit-target" value={extra_evidence['@id']} inputDisabled={true} groupClassName="hidden" />
                         <Input type="text" ref="edit-pmid" value={extra_evidence.articles[0].pmid} inputDisabled={true} groupClassName="hidden" />
                         <Input type="textarea" ref="edit-description" rows="2" label="Evidence:" value={extra_evidence.description} defaultValue={extra_evidence.description}
-                            labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" handleChange={this.handleEditDescriptionChange} />
+                            labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" handleChange={this.handleDescriptionChange} />
                         <div className="curation-submit clearfix">
                             <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel Edit</button>
                             <Input type="submit" inputClassName="btn-info pull-right btn-inline-spacer" id="submit" title="Edit"
@@ -250,7 +251,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                             <PmidSummary article={this.state.tempEvidence} className="alert alert-info" pmidLinkout />
 
                                             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
-                                                <Input type="textarea" ref="description" rows="2" label="Evidence:"
+                                                <Input type="textarea" ref="description" rows="2" label="Evidence:" handleChange={this.handleDescriptionChange}
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
                                                 <div className="curation-submit clearfix">
                                                     <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -204,7 +204,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
 
     renderInterpretationExtraEvidenceEdit: function(extra_evidence) {
         return (
-            <tr key={extra_evidence.subcategory + '_' + extra_evidence.articles[0].pmid}>
+            <tr key={extra_evidence.uuid}>
                 <td colSpan="3">
                     <PmidSummary article={extra_evidence.articles[0]} className="alert alert-info" pmidLinkout />
                     <Form submitHandler={this.submitEditForm} formClassName="form-horizontal form-std">
@@ -212,7 +212,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                         <Input type="text" ref="edit-pmid" value={extra_evidence.articles[0].pmid} inputDisabled={true} groupClassName="hidden" />
                         <Input type="textarea" ref="edit-description" rows="2" label="Evidence:" value={extra_evidence.description} defaultValue={extra_evidence.description}
                             labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" handleChange={this.handleDescriptionChange} />
-                        <div className="curation-submit clearfix">
+                        <div className="clearfix">
                             <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel Edit</button>
                             <Input type="submit" inputClassName="btn-info pull-right btn-inline-spacer" id="submit" title="Edit"
                                 submitBusy={this.state.editBusy} inputDisabled={!(this.state.editDescriptionInput && this.state.editDescriptionInput.length > 0)} />
@@ -276,7 +276,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                             <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                                                 <Input type="textarea" ref="description" rows="2" label="Evidence:" handleChange={this.handleDescriptionChange}
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
-                                                <div className="curation-submit clearfix">
+                                                <div className="clearfix">
                                                     <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>
                                                     <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
                                                         buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -116,9 +116,9 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
         this.setState({tempEvidence: null, descriptionInput: null});
     },
 
-    editEvidenceButton: function(index) {
+    editEvidenceButton: function(id) {
         // called when the Edit button is pressed for an existing evidence
-        this.setState({editEvidenceId: index, editDescriptionInput: null});
+        this.setState({editEvidenceId: id, editDescriptionInput: null});
     },
 
     cancelEditEvidenceButton: function(e) {
@@ -172,7 +172,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             category: this.props.category,
             subcategory: this.props.subcategory,
             articles: [evidence.articles[0]['@id']],
-            evidenceDescription: evidence.description,
+            evidenceDescription: evidence.evidenceDescription,
             status: 'deleted'
         };
 
@@ -211,7 +211,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 <td className="col-md-5"><PmidSummary article={extra_evidence.articles[0]} pmidLinkout /></td>
                 <td className="col-md-5">{extra_evidence.evidenceDescription}</td>
                 <td className="col-md-2">
-                    <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence.articles[0].pmid)}>Edit</button>
+                    <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence['@id'])}>Edit</button>
                     <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Delete" submitBusy={this.state.deleteBusy}
                         clickHandler={() => this.deleteEvidence(extra_evidence)} />
                 </td>
@@ -284,7 +284,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                         <tbody>
                             {relevantEvidenceList.length > 0 ?
                                 relevantEvidenceList.map(evidence => {
-                                    return (this.state.editEvidenceId === evidence.articles[0].pmid
+                                    return (this.state.editEvidenceId === evidence['@id']
                                         ? this.renderInterpretationExtraEvidenceEdit(evidence)
                                         : this.renderInterpretationExtraEvidence(evidence));
                                 })

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -15,15 +15,6 @@ var FormMixin = form.FormMixin;
 var Input = form.Input;
 var InputMixin = form.InputMixin;
 
-/*
-NOTE: disease dependency of criteria codes are in a state of flux right now. The mapping to actually
-dictate whether or not a criteria is disease-dependent is in ../mapping/evidence_code.json, but the
-code to deal with the associated form rendering and storing is here. If criteria codes need to have
-their disease dependency modified, edit evidence_code. To change or remove its behavior, edit here
-(if re-enabling, search for 'DISEASE DEPENDENCY RESTRICTION' and read involved notes. For other tweaks,
-search for 'diseaseCriteria', 'diseaseAssociated', 'diseaseDependent', and finally 'disease')
-*/
-
 // Form component to be re-used by various tabs
 var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
     mixins: [RestMixin, FormMixin, CuratorHistory],
@@ -44,7 +35,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
         return {
             submitBusy: false, // spinner for Save button
             editBusy: false, // spinner for Edit button
-            removeBusy: false, // spinner for Remove button
+            deleteBusy: false, // spinner for Delete button
             updateMsg: null,
             tempEvidence: null,
             editEvidenceId: null,
@@ -140,8 +131,8 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
         this.setState({editEvidenceId: null, editDescriptionInput: null});
     },
 
-    removeEvidence: function(id) {
-        this.setState({removeBusy: true});
+    deleteEvidence: function(id) {
+        this.setState({deleteBusy: true});
         let flatInterpretation = null;
         let freshInterpretation = null;
 
@@ -155,10 +146,10 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 return Promise.resolve(data['@graph'][0]);
             });
         }).then(interpretation => {
-            this.setState({removeBusy: false});
+            this.setState({deleteBusy: false});
             this.props.updateInterpretationObj();
         }).catch(error => {
-            this.setState({removeBusy: false});
+            this.setState({deleteBusy: false});
             console.log(error);
         });
     },
@@ -170,8 +161,8 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 <td className="col-md-5">{extra_evidence.description}</td>
                 <td className="col-md-2">
                     <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence.articles[0].pmid)}>Edit</button>
-                    <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Remove" submitBusy={this.state.removeBusy}
-                        clickHandler={() => this.removeEvidence(extra_evidence['@id'])} />
+                    <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Delete" submitBusy={this.state.deleteBusy}
+                        clickHandler={() => this.deleteEvidence(extra_evidence['@id'])} />
                 </td>
             </tr>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -236,10 +236,10 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 }
             });
         }
-        let parentObj = {
+        let parentObj = {/*
             '@type': ['evidenceList'],
             'evidenceList': relevantEvidenceList
-        };
+        */};
 
         return (
             <div className="panel panel-info">

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -212,7 +212,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                 <td className="col-md-5"><PmidSummary article={extra_evidence.articles[0]} pmidLinkout /></td>
                 <td className="col-md-5">{extra_evidence.evidenceDescription}</td>
                 <td className="col-md-2">
-                    <button className="btn btn-default btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence['@id'])}>Edit</button>
+                    <button className="btn btn-info btn-inline-spacer" onClick={() => this.editEvidenceButton(extra_evidence['@id'])}>Edit</button>
                     <Input type="button-button" inputClassName="btn btn-danger btn-inline-spacer" title="Delete" submitBusy={this.state.deleteBusy}
                         clickHandler={() => this.deleteEvidence(extra_evidence)} />
                 </td>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -98,6 +98,20 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
         });
     },
 
+    cancelAddEvidenceButton: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({tempEvidence: null});
+    },
+
+    editEvidenceButton: function(index) {
+        this.setState({editEvidenceId: index, editDescriptionInput: null});
+    },
+
+    cancelEditEvidenceButton: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({editEvidenceId: null, editDescriptionInput: null});
+    },
+
     submitEditForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
         this.setState({editBusy: true, updateMsg: null}); // Save button pressed; disable it and start spinner
@@ -120,15 +134,6 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             this.setState({editBusy: false, editEvidenceId: null, editDescriptionInput: null});
             console.log(error);
         });
-    },
-
-    editEvidenceButton: function(index) {
-        this.setState({editEvidenceId: index, editDescriptionInput: null});
-    },
-
-    cancelEditEvidenceButton: function(e) {
-        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
-        this.setState({editEvidenceId: null, editDescriptionInput: null});
     },
 
     deleteEvidence: function(id) {
@@ -243,7 +248,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                                 <Input type="textarea" ref="description" rows="2" label="Evidence:"
                                                     labelClassName="col-xs-2 control-label" wrapperClassName="col-xs-10" groupClassName="form-group" />
                                                 <div className="curation-submit clearfix">
-                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelEditEvidenceButton}>Cancel</button>
+                                                    <button className="btn btn-default pull-right btn-inline-spacer" onClick={this.cancelAddEvidenceButton}>Cancel</button>
                                                     <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={this.state.interpretation} wrapperClass="pull-right btn-inline-spacer" buttonClass="btn-info"
                                                         buttonText="Edit PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
                                                     <Input type="submit" inputClassName="btn-primary pull-right btn-inline-spacer" id="submit" title="Save"

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -717,10 +717,6 @@
     padding-right: 10px;
 }
 
-.button-push {
-    margin-right: 15px;
-}
-
 .summary-matrix {
     border: solid 3px #000;
     border-collapse: collapse;

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -1004,7 +1004,9 @@ class Interpretation(Item):
         'evaluations.computational.submitted_by',
         'provisional_variant',
         'provisional_variant.submitted_by',
-        'externalEvidenceList'
+        'extra_evidence_list',
+        'extra_evidence_list.articles',
+        'extra_evidence_list.articles.submitted_by'
     ]
 
     @calculated_property(schema={
@@ -1057,14 +1059,14 @@ class Interpretation(Item):
 
 
 @collection(
-    name='external-evidence',
+    name='extra-evidence',
     properties={
-        'title': "External evidence for VCI",
-        'description': 'External evidence for VCI',
+        'title': "Extra evidence for VCI",
+        'description': 'Extra evidence for VCI',
     })
-class ExternalEvidence(Item):
-    item_type = 'external_evidence'
-    schema = load_schema('clincoded:schemas/external_evidence.json')
+class ExtraEvidence(Item):
+    item_type = 'extra_evidence'
+    schema = load_schema('clincoded:schemas/extra_evidence.json')
     embedded = [
         'variant',
         'articles',

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -1005,6 +1005,7 @@ class Interpretation(Item):
         'provisional_variant',
         'provisional_variant.submitted_by',
         'extra_evidence_list',
+        'extra_evidence_list.submitted_by',
         'extra_evidence_list.articles',
         'extra_evidence_list.articles.submitted_by'
     ]

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -1003,7 +1003,8 @@ class Interpretation(Item):
         'evaluations.computational',
         'evaluations.computational.submitted_by',
         'provisional_variant',
-        'provisional_variant.submitted_by'
+        'provisional_variant.submitted_by',
+        'externalEvidenceList'
     ]
 
     @calculated_property(schema={
@@ -1053,6 +1054,22 @@ class Interpretation(Item):
     })
     def provisional_count(self, provisional_variant=[]):
         return len(provisional_variant)
+
+
+@collection(
+    name='external-evidence',
+    properties={
+        'title': "External evidence for VCI",
+        'description': 'External evidence for VCI',
+    })
+class ExternalEvidence(Item):
+    item_type = 'external_evidence'
+    schema = load_schema('clincoded:schemas/external_evidence.json')
+    embedded = [
+        'variant',
+        'articles',
+        'submitted_by',
+    ]
 
 
 @collection(


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/18619862/b93d8350-7dbb-11e6-8c94-a7750b7888bf.png)

* Added in ability to add PMID evidence to an `interpretation` object via the new `extra_evidence` object
* Added in a module to display this evidence list in the VCI (multiple times per page if needed)
  * Module also supports in-table modal popup to add the articles (via the `add_external_resource` modal) and in-table editing and deleting of `extra_evidence` objects

* The `interpretation` object links to `extra_evidence` via the `extra_evidence_list array`
* The `extra_evidence` object currently only links to `articles`, but can theoretically support different objects such as `families`, `groups`, etc., as well.

**Note:** the article link from `extra_evidence` is currently an array to support multiple articles per evidence object, but the UI only allows for one article per evidence object. Whether or not the user will be allowed to add more than one articles per evidence is still under debate and may change in the future.

Testing:

1. Get to VCI
2. Go to Experimental and Segregation/Case tabs and confirm that there are no extra evidence tables
3. Begin interpretation, then confirm that the extra evidence tables are visible in the two tabs
4. Add PMID evidence
  * Also confirm that the Save button cannot be pressed when Evidence text box is empty
  * Also confirm that the Cancel button clears the returned PMID and hides the Evidence text box
  * Also confirm that pressing the 'Edit PMID' button brings up the modal again and can change the retrieved article
5. Add another PMID evidence
6. Add another PMID evidence, but with the same PMID as a previous evidence
7. Edit one of the previously added evidence items
  * Also confirm that pressing Edit on another evidence item switches the Edit mode to the new item
  * Also confirm that the Cancel button cancels out of Edit mode
8. Delete one of the previously added evidence items