### PR TITLE
Connects to #915 kl bug brackets no disease

### DIFF
--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -211,7 +211,8 @@ module.exports.external_url_map = {
     'VariationViewerGRCh37': 'https://www.ncbi.nlm.nih.gov/variation/view/?chr=',
     'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
     'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
-    'Bustamante': '//predictvar.bustamante-lab.net/variant/position/'
+    'Bustamante': '//predictvar.bustamante-lab.net/variant/position/',
+    'MeSH': 'http://www.ncbi.nlm.nih.gov/mesh?term='
 };
 
 

--- a/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
+++ b/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
@@ -93,10 +93,10 @@ export function parseClinvarInterpretation(result) {
                         }
 
                         for (let childNode of Trait.childNodes) {
-                            if (childNode.nodeName === 'XRef') {
-                                if (childNode.attributes.length === 2) {
+                            if (childNode.nodeName === 'XRef' && childNode.getAttribute('ID') && childNode.getAttribute('DB')) {
+                                if (childNode.getAttribute('Type') && childNode.getAttribute('Type') === 'primary') {
                                     xRefNodes.push(childNode);
-                                } else if (childNode.getAttribute('Type') !== 'secondary') {
+                                } else if (!childNode.getAttribute('Type')) {
                                     xRefNodes.push(childNode);
                                 }
                             }

--- a/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
+++ b/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
@@ -41,7 +41,7 @@ export function getClinvarRCVs(xml) {
 // Method to parse conditions data for the most recent version of individual RCV accession
 export function parseClinvarInterpretation(result) {
     // List of Type values of <Trait>. Each should be traited as disease and collected.
-    const disease_types = ['Disease', 'NamedProteinVariant'];
+    //const disease_types = ['Disease', 'NamedProteinVariant'];
 
     // Define 'interpretation' object model
     let interpretation = {
@@ -81,34 +81,38 @@ export function parseClinvarInterpretation(result) {
                             xRefNodes = [],
                             identifiers = [],
                             disease = '';
-                        if (disease_types.includes(Trait.getAttribute('Type'))) {
-                            nameNodes = Trait.getElementsByTagName('Name');
-                            // Expect to find the only one <ElementValue> node in each <Name> node
-                            for(let nameNode of nameNodes) {
-                                let ElementValueNode = nameNode.getElementsByTagName('ElementValue')[0];
-                                if (ElementValueNode.getAttribute('Type') === 'Preferred') {
-                                    // Set disease name property value for each associated condition
-                                    disease = ElementValueNode.textContent;
-                                }
+                        //if (disease_types.includes(Trait.getAttribute('Type'))) {
+                        nameNodes = Trait.getElementsByTagName('Name');
+                        // Expect to find the only one <ElementValue> node in each <Name> node
+                        for(let nameNode of nameNodes) {
+                            let ElementValueNode = nameNode.getElementsByTagName('ElementValue')[0];
+                            if (ElementValueNode.getAttribute('Type') === 'Preferred') {
+                                // Set disease name property value for each associated condition
+                                disease = ElementValueNode.textContent;
                             }
-                            // Expect to find multiple <XRef> nodes in each <Trait> node
-                            // Filter & find only the <XRef> nodes that are immediate children of <Trait> node
-                            for (var i=0; i<Trait.childNodes.length; i++) {
-                                if (Trait.childNodes[i].nodeName === 'XRef') {
-                                    xRefNodes.push(Trait.childNodes[i]);
-                                }
-                            }
-                            // Set identifiers property value for each associated condition
-                            if (xRefNodes) {
-                                for(let xRef of xRefNodes) {
-                                    let identifier = {
-                                        'db': xRef.getAttribute('DB'),
-                                        'id': xRef.getAttribute('ID')
-                                    };
-                                    identifiers.push(identifier);
+                        }
+
+                        for (let childNode of Trait.childNodes) {
+                            if (childNode.nodeName === 'XRef') {
+                                if (childNode.attributes.length === 2) {
+                                    xRefNodes.push(childNode);
+                                } else if (childNode.getAttribute('Type') !== 'secondary') {
+                                    xRefNodes.push(childNode);
                                 }
                             }
                         }
+
+                        // Set identifiers property value for each associated condition
+                        if (xRefNodes) {
+                            for(let xRef of xRefNodes) {
+                                let identifier = {
+                                    'db': xRef.getAttribute('DB'),
+                                    'id': xRef.getAttribute('ID')
+                                };
+                                identifiers.push(identifier);
+                            }
+                        }
+                        //}
                         let condition = {
                             'name': disease,
                             'identifiers': identifiers

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -439,7 +439,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                             <th>Reference Accession</th>
                                             <th>Review Status</th>
                                             <th>Clinical Significance</th>
-                                            <th>Disease [Source]</th>
+                                            <th>Condition [Source]</th>
                                         </tr>
                                     </thead>
                                     <tbody>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -266,6 +266,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             case "Gene":
                 url = external_url_map['Entrez'] + id;
                 break;
+            case "Human Phenotype Ontology":
+                url = external_url_map['HPO'] + id;
+                break;
             default:
                 url = '#';
         }

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -220,7 +220,12 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 <td className="clinical-significance">{item.clinicalSignificance}</td>
                 <td className="disease">
                     {item.conditions.map(function(condition, i) {
-                        return (self.handleCondition(condition, i));
+                        return (
+                            <div>
+                                {self.handleCondition(condition, i)}
+                                {i < item.conditions.length - 1 ? <br /> : null}
+                            </div>
+                        );
                     })}
                 </td>
             </tr>
@@ -238,7 +243,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                         {condition.identifiers.map(function(identifier, i) {
                             return (
                                 <li key={i} className="xref-linkout">
-                                    <a href={self.handleLinkOuts(identifier.id, identifier.db)} target="_blank">{identifier.db}</a>
+                                    <a href={self.handleLinkOuts(identifier.id, identifier.db)} target="_blank">{identifier.db === 'Human Phenotype Ontology' ? 'HPO' : identifier.db}</a>
                                 </li>
                             );
                         })}

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -543,7 +543,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                null
+                                <dd className="col-lg-3">UCSC</dd>
                             }
                             {(links_38 || links_37) ?
                                 <dd>Variation Viewer [
@@ -553,7 +553,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                null
+                                <dd className="col-lg-4">Variation Viewer</dd>
                             }
                             {(links_38 || links_37) ?
                                 <dd>Ensembl Browser [
@@ -563,7 +563,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                null
+                                <dd className="col-lg-3">Ensembl Browser</dd>
                             }
                         </dl>
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -240,9 +240,14 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 {condition.identifiers && condition.identifiers.length ?
                     <span className="identifiers"> [<ul className="clearfix">
                         {condition.identifiers.map(function(identifier, i) {
+                            let url = self.handleLinkOuts(identifier.id, identifier.db);
                             return (
                                 <li key={i} className="xref-linkout">
-                                    <a href={self.handleLinkOuts(identifier.id, identifier.db)} target="_blank">{identifier.db === 'Human Phenotype Ontology' ? 'HPO' : identifier.db}</a>
+                                    {url ?
+                                        <a href={url} target="_blank">{identifier.db === 'Human Phenotype Ontology' ? 'HPO' : identifier.db}</a>
+                                        :
+                                        <span>{identifier.db + ': ' + identifier.id}</span>
+                                    }
                                 </li>
                             );
                         })}
@@ -274,7 +279,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 url = external_url_map['HPO'] + id;
                 break;
             default:
-                url = '#';
+                url = null;
+                //url = '#';
         }
         return url;
     },

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -221,9 +221,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 <td className="disease">
                     {item.conditions.map(function(condition, i) {
                         return (
-                            <div>
+                            <div className={i < item.conditions.length - 1 ? 'space-between-condition' : null}>
                                 {self.handleCondition(condition, i)}
-                                {i < item.conditions.length - 1 ? <br /> : null}
                             </div>
                         );
                     })}

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -236,9 +236,9 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         let self = this;
         return (
             <div key={condition.name}>
-                <span className="condition-name">{condition.name}</span>
+                <span className="condition-name">{condition.name}</span>&nbsp;
                 {condition.identifiers && condition.identifiers.length ?
-                    <span className="identifiers"> [<ul className="clearfix">
+                    <span className="identifiers">[<ul className="clearfix">
                         {condition.identifiers.map(function(identifier, i) {
                             let url = self.handleLinkOuts(identifier.id, identifier.db);
                             return (

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -413,7 +413,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                         <th>Reference Accession</th>
                                         <th>Review Status</th>
                                         <th>Clinical Significance</th>
-                                        <th>Disease [Source]</th>
+                                        <th>Condition [Source]</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -233,15 +233,19 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         return (
             <div key={condition.name}>
                 <span className="condition-name">{condition.name}</span>
-                <span className="identifiers"> [<ul className="clearfix">
-                    {condition.identifiers.map(function(identifier, i) {
-                        return (
-                            <li key={i} className="xref-linkout">
-                                <a href={self.handleLinkOuts(identifier.id, identifier.db)} target="_blank">{identifier.db}</a>
-                            </li>
-                        );
-                    })}
-                </ul>]</span>
+                {condition.identifiers && condition.identifiers.length ?
+                    <span className="identifiers"> [<ul className="clearfix">
+                        {condition.identifiers.map(function(identifier, i) {
+                            return (
+                                <li key={i} className="xref-linkout">
+                                    <a href={self.handleLinkOuts(identifier.id, identifier.db)} target="_blank">{identifier.db}</a>
+                                </li>
+                            );
+                        })}
+                    </ul>]</span>
+                    :
+                    null
+                }
             </div>
         );
     },

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -282,9 +282,11 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             case "Human Phenotype Ontology":
                 url = external_url_map['HPO'] + id;
                 break;
+            case "MeSH":
+                url = external_url_map['MeSH'] + id + '%5BMeSH+Unique+ID%5D&cmd=DetailsSearch&log$=activity';
+                break;
             default:
                 url = null;
-                //url = '#';
         }
         return url;
     },

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -283,7 +283,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 url = external_url_map['HPO'] + id;
                 break;
             case "MeSH":
-                url = external_url_map['MeSH'] + id + '%5BMeSH+Unique+ID%5D&cmd=DetailsSearch&log$=activity';
+                url = external_url_map['MeSH'] + id + '%5BMeSH%20Unique%20ID%5D';
                 break;
             default:
                 url = null;

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -220,11 +220,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 <td className="clinical-significance">{item.clinicalSignificance}</td>
                 <td className="disease">
                     {item.conditions.map(function(condition, i) {
-                        return (
-                            <div className={i < item.conditions.length - 1 ? 'space-between-condition' : null}>
-                                {self.handleCondition(condition, i)}
-                            </div>
-                        );
+                        return (self.handleCondition(condition, i));
                     })}
                 </td>
             </tr>
@@ -235,7 +231,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     handleCondition: function(condition, key) {
         let self = this;
         return (
-            <div key={condition.name}>
+            <div className="condition" key={condition.name}>
                 <span className="condition-name">{condition.name}</span>&nbsp;
                 {condition.identifiers && condition.identifiers.length ?
                     <span className="identifiers">[<ul className="clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -836,7 +836,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        null
+                                        <dd className="col-lg-3">UCSC</dd>
                                     }
                                     {(links_38 || links_37) ?
                                         <dd>Variation Viewer [
@@ -846,7 +846,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        null
+                                        <dd className="col-lg-4">Variation Viewer</dd>
                                     }
                                     {(links_38 || links_37) ?
                                         <dd>Ensembl Browser [
@@ -856,7 +856,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        null
+                                        <dd className="col-lg-3">Ensembl Browser</dd>
                                     }
                                 </dl>
                             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/externalLinks.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/externalLinks.js
@@ -21,22 +21,26 @@ module.exports.setContextLinks = function(nc_hgvs, ref) {
     var start = null;
     var end = null;
     var re = /:[g].(\d+)\D/;
-    var point = nc_hgvs.match(re)[1];
-    start = (parseInt(point) - 30).toString();
-    end = (parseInt(point) + 30).toString();
 
-    // set links and return
-    if (ref === 'GRCh38') {
-        return {
-            ucsc_url_38: external_url_map['UCSCGRCh38'] + chr + '%3A' + start + '-' + end,
-            viewer_url_38: external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start + '&to=' + end,
-            ensembl_url_38: external_url_map['EnsemblGRCh38'] + chr + ':' + start + '-' + end
-        };
-    } else if (ref === 'GRCh37') {
-        return {
-            ucsc_url_37: external_url_map['UCSCGRCh37'] + chr + '%3A' + start + '-' + end,
-            viewer_url_37: external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start + '&to=' + end,
-            ensembl_url_37: external_url_map['EnsemblGRCh37'] + chr + ':' + start + '-' + end
-        };
+    if (nc_hgvs.match(re) && nc_hgvs.match(re).length > 1) {
+        var point = nc_hgvs.match(re)[1];
+        start = (parseInt(point) - 30).toString();
+        end = (parseInt(point) + 30).toString();
+
+        //debugger;
+        // set links and return
+        if (ref === 'GRCh38') {
+            return {
+                ucsc_url_38: external_url_map['UCSCGRCh38'] + chr + '%3A' + start + '-' + end,
+                viewer_url_38: external_url_map['VariationViewerGRCh38'] + chr + '&assm=GCF_000001405.28&from=' + start + '&to=' + end,
+                ensembl_url_38: external_url_map['EnsemblGRCh38'] + chr + ':' + start + '-' + end
+            };
+        } else if (ref === 'GRCh37') {
+            return {
+                ucsc_url_37: external_url_map['UCSCGRCh37'] + chr + '%3A' + start + '-' + end,
+                viewer_url_37: external_url_map['VariationViewerGRCh37'] + chr + '&assm=GCF_000001405.25&from=' + start + '&to=' + end,
+                ensembl_url_37: external_url_map['EnsemblGRCh37'] + chr + ':' + start + '-' + end
+            };
+        }
     }
 };

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -90,7 +90,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            null
+                            <dd>UCSC</dd>
                         }
                         {(links_38 || links_37) ?
                             <dd>Variation Viewer [
@@ -100,7 +100,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            null
+                            <dd>Variation Viewer</dd>
                         }
                         {(links_38 || links_37) ?
                             <dd>Ensembl Browser [
@@ -110,7 +110,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            null
+                            <dd>Ensembl Browser</dd>
                         }
                     </dl>
                 </div>

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1173,12 +1173,16 @@
                 text-transform: capitalize;
             }
 
-            .basic-info .clinvar-interpretation .disease .identifiers ul {
+            .basic-info .clinvar-interpretation .disease .identifiers {
                 display: inline-block;
-                list-style: none;
-                margin: 0;
-                padding: 0;
-                vertical-align: bottom;
+
+                ul {
+                    display: inline-block;
+                    list-style: none;
+                    margin: 0;
+                    padding: 0;
+                    vertical-align: bottom;
+                }
             }
 
             .basic-info .clinvar-interpretation .disease .identifiers li {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1173,15 +1173,21 @@
                 text-transform: capitalize;
             }
 
-            .basic-info .clinvar-interpretation .disease .identifiers {
-                display: inline-block;
+            .basic-info .clinvar-interpretation .disease {
+                .condition:not(:first-child) {
+                    padding-top: 5px;
+                }
 
-                ul {
+                .identifiers {
                     display: inline-block;
-                    list-style: none;
-                    margin: 0;
-                    padding: 0;
-                    vertical-align: bottom;
+
+                    ul {
+                        display: inline-block;
+                        list-style: none;
+                        margin: 0;
+                        padding: 0;
+                        vertical-align: bottom;
+                    }
                 }
             }
 
@@ -1881,8 +1887,4 @@ dl.inline-dl {
 
 .criteria-description {
     text-overflow: clip;
-}
-
-.space-between-condition {
-    padding-bottom: 5px;
 }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1878,3 +1878,7 @@ dl.inline-dl {
 .criteria-description {
     text-overflow: clip;
 }
+
+.space-between-condition {
+    padding-bottom: 5px;
+}


### PR DESCRIPTION
**This PR has changes for parsing and displaying ClinVar interpretation data in Basic Info tab, including:**
 1. Only retrieve and display "primary" RCVs.
 2. Retrieve and display not only "Disease" type but also all other types of condition associated to a RCV.
 3. Add external links to HPO and MeSH. In case source name of an identifier is not "MedGen", "Orphanet", "OMIM", "HPO" or "MeSH", display identifier as "source name: id" without link since pre-set urls to external web pages are limited to the 5 sources above currently.

**Test Steps**
* Test 1 (primary RCVs)
  - In VCI, use ClinVar variant "15333" and expect to see only 4 primary RCVs (RCV000016575, RCV000016573, RCV000016574 and RCV000224000) as:
![screen shot 2016-09-18 at 11 01 20 pm](https://cloud.githubusercontent.com/assets/9206696/18623617/49dddc9c-7df4-11e6-9cc3-64a6a26c4a53.png)
Related meta data in ClinVar xml file: 
![screen shot 2016-09-18 at 11 10 17 pm](https://cloud.githubusercontent.com/assets/9206696/18623698/59551fa4-7df5-11e6-9814-0f787c79b69e.png)
xml file at: [https://www.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=15333](https://www.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=15333)

* Test 2 (Non-disease type condition)
  - Click `New Variant Curation` button at top, enter variant id "60671", click `Save and View Evidence` and expect to see ClinVar interpretation data as:
![screen shot 2016-09-18 at 7 16 57 pm](https://cloud.githubusercontent.com/assets/9206696/18621187/805e6cde-7dd4-11e6-8ca8-db3279aada57.png)
Related ClinVar meta data `Type="DrugResponse"` as:
![screen shot 2016-09-18 at 11 23 47 pm](https://cloud.githubusercontent.com/assets/9206696/18623887/1d4b387a-7df7-11e6-8008-6b4297065453.png)
in xml file [https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=clinvarset&id=RCV000054486](https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=clinvarset&id=RCV000054486)

* Test 3 (Links to MeSH and HPO)
  - Click `New Variant Curation`, enter variant "13969",  click `Save and View Evidence` and expect to see identifier "MeSH" with a link:
![screen shot 2016-09-21 at 1 06 50 pm](https://cloud.githubusercontent.com/assets/9206696/18727170/594fa296-7ffc-11e6-9cc5-99fd7c1e2d45.png)
  - Click the link and expect to open a MeSH web page in a new browser tab as:
![screen shot 2016-09-21 at 1 02 41 pm](https://cloud.githubusercontent.com/assets/9206696/18727057/e4f8a154-7ffb-11e6-88ff-c21de8f7c246.png)
  - Click `New Variant Curation`, enter variant "156411",  click `Save and View Evidence` and expect to see "HPO" identifiers with links as:
![screen shot 2016-09-19 at 11 32 13 pm](https://cloud.githubusercontent.com/assets/9206696/18659734/52378cda-7ec1-11e6-91fc-4cae1bcefc4b.png)
  - Click a HPO link and expect to see HPO web page for relevant condition in a new browser tab.

**End of Test**