### PR TITLE
Connects to #1013 kl bug css aws

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -77,7 +77,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (nextProps.data && this.props.data && !_.isEqual(nextProps.data, this.props.data)) {
+        if (nextProps.data && this.props.data) {
             this.parseData(nextProps.data);
         }
         // update data based on api call results

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -77,7 +77,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (nextProps.data && this.props.data) {
+        if (nextProps.data && this.props.data && !_.isEqual(nextProps.data, this.props.data)) {
             this.parseData(nextProps.data);
         }
         // update data based on api call results

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1184,8 +1184,8 @@
             }
 
             .basic-info .clinvar-interpretation .disease {
-                .condition:not(:first-child) {
-                    padding-top: 5px;
+                .condition {
+                    padding-bottom: 5px;
                 }
 
                 .identifiers {


### PR DESCRIPTION
This PR fixes a bug causing error and stop AWS instance. 

The bug is resulted by a CSS pseudo class `:not(:first-child)` in file `/src/clincoded/static/scss/clincoded/modules/_curator.scss` line 1182-1183.

It has been corrected by removing the pseudo class  from  the file.

**Test**
* Login to instance [https://bug-css-aws-6457060-kangliu.demo.clinicalgenome.org](https://bug-css-aws-6457060-kangliu.demo.clinicalgenome.org)
* In VCI, use ClinVar variant 13969 and expect to see Basic Info tab in Evidence View as:
![screen shot 2016-09-26 at 6 01 54 pm](https://cloud.githubusercontent.com/assets/9206696/18856834/67857226-8413-11e6-8f89-9be8752c5c1c.png)

**End of Test**