### PR TITLE
Connects to #943. VCI summary page.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1444,6 +1444,10 @@ var flatten = module.exports.flatten = function(obj, type) {
                 flat = flattenProvisional(obj);
                 break;
 
+            case 'provisional_variant':
+                flat = flattenProvisionalVariant(obj);
+                break;
+
             case 'interpretation':
                 flat = flattenInterpretation(obj);
                 break;
@@ -1789,6 +1793,18 @@ function flattenProvisional(provisional) {
 
     return flat;
 }
+
+
+var provisionalVariantSimpleProps = [
+    "autoClassification", "alteredClassification", "reasons"
+];
+
+function flattenProvisionalVariant(provisional_variant) {
+    var flat = cloneSimpleProps(provisional_variant, provisionalVariantSimpleProps);
+
+    return flat;
+}
+
 
 var interpretationSimpleProps = ["active", "date_created", "completed_sections"];
 

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -45,6 +45,17 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     },
 
     componentWillReceiveProps: function(nextProps) {
+        if (this.props.variantData) {
+            let variant_data = this.props.variantData;
+            if (variant_data.associatedInterpretations && variant_data.associatedInterpretations.length) {
+                let associatedInterpretations = variant_data.associatedInterpretations;
+                associatedInterpretations.forEach(associatedInterpretation => {
+                    if (associatedInterpretation.submitted_by['@id'] === this.props.session.user_properties['@id']) {
+                        this.setState({hasExistingInterpretation: true});
+                    }
+                });
+            }
+        }
         if (nextProps.interpretation && this.props.interpretation) {
             this.setState({interpretation: nextProps.interpretation}, () => {
                 let interpretation = this.state.interpretation;
@@ -108,13 +119,13 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
             associateDiseaseButtonTitle = '',
             associateDiseaseModalTitle = '';
 
-        if (!interpretation) {
+        if (!this.state.hasExistingInterpretation) {
             interpretationButtonTitle = 'Start New Interpretation';
-        } else if (interpretation) {
+        } else {
             if (!this.state.isInterpretationActive) {
                 interpretationButtonTitle = 'Continue Interpretation';
             } else {
-                if (interpretation.disease && this.state.hasAssociatedDisease) {
+                if (interpretation && this.state.hasAssociatedDisease) {
                     associateDiseaseButtonTitle = 'Edit Disease';
                     associateDiseaseModalTitle = 'Associate this interpretation with a different disease';
                 } else {

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -50,6 +50,9 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
                 if (interpretation.disease) {
                     this.setState({hasAssociatedDisease: true});
                 }
+                if (interpretation.modeInheritance) {
+                    this.setState({hasAssociatedInheritance: true});
+                }
             }
         }
     },
@@ -70,7 +73,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         if (this.props.editKey === 'true' && nextProps.interpretation) {
             this.setState({isInterpretationActive: true, interpretation: nextProps.interpretation});
             // set disease and inheritance flags accordingly
-            if (nextProps.interpretation.interpretation_disease) {
+            if (nextProps.interpretation.disease) {
                 this.setState({hasAssociatedDisease: true});
             } else {
                 this.setState({hasAssociatedDisease: false});

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -45,6 +45,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     },
 
     componentWillReceiveProps: function(nextProps) {
+        // Checks whether there are any associated interpretations already existed in the variant object
+        // in the 'evidence only' view or prior to proceeding into an interpretation phase
         if (this.props.variantData) {
             let variant_data = this.props.variantData;
             if (variant_data.associatedInterpretations && variant_data.associatedInterpretations.length) {
@@ -56,6 +58,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
                 });
             }
         }
+        // Gets an updated interpretation object from parent
+        // And confirms the existence of an associated interpretation object
         if (nextProps.interpretation && this.props.interpretation) {
             this.setState({interpretation: nextProps.interpretation}, () => {
                 let interpretation = this.state.interpretation;

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -33,12 +33,25 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     getInitialState: function() {
         return {
             variantUuid: null,
-            interpretation: null,
+            interpretation: this.props.interpretation,
             hasExistingInterpretation: false,
             isInterpretationActive: false,
             hasAssociatedDisease: false,
             hasAssociatedInheritance: false
         };
+    },
+
+    componentDidMount: function() {
+        if (this.props.interpretation) {
+            this.setState({hasExistingInterpretation: true});
+            if (this.props.editKey && this.props.editKey === 'true') {
+                this.setState({isInterpretationActive: true});
+                let interpretation = this.props.interpretation;
+                if (interpretation.disease) {
+                    this.setState({hasAssociatedDisease: true});
+                }
+            }
+        }
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -55,7 +68,7 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
             }
         }
         if (this.props.editKey === 'true' && nextProps.interpretation) {
-            this.setState({isInterpretationActive: true});
+            this.setState({isInterpretationActive: true, interpretation: nextProps.interpretation});
             // set disease and inheritance flags accordingly
             if (nextProps.interpretation.interpretation_disease) {
                 this.setState({hasAssociatedDisease: true});

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -26,39 +26,44 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         session: React.PropTypes.object,
         interpretation: React.PropTypes.object,
         editKey: React.PropTypes.string,
-        updateInterpretationObj: React.PropTypes.func
+        updateInterpretationObj: React.PropTypes.func,
+        hasExistingInterpretation: React.PropTypes.bool,
+        isInterpretationActive: React.PropTypes.bool,
+        hasAssociatedDisease: React.PropTypes.bool,
     },
 
     getInitialState: function() {
         return {
             variantUuid: null,
-            interpretation: null,
-            hasExistingInterpretation: false,
-            isInterpretationActive: false,
-            hasAssociatedDisease: false
+            variantData: this.props.variantData,
+            interpretation: this.props.interpretation,
+            editKey: this.props.editKey,
+            hasExistingInterpretation: this.props.hasExistingInterpretation,
+            isInterpretationActive: this.props.isInterpretationActive,
+            hasAssociatedDisease: this.props.hasAssociatedDisease
         };
     },
 
     componentWillReceiveProps: function(nextProps) {
-        if (this.props.variantData) {
-            if (this.props.variantData.associatedInterpretations) {
-                if (this.props.variantData.associatedInterpretations.length) {
-                    var associatedInterpretations = this.props.variantData.associatedInterpretations;
-                    associatedInterpretations.forEach(associatedInterpretation => {
-                        if (associatedInterpretation.submitted_by['@id'] === this.props.session.user_properties['@id']) {
-                            this.setState({hasExistingInterpretation: true});
-                        }
-                    });
+        if (nextProps.interpretation && this.props.interpretation) {
+            this.setState({interpretation: nextProps.interpretation}, () => {
+                let interpretation = this.state.interpretation;
+                if (interpretation.submitted_by['@id'] === this.props.session.user_properties['@id']) {
+                    this.setState({hasExistingInterpretation: true});
                 }
-            }
+            });
         }
-        if (this.props.editKey === 'true' && this.props.interpretation) {
-            this.setState({isInterpretationActive: true});
-            if (this.props.interpretation) {
-                if (this.props.interpretation.interpretation_disease) {
-                    this.setState({hasAssociatedDisease: true});
-                }
-            }
+        if (nextProps.editKey) {
+            this.setState({editKey: nextProps.editKey});
+        }
+        if (nextProps.hasExistingInterpretation) {
+            this.setState({hasExistingInterpretation: nextProps.hasExistingInterpretation});
+        }
+        if (nextProps.isInterpretationActive) {
+            this.setState({isInterpretationActive: nextProps.isInterpretationActive});
+        }
+        if (nextProps.hasAssociatedDisease) {
+            this.setState({hasAssociatedDisease: nextProps.hasAssociatedDisease});
         }
     },
 
@@ -98,20 +103,25 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
     },
 
     render: function() {
-        var interpretationButtonTitle = '';
-        if (!this.state.hasExistingInterpretation) {
-            interpretationButtonTitle = 'Start New Interpretation';
-        } else if (this.state.hasExistingInterpretation && !this.state.isInterpretationActive) {
-            interpretationButtonTitle = 'Continue Interpretation';
-        }
+        let interpretation = this.state.interpretation;
+        let interpretationButtonTitle = '',
+            associateDiseaseButtonTitle = '',
+            associateDiseaseModalTitle = '';
 
-        var associateDiseaseButtonTitle = '', associateDiseaseModalTitle = '';
-        if (this.state.hasAssociatedDisease) {
-            associateDiseaseButtonTitle = 'Edit Disease';
-            associateDiseaseModalTitle = 'Associate this interpretation with a different disease';
-        } else {
-            associateDiseaseButtonTitle = 'Associate with Disease';
-            associateDiseaseModalTitle = 'Associate this interpretation with a disease';
+        if (!interpretation) {
+            interpretationButtonTitle = 'Start New Interpretation';
+        } else if (interpretation) {
+            if (!this.state.isInterpretationActive) {
+                interpretationButtonTitle = 'Continue Interpretation';
+            } else {
+                if (interpretation.disease && this.state.hasAssociatedDisease) {
+                    associateDiseaseButtonTitle = 'Edit Disease';
+                    associateDiseaseModalTitle = 'Associate this interpretation with a different disease';
+                } else {
+                    associateDiseaseButtonTitle = 'Associate with Disease';
+                    associateDiseaseModalTitle = 'Associate this interpretation with a disease';
+                }
+            }
         }
 
         return (

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -17,16 +17,13 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
         session: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
         summaryVisible: React.PropTypes.bool,
-        getSelectedTab: React.PropTypes.func,
-        persistProvisionalCheckBox: React.PropTypes.func,
-        disabledProvisionalCheckbox: React.PropTypes.bool
+        getSelectedTab: React.PropTypes.func
     },
 
     getInitialState: function() {
         return {
             interpretation: null, // parent interpretation object
-            summaryVisible: this.props.summaryVisible,
-            disabledProvisionalCheckbox: this.props.disabledProvisionalCheckbox
+            summaryVisible: this.props.summaryVisible
         };
     },
 
@@ -37,8 +34,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
             this.setState({interpretation: nextProps.interpretation});
         }
         this.setState({
-            summaryVisible: nextProps.summaryVisible,
-            disabledProvisionalCheckbox: nextProps.disabledProvisionalCheckbox
+            summaryVisible: nextProps.summaryVisible
         });
     },
 
@@ -54,8 +50,7 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                     <div className="container">
                         <Title data={variant} interpretation={interpretation} interpretationUuid={interpretationUuid}
                             setSummaryVisibility={this.props.setSummaryVisibility} summaryVisible={this.state.summaryVisible}
-                            disabledProvisionalCheckbox={this.state.disabledProvisionalCheckbox}
-                            getSelectedTab={this.props.getSelectedTab} persistProvisionalCheckBox={this.props.persistProvisionalCheckBox} />
+                            getSelectedTab={this.props.getSelectedTab} />
                     </div>
                 </div>
                 <div className="container curation-data curation-variant">

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -16,7 +16,8 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
         interpretation: React.PropTypes.object,
         session: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
-        summaryVisible: React.PropTypes.bool
+        summaryVisible: React.PropTypes.bool,
+        getSelectedTab: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -46,7 +47,8 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                 <div className="curation-data-title">
                     <div className="container">
                         <Title data={variant} interpretation={interpretation} interpretationUuid={interpretationUuid}
-                            setSummaryVisibility={this.props.setSummaryVisibility} summaryVisible={this.state.summaryVisible} />
+                            setSummaryVisibility={this.props.setSummaryVisibility} summaryVisible={this.state.summaryVisible}
+                            getSelectedTab={this.props.getSelectedTab} />
                     </div>
                 </div>
                 <div className="container curation-data curation-variant">

--- a/src/clincoded/static/components/variant_central/header.js
+++ b/src/clincoded/static/components/variant_central/header.js
@@ -17,13 +17,16 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
         session: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
         summaryVisible: React.PropTypes.bool,
-        getSelectedTab: React.PropTypes.func
+        getSelectedTab: React.PropTypes.func,
+        persistProvisionalCheckBox: React.PropTypes.func,
+        disabledProvisionalCheckbox: React.PropTypes.bool
     },
 
     getInitialState: function() {
         return {
             interpretation: null, // parent interpretation object
-            summaryVisible: this.props.summaryVisible
+            summaryVisible: this.props.summaryVisible,
+            disabledProvisionalCheckbox: this.props.disabledProvisionalCheckbox
         };
     },
 
@@ -33,7 +36,10 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
         if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
             this.setState({interpretation: nextProps.interpretation});
         }
-        this.setState({summaryVisible: nextProps.summaryVisible});
+        this.setState({
+            summaryVisible: nextProps.summaryVisible,
+            disabledProvisionalCheckbox: nextProps.disabledProvisionalCheckbox
+        });
     },
 
     render: function() {
@@ -48,7 +54,8 @@ var VariantCurationHeader = module.exports.VariantCurationHeader = React.createC
                     <div className="container">
                         <Title data={variant} interpretation={interpretation} interpretationUuid={interpretationUuid}
                             setSummaryVisibility={this.props.setSummaryVisibility} summaryVisible={this.state.summaryVisible}
-                            getSelectedTab={this.props.getSelectedTab} />
+                            disabledProvisionalCheckbox={this.state.disabledProvisionalCheckbox}
+                            getSelectedTab={this.props.getSelectedTab} persistProvisionalCheckBox={this.props.persistProvisionalCheckBox} />
                     </div>
                 </div>
                 <div className="container curation-data curation-variant">

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -491,7 +491,7 @@ var VariantCurationHub = React.createClass({
         var editKey = this.state.editKey;
         var session = (this.props.session && Object.keys(this.props.session).length) ? this.props.session : null;
         var selectedTab = this.state.selectedTab;
-        let calculated_pathogenicity = this.state.calculated_pathogenicity;
+        let calculated_pathogenicity = (this.state.autoClassification) ? this.state.autoClassification : this.state.calculated_pathogenicity;
 
         return (
             <div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -496,7 +496,7 @@ var VariantCurationHub = React.createClass({
         var editKey = this.state.editKey;
         var session = (this.props.session && Object.keys(this.props.session).length) ? this.props.session : null;
         var selectedTab = this.state.selectedTab;
-        let calculated_pathogenicity = (this.state.autoClassification) ? this.state.autoClassification : this.state.calculated_pathogenicity;
+        let calculated_pathogenicity = (this.state.calculated_pathogenicity) ? this.state.calculated_pathogenicity : this.state.autoClassification;
 
         return (
             <div>

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -18,7 +18,7 @@ import { setPrimaryTranscript } from './helpers/primary_transcript';
 import { getClinvarRCVs, parseClinvarInterpretation } from './helpers/clinvar_interpretations';
 
 var CurationInterpretationCriteria = require('./interpretation/criteria').CurationInterpretationCriteria;
-import EvaluationSummary from './interpretation/summary';
+var EvaluationSummary = require('./interpretation/summary').EvaluationSummary;
 
 // Variant Curation Hub
 var VariantCurationHub = React.createClass({

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -57,9 +57,6 @@ var VariantCurationHub = React.createClass({
             loading_bustamante: true,
             calculated_pathogenicity: null,
             autoClassification: null,
-            hasExistingInterpretation: false,
-            isInterpretationActive: false,
-            hasAssociatedDisease: false,
             provisionalPathogenicity: null,
             provisionalReason: null,
             provisionalInterpretation: false
@@ -69,11 +66,6 @@ var VariantCurationHub = React.createClass({
     componentDidMount: function() {
         this.getClinVarData(this.state.variantUuid);
         if (this.state.interpretationUuid) {
-            this.setState({hasExistingInterpretation: true});
-            // User starts a new or continues an existing interpretation
-            if (this.state.editKey && this.state.editKey === 'true') {
-                this.setState({isInterpretationActive: true});
-            }
             this.getRestData('/interpretation/' + this.state.interpretationUuid).then(interpretation => {
                 this.setState({interpretation: interpretation}, () => {
                     // Return provisional-variant object properties
@@ -87,10 +79,6 @@ var VariantCurationHub = React.createClass({
                     // Return interpretation object's 'maskAsProvisional' property
                     if (this.state.interpretation.markAsProvisional) {
                         this.setState({provisionalInterpretation: true});
-                    }
-                    // Determine whether there is an associated disease
-                    if (this.state.interpretation.disease) {
-                        this.setState({hasAssociatedDisease: true});
                     }
                 });
             });
@@ -387,11 +375,7 @@ var VariantCurationHub = React.createClass({
     // method to update the interpretation object and send it down to child components on demand
     updateInterpretationObj: function() {
         this.getRestData('/interpretation/' + this.state.interpretationUuid).then(interpretation => {
-            this.setState({interpretation: interpretation}, () => {
-                if (this.state.interpretation.disease) {
-                    this.setState({hasAssociatedDisease: true});
-                }
-            });
+            this.setState({interpretation: interpretation});
         });
     },
 
@@ -446,9 +430,7 @@ var VariantCurationHub = React.createClass({
                     <div>
                         <CurationInterpretationCriteria interpretation={interpretation} selectedTab={selectedTab} />
                         <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
-                            href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj}
-                            hasExistingInterpretation={this.state.hasExistingInterpretation} isInterpretationActive={this.state.isInterpretationActive}
-                            hasAssociatedDisease={this.state.hasAssociatedDisease} />
+                            href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj} />
                         <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                             href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} getSelectedTab={this.getSelectedTab}
                             ext_myGeneInfo={(this.state.ext_myGeneInfo_MyVariant) ? this.state.ext_myGeneInfo_MyVariant : this.state.ext_myGeneInfo_VEP}

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -380,7 +380,7 @@ var VariantCurationHub = React.createClass({
                             setCalculatedPathogenicity={this.setCalculatedPathogenicity} />
                     </div>
                     :
-                    <EvaluationSummary interpretation={interpretation} calculatedAssertion={calculated_pathogenicity} />
+                    <EvaluationSummary interpretation={interpretation} calculatedAssertion={calculated_pathogenicity} updateInterpretationObj={this.updateInterpretationObj} />
                 }
             </div>
         );

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -391,11 +391,8 @@ var VariantCurationHub = React.createClass({
 
     // Method to set the calculated pathogenicity state for summary page
     setCalculatedPathogenicity: function(assertion) {
-        if (assertion) {
-            // In this method, 'this.setState' can't be used
-            // as it causes infinite error loop in React rendering
-            // FIXME candidate?
-            this.state.calculated_pathogenicity = assertion;
+        if (assertion && this.state.calculated_pathogenicity !== assertion) {
+            this.setState({calculated_pathogenicity: assertion});
         }
     },
 

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -62,8 +62,7 @@ var VariantCurationHub = React.createClass({
             hasAssociatedDisease: false,
             provisionalPathogenicity: null,
             provisionalReason: null,
-            provisionalInterpretation: false,
-            disabledProvisionalCheckbox: false
+            provisionalInterpretation: false
         };
     },
 
@@ -91,22 +90,7 @@ var VariantCurationHub = React.createClass({
                     }
                     // Determine whether there is an associated disease
                     if (this.state.interpretation.disease) {
-                        this.setState({hasAssociatedDisease: true}, () => {
-                            // Enable provisional interpretation checkbox if there is an associated disease,
-                            // regardless the calculated/modified pathogenicity
-                            this.setState({disabledProvisionalCheckbox: false});
-                        });
-                    } else {
-                        // If no disease is associated, we disable provisional checkbox
-                        // 1) when modified pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
-                        // 2) when calculated pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
-                        if (this.state.provisionalPathogenicity) {
-                            this.handleProvisionalCheckBox(this.state.provisionalPathogenicity);
-                        } else if (this.state.autoClassification) {
-                            this.handleProvisionalCheckBox(this.state.autoClassification);
-                        } else if (this.state.calculated_pathogenicity) {
-                            this.handleProvisionalCheckBox(this.state.calculated_pathogenicity);
-                        }
+                        this.setState({hasAssociatedDisease: true});
                     }
                 });
             });
@@ -405,9 +389,7 @@ var VariantCurationHub = React.createClass({
         this.getRestData('/interpretation/' + this.state.interpretationUuid).then(interpretation => {
             this.setState({interpretation: interpretation}, () => {
                 if (this.state.interpretation.disease) {
-                    this.setState({hasAssociatedDisease: true}, () => {
-                        this.setState({disabledProvisionalCheckbox: false});
-                    });
+                    this.setState({hasAssociatedDisease: true});
                 }
             });
         });
@@ -416,11 +398,6 @@ var VariantCurationHub = React.createClass({
     // Method to update status of summary page visibility
     setSummaryVisibility: function(visible) {
         this.setState({summaryVisible: visible});
-    },
-
-    // Method to retain current provisional checkbox state in toggling 'View Summary' button
-    persistProvisionalCheckBox: function(state) {
-        this.setState({disabledProvisionalCheckbox: state});
     },
 
     // Method to update the selected tab state to be used by criteria bar
@@ -435,57 +412,19 @@ var VariantCurationHub = React.createClass({
             // as it causes infinite error loop in React rendering
             // FIXME candidate?
             this.state.calculated_pathogenicity = assertion;
-            if (!this.state.hasAssociatedDisease) {
-                // If no disease is associated, we disable provisional checkbox
-                // when calculated pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
-                if (assertion === 'Likely pathogenic' || assertion === 'Pathogenic') {
-                    if(this.state.provisionalPathogenicity === 'Benign' ||
-                       this.state.provisionalPathogenicity === 'Likely benign' ||
-                       this.state.provisionalPathogenicity === 'Uncertain significance') {
-                        this.state.disabledProvisionalCheckbox = false;
-                    } else {
-                        this.state.disabledProvisionalCheckbox = true;
-                    }
-                } else {
-                    this.state.disabledProvisionalCheckbox = false;
-                }
-            }
         }
     },
 
     // Method to persist provisional evaluation states
     setProvisionalEvaluation: function(field, value) {
         if (field === 'provisional-pathogenicity') {
-            this.setState({provisionalPathogenicity: value}, () => {
-                if (!this.state.hasAssociatedDisease) {
-                    // If no disease is associated, we disable provisional checkbox
-                    // when modified pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
-                    this.handleProvisionalCheckBox(value);
-                }
-            });
+            this.setState({provisionalPathogenicity: value});
         }
         if (field === 'provisional-reason') {
             this.setState({provisionalReason: value});
         }
         if (field === 'provisional-interpretation') {
             this.setState({provisionalInterpretation: value});
-        }
-    },
-
-    // Method to set provisional checkbox state given the modified or calculated pathogenicity
-    handleProvisionalCheckBox: function(pathogenicity) {
-        // Avoid setting state if param value is null
-        if (pathogenicity === 'Likely pathogenic' || pathogenicity === 'Pathogenic') {
-            this.setState({disabledProvisionalCheckbox: true});
-        } else if (pathogenicity === 'Benign' || pathogenicity === 'Likely benign' || pathogenicity === 'Uncertain significance') {
-            this.setState({disabledProvisionalCheckbox: false});
-        } else if (!pathogenicity) {
-            if (this.state.autoClassification === 'Likely pathogenic' ||
-                this.state.autoClassification === 'Pathogenic' ||
-                this.state.calculated_pathogenicity === 'Likely pathogenic' ||
-                this.state.calculated_pathogenicity === 'Pathogenic') {
-                this.setState({disabledProvisionalCheckbox: true});
-            }
         }
     },
 
@@ -502,8 +441,7 @@ var VariantCurationHub = React.createClass({
             <div>
                 <VariantCurationHeader variantData={variantData} interpretationUuid={interpretationUuid} session={session}
                     interpretation={interpretation} setSummaryVisibility={this.setSummaryVisibility} summaryVisible={this.state.summaryVisible}
-                    getSelectedTab={this.getSelectedTab} disabledProvisionalCheckbox={this.state.disabledProvisionalCheckbox}
-                    persistProvisionalCheckBox={this.persistProvisionalCheckBox} />
+                    getSelectedTab={this.getSelectedTab} />
                 {!this.state.summaryVisible ?
                     <div>
                         <CurationInterpretationCriteria interpretation={interpretation} selectedTab={selectedTab} />
@@ -542,8 +480,7 @@ var VariantCurationHub = React.createClass({
                         setProvisionalEvaluation={this.setProvisionalEvaluation}
                         provisionalPathogenicity={this.state.provisionalPathogenicity}
                         provisionalReason={this.state.provisionalReason}
-                        provisionalInterpretation={this.state.provisionalInterpretation}
-                        disabledProvisionalCheckbox={this.state.disabledProvisionalCheckbox} />
+                        provisionalInterpretation={this.state.provisionalInterpretation} />
                 }
             </div>
         );

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -439,14 +439,12 @@ var VariantCurationHub = React.createClass({
                 // If no disease is associated, we disable provisional checkbox
                 // when calculated pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
                 if (assertion === 'Likely pathogenic' || assertion === 'Pathogenic') {
-                    switch (this.state.provisionalPathogenicity) {
-                        case 'Benign':
-                        case 'Likely benign':
-                        case 'Uncertain significance':
-                            this.state.disabledProvisionalCheckbox = false;
-                            break;
-                        default:
-                            this.state.disabledProvisionalCheckbox = true;
+                    if(this.state.provisionalPathogenicity === 'Benign' ||
+                       this.state.provisionalPathogenicity === 'Likely benign' ||
+                       this.state.provisionalPathogenicity === 'Uncertain significance') {
+                        this.state.disabledProvisionalCheckbox = false;
+                    } else {
+                        this.state.disabledProvisionalCheckbox = true;
                     }
                 } else {
                     this.state.disabledProvisionalCheckbox = false;
@@ -481,6 +479,13 @@ var VariantCurationHub = React.createClass({
             this.setState({disabledProvisionalCheckbox: true});
         } else if (pathogenicity === 'Benign' || pathogenicity === 'Likely benign' || pathogenicity === 'Uncertain significance') {
             this.setState({disabledProvisionalCheckbox: false});
+        } else if (!pathogenicity) {
+            if (this.state.autoClassification === 'Likely pathogenic' ||
+                this.state.autoClassification === 'Pathogenic' ||
+                this.state.calculated_pathogenicity === 'Likely pathogenic' ||
+                this.state.calculated_pathogenicity === 'Pathogenic') {
+                this.setState({disabledProvisionalCheckbox: true});
+            }
         }
     },
 

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -52,7 +52,8 @@ var VariantCurationHub = React.createClass({
             loading_ensemblVariation: true,
             loading_myVariantInfo: true,
             loading_myGeneInfo: true,
-            loading_bustamante: true
+            loading_bustamante: true,
+            calculated_pathogenicity: null
         };
     },
 
@@ -331,6 +332,13 @@ var VariantCurationHub = React.createClass({
         this.setState({selectedTab: selectedTab});
     },
 
+    // Method to set the calculated pathogenicity state for summary page
+    setCalculatedPathogenicity: function(assertion) {
+        if (assertion) {
+            this.state.calculated_pathogenicity = assertion;
+        }
+    },
+
     render: function() {
         var variantData = this.state.variantObj;
         var interpretation = (this.state.interpretation) ? this.state.interpretation : null;
@@ -338,7 +346,7 @@ var VariantCurationHub = React.createClass({
         var editKey = this.state.editKey;
         var session = (this.props.session && Object.keys(this.props.session).length) ? this.props.session : null;
         var selectedTab = this.state.selectedTab;
-        let summaryKey = this.state.summaryKey;
+        let calculated_pathogenicity = this.state.calculated_pathogenicity;
 
         return (
             <div>
@@ -368,10 +376,11 @@ var VariantCurationHub = React.createClass({
                             loading_ensemblVariation={this.state.loading_ensemblVariation}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_myGeneInfo={this.state.loading_myGeneInfo}
-                            loading_bustamante={this.state.loading_bustamante} />
+                            loading_bustamante={this.state.loading_bustamante}
+                            setCalculatedPathogenicity={this.setCalculatedPathogenicity} />
                     </div>
                     :
-                    <EvaluationSummary interpretation={interpretation} />
+                    <EvaluationSummary interpretation={interpretation} calculatedAssertion={calculated_pathogenicity} />
                 }
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -53,7 +53,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         loading_myVariantInfo: React.PropTypes.bool,
         loading_myGeneInfo: React.PropTypes.bool,
         loading_bustamante: React.PropTypes.bool,
-        setCalculatedPathogenicity: React.PropTypes.func
+        setCalculatedPathogenicity: React.PropTypes.func,
+        selectedTab:React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -118,6 +119,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_geneSynonyms) {
             this.setState({ext_geneSynonyms: nextProps.ext_geneSynonyms});
+        }
+        if (nextProps.selectedTab) {
+            this.setState({selectedTab: nextProps.selectedTab});
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -51,7 +51,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         loading_ensemblVariation: React.PropTypes.bool,
         loading_myVariantInfo: React.PropTypes.bool,
         loading_myGeneInfo: React.PropTypes.bool,
-        loading_bustamante: React.PropTypes.bool
+        loading_bustamante: React.PropTypes.bool,
+        setCalculatedPathogenicity: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -150,7 +151,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         // Adding or deleting a tab also requires its corresponding TabPanel to be added/deleted
         return (
             <div className="container curation-variant-tab-group">
-                <PathogenicityCalculator interpretation={interpretation} />
+                <PathogenicityCalculator interpretation={interpretation} setCalculatedPathogenicity={this.props.setCalculatedPathogenicity} />
                 <div className="vci-tabs">
                     <ul className="vci-tabs-header tab-label-list" role="tablist">
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('basic-info')} aria-selected={this.state.selectedTab == 'basic-info'}>Basic Information</li>

--- a/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
+++ b/src/clincoded/static/components/variant_central/interpretation/mapping/evidence_code.json
@@ -1,6 +1,6 @@
 {
     "BA1": {
-        "class": "benign-strong",
+        "class": "stand-alone",
         "definition": "Allele frequency greater than 5% in a population database",
         "definitionLong": "Allele frequency is > 5% in ExAC, 1000 Genomes, or ESP",
         "category": "population",

--- a/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
@@ -11,8 +11,30 @@ var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.cre
 
     getInitialState: function() {
         return {
-            rules: 'ACMG 2015' // Currently use ACMG rules only
+            rules: 'ACMG 2015', // Currently use ACMG rules only
+            interpretation: this.props.interpretation,
+            calculatedResult: null
         };
+    },
+
+    componentDidMount: function() {
+        if (this.props.interpretation) {
+            if (this.props.interpretation.evaluations && this.props.interpretation.evaluations.length) {
+                let evaluations = this.state.interpretation.evaluations;
+                this.calculatePathogenicity(evaluations);
+            }
+        }
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        if (nextProps.interpretation) {
+            this.setState({interpretation: nextProps.interpretation}, () => {
+                if (this.state.interpretation && this.state.interpretation.evaluations) {
+                    let evaluations = this.state.interpretation.evaluations;
+                    this.calculatePathogenicity(evaluations);
+                }
+            });
+        }
     },
 
     calculatePathogenicity: function(evaluationObjList) {
@@ -135,7 +157,7 @@ var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.cre
                 assertion: assertion,
                 path_summary: {},
                 benign_summary: {}
-            }
+            };
 
             if (pvs_count > 0) {
                 result.path_summary['Very strong'] = pvs_count;
@@ -163,13 +185,13 @@ var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.cre
         // set calculated pathogenicity in interpretation
         this.props.setCalculatedPathogenicity(result.assertion);
 
-        return result;
+        this.setState({calculatedResult: result});
     },
 
     render: function() {
-        let interpretation = this.props.interpretation ? this.props.interpretation : null;
+        let interpretation = this.state.interpretation ? this.state.interpretation : null;
         let evaluations = interpretation && interpretation.evaluations && interpretation.evaluations.length ? interpretation.evaluations : null;
-        let result = evaluations ? this.calculatePathogenicity(evaluations) : null;
+        let result = this.state.calculatedResult ? this.state.calculatedResult : null;
         let rules = this.state.rules;
 
         let benign_summary = result && result.benign_summary ? result.benign_summary : null;

--- a/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/calculator.js
@@ -6,6 +6,7 @@ import  _ from 'underscore';
 var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.createClass({
     propTypes: {
         interpretation: React.PropTypes.object,
+        setCalculatedPathogenicity: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -158,6 +159,9 @@ var PathogenicityCalculator = module.exports.PathogenicityCalculator = React.cre
                 result.benign_summary['Supporting'] = bp_count;
             }
         }
+
+        // set calculated pathogenicity in interpretation
+        this.props.setCalculatedPathogenicity(result.assertion);
 
         return result;
     },

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -291,64 +291,72 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                         <div className="panel panel-info datasource-evaluation-summary-provision">
                             <div className="panel-body">
                                 <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
-                                    <div className="col-xs-12 col-sm-6">
-                                        <dl className="inline-dl clearfix">
-                                            <dt>Calculated Pathogenicity:</dt>
-                                            <dd>{calculatedAssertion ? calculatedAssertion : 'None'}</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>Modified Pathogenicity:</dt>
-                                            <dd>{modifiedPathogenicity ? modifiedPathogenicity : 'None'}</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>Disease:</dt>
-                                            <dd>{interpretation.disease ? interpretation.disease.term : 'None'}</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>Mode of Inheritance:</dt>
-                                            <dd>{interpretation.modeInheritance ? interpretation.modeInheritance : 'None'}</dd>
-                                        </dl>
-                                        <dl className="inline-dl clearfix">
-                                            <dt>Provisional Interpretation Status:</dt>
-                                            <dd className="provisional-interpretation-status">{provisionalStatus ? 'Provisional' : 'In progress'}</dd>
-                                        </dl>
-                                    </div>
-                                    <div className="col-xs-12 col-sm-6 provisional-form-content-wrapper">
-                                        <div className="evaluation-provision provisional-pathogenicity">
-                                            <Input type="select" ref="provisional-pathogenicity" label={<span>Modify Pathogenicity:<i>(optional)</i></span>}
-                                                value={provisionalPathogenicity ? provisionalPathogenicity : ''}
-                                                labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
-                                                <option value=''>Select an option</option>
-                                                <option value="Benign">Benign</option>
-                                                <option value="Likely benign">Likely Benign</option>
-                                                <option value="Uncertain significance">Uncertain Significance</option>
-                                                <option value="Likely pathogenic">Likely Pathogenic</option>
-                                                <option value="Pathogenic">Pathogenic</option>
-                                            </Input>
-                                            <Input type="textarea" ref="provisional-reason" label={<span>Explain reason(s) for change:<i>(<strong>required</strong> for modified pathogenicity)</i></span>} rows="5"
-                                                value={provisionalReason ? provisionalReason : null}
-                                                placeholder="Note: If you selected a pathogenicity different from the Calculated Pathogenicity, you must provide a reason for the change here."
-                                                labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />
+                                    <div className="col-md-12 provisional-static-content-wrapper">
+                                        <div className="col-xs-12 col-sm-6">
+                                            <dl className="inline-dl clearfix">
+                                                <dt>Calculated Pathogenicity:</dt>
+                                                <dd>{calculatedAssertion ? calculatedAssertion : 'None'}</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>Modified Pathogenicity:</dt>
+                                                <dd>{modifiedPathogenicity ? modifiedPathogenicity : 'None'}</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>Provisional Interpretation Status:</dt>
+                                                <dd className="provisional-interpretation-status">{provisionalStatus ? 'Provisional' : 'In progress'}</dd>
+                                            </dl>
                                         </div>
-                                        <div className="evaluation-provision provisional-interpretation">
-                                            <div>
-                                                <i className="icon icon-question-circle"></i>
-                                                <span>Mark as Provisional Interpretation (optional):</span>
-                                                <Input type="checkbox" ref="provisional-interpretation" inputDisabled={disabledCheckbox} checked={provisionalInterpretation} defaultChecked="false"
+                                        <div className="col-xs-12 col-sm-6">
+                                            <dl className="inline-dl clearfix">
+                                                <dt>Disease:</dt>
+                                                <dd>{interpretation.disease ? interpretation.disease.term : 'None'}</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>Mode of Inheritance:</dt>
+                                                <dd>{interpretation.modeInheritance ? interpretation.modeInheritance : 'None'}</dd>
+                                            </dl>
+                                        </div>
+                                    </div>
+                                    <div className="col-md-12 provisional-form-content-wrapper">
+                                        <div className="col-xs-12 col-sm-6">
+                                            <div className="evaluation-provision provisional-pathogenicity">
+                                                <Input type="select" ref="provisional-pathogenicity" label={<span>Modify Pathogenicity:<i>(optional)</i></span>}
+                                                    value={provisionalPathogenicity ? provisionalPathogenicity : ''}
+                                                    labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
+                                                    <option value=''>Select an option</option>
+                                                    <option value="Benign">Benign</option>
+                                                    <option value="Likely benign">Likely Benign</option>
+                                                    <option value="Uncertain significance">Uncertain Significance</option>
+                                                    <option value="Likely pathogenic">Likely Pathogenic</option>
+                                                    <option value="Pathogenic">Pathogenic</option>
+                                                </Input>
+                                                <Input type="textarea" ref="provisional-reason" label={<span>Explain reason(s) for change:<i>(<strong>required</strong> for modified pathogenicity)</i></span>} rows="5"
+                                                    value={provisionalReason ? provisionalReason : null}
+                                                    placeholder="Note: If you selected a pathogenicity different from the Calculated Pathogenicity, you must provide a reason for the change here."
                                                     labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />
                                             </div>
                                         </div>
-                                        <div className="alert alert-warning">
-                                            Note: If the Calculated Pathogenicity is "Likely Pathogenic" or "Pathogenic,"
-                                            a disease must first be associated with the interpretation before it can be marked
-                                            as a "Provisional Interpretation". Please select "Return to Interpretation" to add a disease.
-                                        </div>
-                                        <div className="provisional-submit">
-                                            <Input type="submit" inputClassName={(provisionalVariant ? "btn-info" : "btn-primary") + " pull-right btn-inline-spacer"}
-                                                id="submit" title={provisionalVariant ? "Update" : "Save"} submitBusy={this.state.submitBusy} inputDisabled={disabledFormSumbit} />
-                                            {this.state.updateMsg ?
-                                                <div className="submit-info pull-right">{this.state.updateMsg}</div>
-                                            : null}
+                                        <div className="col-xs-12 col-sm-6">
+                                            <div className="evaluation-provision provisional-interpretation">
+                                                <div>
+                                                    <i className="icon icon-question-circle"></i>
+                                                    <span>Mark as Provisional Interpretation (optional):</span>
+                                                    <Input type="checkbox" ref="provisional-interpretation" inputDisabled={disabledCheckbox} checked={provisionalInterpretation} defaultChecked="false"
+                                                        labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />
+                                                </div>
+                                            </div>
+                                            <div className="alert alert-warning">
+                                                Note: If the Calculated Pathogenicity is "Likely Pathogenic" or "Pathogenic,"
+                                                a disease must first be associated with the interpretation before it can be marked
+                                                as a "Provisional Interpretation". Please select "Return to Interpretation" to add a disease.
+                                            </div>
+                                            <div className="provisional-submit">
+                                                <Input type="submit" inputClassName={(provisionalVariant ? "btn-info" : "btn-primary") + " pull-right btn-inline-spacer"}
+                                                    id="submit" title={provisionalVariant ? "Update" : "Save"} submitBusy={this.state.submitBusy} inputDisabled={disabledFormSumbit} />
+                                                {this.state.updateMsg ?
+                                                    <div className="submit-info pull-right">{this.state.updateMsg}</div>
+                                                : null}
+                                            </div>
                                         </div>
                                     </div>
                                 </Form>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -58,6 +58,23 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         });
     },
 
+    // Method to construct mode of inheritance linkout
+    renderModeInheritanceLink: function(modeInheritance) {
+        if (modeInheritance) {
+            let start = modeInheritance.indexOf('(');
+            var end = modeInheritance.indexOf(')');
+            if (start && end) {
+                let hpoNumber = modeInheritance.substring(start+1, end);
+                if (hpoNumber && hpoNumber.indexOf('HP:') > -1) {
+                    let hpoLink = 'http://compbio.charite.de/hpoweb/showterm?id=' + hpoNumber;
+                    return (
+                        <a href={hpoLink} target="_blank">{modeInheritance}</a>
+                    );
+                }
+            }
+        }
+    },
+
     // Method to set provisional checkbox state given the modified or calculated pathogenicity
     handleProvisionalCheckBox: function(pathogenicity) {
         if (!this.props.interpretation.disease) {
@@ -68,11 +85,13 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                    pathogenicity === 'Uncertain significance') {
                     this.setState({disabledCheckbox: false});
                 } else {
+                    this.props.setProvisionalEvaluation('provisional-interpretation', false);
                     this.setState({disabledCheckbox: true});
                 }
             } else {
                 if(pathogenicity === 'Likely pathogenic' ||
                    pathogenicity === 'Pathogenic') {
+                    this.props.setProvisionalEvaluation('provisional-interpretation', false);
                     this.setState({disabledCheckbox: true});
                 } else {
                     this.setState({disabledCheckbox: false});
@@ -80,6 +99,19 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
             }
         } else {
             this.setState({disabledCheckbox: false});
+        }
+    },
+
+    // Method to alert users about requied input missing values
+    handleRequiredInput: function(action) {
+        const inputElement = document.querySelector('.provisional-pathogenicity textarea');
+        if (action === 'setAttribute') {
+            if (!inputElement.getAttribute('required')) {
+                inputElement.setAttribute('required', 'required');
+            }
+        }
+        if (action === 'removeAttribute') {
+            inputElement.removeAttribute('required');
         }
     },
 
@@ -94,8 +126,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     // Disable save button if a reason is not provided for the modification
                     if (!this.state.provisionalReason) {
                         this.setState({disabledFormSumbit: true});
+                        this.handleRequiredInput('setAttribute');
                     } else {
                         this.setState({disabledFormSumbit: false});
+                        this.handleRequiredInput('removeAttribute');
                     }
                     // If no disease is associated, we disable provisional checkbox
                     // when modified pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
@@ -108,8 +142,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     // Disable save button if a reason is provided without the modification
                     if (this.state.provisionalReason) {
                         this.setState({disabledFormSumbit: true});
+                        this.handleRequiredInput('setAttribute');
                     } else {
                         this.setState({disabledFormSumbit: false});
+                        this.handleRequiredInput('removeAttribute');
                     }
                     // If no disease is associated, we disable provisional checkbox
                     // when modified pathogenicity is either 'Likely pathogenic' or 'Pathogenic'
@@ -126,8 +162,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     // Disable save button if a modification is not provided for the reason
                     if (!this.state.provisionalPathogenicity) {
                         this.setState({disabledFormSumbit: true});
+                        this.handleRequiredInput('setAttribute');
                     } else {
                         this.setState({disabledFormSumbit: false});
+                        this.handleRequiredInput('removeAttribute');
                     }
                 });
             } else {
@@ -137,8 +175,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     // Disable save button if a modification is provided without the reason
                     if (this.state.provisionalPathogenicity) {
                         this.setState({disabledFormSumbit: true});
+                        this.handleRequiredInput('setAttribute');
                     } else {
                         this.setState({disabledFormSumbit: false});
+                        this.handleRequiredInput('removeAttribute');
                     }
                 });
             }
@@ -283,7 +323,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
 
         return (
             <div className="container evaluation-summary">
-                <h2><span>Evaluations Summary View</span></h2>
+                <h2><span>Evaluation Summary</span></h2>
 
                 {(evaluations && evaluations.length) ?
                     <div className="summary-content-wrapper">
@@ -313,7 +353,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                             </dl>
                                             <dl className="inline-dl clearfix">
                                                 <dt>Mode of Inheritance:</dt>
-                                                <dd>{interpretation.modeInheritance ? interpretation.modeInheritance : 'None'}</dd>
+                                                <dd className="modeInheritance">{interpretation.modeInheritance ? this.renderModeInheritanceLink(interpretation.modeInheritance) : 'None'}</dd>
                                             </dl>
                                         </div>
                                     </div>
@@ -324,6 +364,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                                     value={provisionalPathogenicity ? provisionalPathogenicity : ''}
                                                     labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
                                                     <option value=''>Select an option</option>
+                                                    <option value=''>No modification</option>
                                                     <option value="Benign">Benign</option>
                                                     <option value="Likely benign">Likely Benign</option>
                                                     <option value="Uncertain significance">Uncertain Significance</option>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -58,6 +58,25 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         });
     },
 
+    componentDidUpdate: function(prevProps, prevState) {
+        // Add notes to labels for modified pathogenicity/reason
+        let nodeList = document.querySelectorAll('.evaluation-provision.provisional-pathogenicity label');
+        let labelNodes = Array.from(nodeList);
+        if (labelNodes) {
+            labelNodes.forEach(node => {
+                let note = document.createElement('i');
+                if (node.getAttribute('for') === 'provisional-pathogenicity') {
+                    note.innerHTML = '(optional)';
+                    node.insertAdjacentElement('beforeend', note);
+                }
+                if (node.getAttribute('for') === 'provisional-reason') {
+                    note.innerHTML = '(<strong>required</strong> for modified pathogenicity)';
+                    node.insertAdjacentElement('beforeend', note);
+                }
+            });
+        }
+    },
+
     // Method to set provisional checkbox state given the modified or calculated pathogenicity
     handleProvisionalCheckBox: function(pathogenicity) {
         if (!this.props.interpretation.disease) {
@@ -315,7 +334,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                     </div>
                                     <div className="col-xs-12 col-sm-6 provisional-form-content-wrapper">
                                         <div className="evaluation-provision provisional-pathogenicity">
-                                            <Input type="select" ref="provisional-pathogenicity" label="Modify Pathogenicity (optional):"
+                                            <Input type="select" ref="provisional-pathogenicity" label="Modify Pathogenicity:"
                                                 value={provisionalPathogenicity ? provisionalPathogenicity : ''}
                                                 labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
                                                 <option value=''>Select an option</option>
@@ -325,7 +344,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                                 <option value="Likely pathogenic">Likely Pathogenic</option>
                                                 <option value="Pathogenic">Pathogenic</option>
                                             </Input>
-                                            <Input type="textarea" ref="provisional-reason" label="Explain Reason(s) for change:" rows="5"
+                                            <Input type="textarea" ref="provisional-reason" label="Explain reason(s) for change:" rows="5"
                                                 value={provisionalReason ? provisionalReason : null}
                                                 placeholder="Note: If you selected a pathogenicity different from the Calculated Pathogenicity, you must provide a reason for the change here."
                                                 labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -109,8 +109,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         let evaluations = interpretation ? interpretation.evaluations : null;
         let sortedEvaluations = evaluations ? sortByStrength(evaluations) : null;
         let calculatedAssertion = this.state.calculatedAssertion;
-        let provisionalVariant = interpretation ? interpretation.provisional_variant[0] : null;
-
+        let provisionalVariant = null;
         let disabledCheckbox = false;
         if (interpretation) {
             if (interpretation.disease && interpretation.disease.term) {
@@ -124,6 +123,9 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     default:
                         disabledCheckbox === false;
                 }
+            }
+            if (interpretation.provisional_variant && interpretation.provisional_variant.length) {
+                provisionalVariant = interpretation.provisional_variant[0];
             }
         }
 

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -20,7 +20,8 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
             calculatedAssertion: this.props.calculatedAssertion,
             provisionalPathogenicity: null,
             provisionalReason: null,
-            provisionalInterpretation: false
+            provisionalInterpretation: false,
+            submitBusy: false // spinner for Save button
         };
     },
 
@@ -41,9 +42,14 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         if (ref === 'provisional-reason' && this.refs[ref].getValue()) {
             this.setState({provisionalReason: this.refs[ref].getValue()});
         }
-        if (ref === 'provisional-interpretation' && this.refs[ref].getValue()) {
-            this.setState({provisionalInterpretation: this.refs[ref].getValue()});
+        if (ref === 'provisional-interpretation' && this.refs[ref]) {
+            this.setState({provisionalInterpretation: !this.state.provisionalInterpretation});
         }
+    },
+
+    submitForm: function(e) {
+        e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
+        this.setState({submitBusy: true}); // Save button pressed; disable it and start spinner
     },
 
     render: function() {
@@ -51,6 +57,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         let evaluations = interpretation ? interpretation.evaluations : null;
         let sortedEvaluations = evaluations ? sortByStrength(evaluations) : null;
         let calculatedAssertion = this.state.calculatedAssertion;
+        let provisionalVariant = interpretation ? interpretation.provisional_variant : null;
 
         let disabledCheckbox = false;
         if (interpretation) {
@@ -153,7 +160,8 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                 <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                                     <div className="evaluation-provision provisional-pathogenicity">
                                         <div className="col-xs-12 col-sm-6">
-                                            <Input type="select" ref="provisional-pathogenicity" label="Select Provisional Pathogenicity:" defaultValue="none"
+                                            <Input type="select" ref="provisional-pathogenicity" label="Select Provisional Pathogenicity:"
+                                                value={provisionalVariant ? provisionalVariant.alteredClassification : 'Benign'}
                                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange}>
                                                 <option value="Benign">Benign</option>
                                                 <option value="Likely Benign">Likely Benign</option>
@@ -164,6 +172,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                         </div>
                                         <div className="col-xs-12 col-sm-6">
                                             <Input type="textarea" ref="provisional-reason" label="Explain Reason(s) for change:" rows="5"
+                                                value={provisionalVariant ? provisionalVariant.reason : null}
                                                 placeholder="Note: If your selected pathogenicity is different from the Calculated Pathogenicity, provide a reason to explain why."
                                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange} />
                                         </div>
@@ -172,9 +181,13 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                         <div className="col-xs-12 col-sm-7">
                                             <i className="icon icon-question-circle"></i>
                                             <strong>Mark as Provisional Interpretation</strong>
-                                            <Input type="checkbox" ref="provisional-interpretation" defaultChecked="false" inputDisabled={disabledCheckbox}
+                                            <Input type="checkbox" ref="provisional-interpretation" inputDisabled={disabledCheckbox} checked={this.state.provisionalInterpretation} defaultChecked="false"
                                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange} />
                                         </div>
+                                    </div>
+                                    <div className="provisional-submit">
+                                        <Input type="submit" inputClassName={(provisionalVariant ? "btn-info" : "btn-primary") + " pull-right btn-inline-spacer"}
+                                            id="submit" title={provisionalVariant ? "Update" : "Save"} submitBusy={this.state.submitBusy} />
                                     </div>
                                 </Form>
                             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -483,12 +483,12 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
 function tableHeader() {
     return (
         <tr>
-            <th><span className="label-benign">B</span>/<span className="label-pathogenic">P</span></th>
-            <th>Criteria</th>
-            <th>Criteria Descriptions</th>
-            <th>Modified</th>
-            <th>Evaluation Status</th>
-            <th>Evaluation Descriptions</th>
+            <th className="col-md-1"><span className="label-benign">B</span>/<span className="label-pathogenic">P</span></th>
+            <th className="col-md-1">Criteria</th>
+            <th className="col-md-3">Criteria Descriptions</th>
+            <th className="col-md-1">Modified</th>
+            <th className="col-md-2">Evaluation Status</th>
+            <th className="col-md-4">Evaluation Explanation</th>
         </tr>
     );
 }

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -58,25 +58,6 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         });
     },
 
-    componentDidUpdate: function(prevProps, prevState) {
-        // Add notes to labels for modified pathogenicity/reason
-        let nodeList = document.querySelectorAll('.evaluation-provision.provisional-pathogenicity label');
-        let labelNodes = Array.from(nodeList);
-        if (labelNodes) {
-            labelNodes.forEach(node => {
-                let note = document.createElement('i');
-                if (node.getAttribute('for') === 'provisional-pathogenicity') {
-                    note.innerHTML = '(optional)';
-                    node.insertAdjacentElement('beforeend', note);
-                }
-                if (node.getAttribute('for') === 'provisional-reason') {
-                    note.innerHTML = '(<strong>required</strong> for modified pathogenicity)';
-                    node.insertAdjacentElement('beforeend', note);
-                }
-            });
-        }
-    },
-
     // Method to set provisional checkbox state given the modified or calculated pathogenicity
     handleProvisionalCheckBox: function(pathogenicity) {
         if (!this.props.interpretation.disease) {
@@ -334,7 +315,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                     </div>
                                     <div className="col-xs-12 col-sm-6 provisional-form-content-wrapper">
                                         <div className="evaluation-provision provisional-pathogenicity">
-                                            <Input type="select" ref="provisional-pathogenicity" label="Modify Pathogenicity:"
+                                            <Input type="select" ref="provisional-pathogenicity" label={<span>Modify Pathogenicity:<i>(optional)</i></span>}
                                                 value={provisionalPathogenicity ? provisionalPathogenicity : ''}
                                                 labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
                                                 <option value=''>Select an option</option>
@@ -344,7 +325,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                                 <option value="Likely pathogenic">Likely Pathogenic</option>
                                                 <option value="Pathogenic">Pathogenic</option>
                                             </Input>
-                                            <Input type="textarea" ref="provisional-reason" label="Explain reason(s) for change:" rows="5"
+                                            <Input type="textarea" ref="provisional-reason" label={<span>Explain reason(s) for change:<i>(<strong>required</strong> for modified pathogenicity)</i></span>} rows="5"
                                                 value={provisionalReason ? provisionalReason : null}
                                                 placeholder="Note: If you selected a pathogenicity different from the Calculated Pathogenicity, you must provide a reason for the change here."
                                                 labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -10,12 +10,14 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
     mixins: [FormMixin],
 
     propTypes: {
-        interpretation: React.PropTypes.object
+        interpretation: React.PropTypes.object,
+        calculatedAssertion: React.PropTypes.string
     },
 
     getInitialState: function() {
         return {
             interpretation: this.props.interpretation,
+            calculatedAssertion: this.props.calculatedAssertion,
             provisionalPathogenicity: null,
             provisionalReason: null,
             provisionalInterpretation: false
@@ -25,6 +27,9 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
     componentWillReceiveProps: function(nextProps) {
         if (nextProps.interpretation && this.props.interpretation) {
             this.setState({interpretation: nextProps.interpretation});
+        }
+        if (nextProps.calculatedAssertion && this.props.calculatedAssertion) {
+            this.setState({calculatedAssertion: nextProps.calculatedAssertion});
         }
     },
 
@@ -45,6 +50,23 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         let interpretation = this.state.interpretation;
         let evaluations = interpretation ? interpretation.evaluations : null;
         let sortedEvaluations = evaluations ? sortByStrength(evaluations) : null;
+        let calculatedAssertion = this.state.calculatedAssertion;
+
+        let disabledCheckbox = false;
+        if (interpretation) {
+            if (interpretation.disease && interpretation.disease.term) {
+                switch (calculatedAssertion) {
+                    case 'Likely Pathogenic':
+                        disabledCheckbox === true;
+                        break;
+                    case 'Pathogenic':
+                        disabledCheckbox === true;
+                        break;
+                    default:
+                        disabledCheckbox === false;
+                }
+            }
+        }
 
         return (
             <div className="container evaluation-summary">
@@ -122,11 +144,11 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                             <div className="panel-body">
                                 <dl className="inline-dl clearfix">
                                     <dt>Calculated Pathogenicity:</dt>
-                                    <dd>Likely Benign</dd>
+                                    <dd>{calculatedAssertion ? calculatedAssertion : 'None'}</dd>
                                 </dl>
                                 <dl className="inline-dl clearfix">
                                     <dt>Disease:</dt>
-                                    <dd>{interpretation.interpretation_disease ? interpretation.interpretation_disease : 'None'}</dd>
+                                    <dd>{interpretation.disease ? interpretation.disease.term : 'None'}</dd>
                                 </dl>
                                 <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                                     <div className="evaluation-provision provisional-pathogenicity">
@@ -150,7 +172,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                         <div className="col-xs-12 col-sm-7">
                                             <i className="icon icon-question-circle"></i>
                                             <strong>Mark as Provisional Interpretation</strong>
-                                            <Input type="checkbox" ref="provisional-interpretation" defaultChecked="false"
+                                            <Input type="checkbox" ref="provisional-interpretation" defaultChecked="false" inputDisabled={disabledCheckbox}
                                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange} />
                                         </div>
                                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -37,6 +37,19 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
     componentDidMount: function() {
         if (this.props.interpretation && this.props.calculatedAssertion) {
             this.handleProvisionalCheckBox(this.state.provisionalPathogenicity);
+            // Reset form values to last saved values
+            let interpretation = this.props.interpretation;
+            let markAsProvisional, alteredClassification, reason;
+            if (interpretation) {
+                markAsProvisional = interpretation.markAsProvisional;
+                if (interpretation.provisional_variant) {
+                    alteredClassification = interpretation.provisional_variant[0].alteredClassification;
+                    reason = interpretation.provisional_variant[0].reason;
+                }
+            }
+            this.props.setProvisionalEvaluation('provisional-pathogenicity', alteredClassification ? alteredClassification : null);
+            this.props.setProvisionalEvaluation('provisional-reason', reason ? reason : null);
+            this.props.setProvisionalEvaluation('provisional-interpretation', markAsProvisional);
         }
     },
 
@@ -47,14 +60,20 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         if (nextProps.calculatedAssertion) {
             this.setState({calculatedAssertion: nextProps.calculatedAssertion});
         }
-        if (nextProps.provisionalPathogenicity) {
-            this.setState({provisionalPathogenicity: nextProps.provisionalPathogenicity});
-        }
-        if (nextProps.provisionalReason) {
-            this.setState({provisionalReason: nextProps.provisionalReason});
-        }
+        // Because we accept null values for modified pathogenicity and reason,
+        // the "if (nextProps.provisionalPathogenicity')" check doesn't apply
         this.setState({
+            provisionalPathogenicity: nextProps.provisionalPathogenicity,
+            provisionalReason: nextProps.provisionalReason,
             provisionalInterpretation: nextProps.provisionalInterpretation
+        }, () => {
+            if (!this.state.provisionalPathogenicity) {
+                this.refs['provisional-pathogenicity'].resetSelectedOption();
+                this.refs['provisional-reason'].resetValue();
+            } else {
+                this.refs['provisional-pathogenicity'].setValue(this.state.provisionalPathogenicity);
+                this.refs['provisional-reason'].setValue(this.state.provisionalReason);
+            }
         });
     },
 
@@ -141,8 +160,9 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     this.props.setProvisionalEvaluation('provisional-pathogenicity', this.state.provisionalPathogenicity);
                     // Disable save button if a reason is provided without the modification
                     if (this.state.provisionalReason) {
-                        this.setState({disabledFormSumbit: true});
-                        this.handleRequiredInput('setAttribute');
+                        this.props.setProvisionalEvaluation('provisional-reason', null);
+                        this.setState({disabledFormSumbit: false});
+                        this.handleRequiredInput('removeAttribute');
                     } else {
                         this.setState({disabledFormSumbit: false});
                         this.handleRequiredInput('removeAttribute');
@@ -343,7 +363,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                             </dl>
                                             <dl className="inline-dl clearfix">
                                                 <dt>Provisional Interpretation Status:</dt>
-                                                <dd className="provisional-interpretation-status">{provisionalStatus ? 'Provisional' : 'In progress'}</dd>
+                                                <dd className="provisional-interpretation-status">{provisionalStatus ? 'Provisional' : 'In Progress'}</dd>
                                             </dl>
                                         </div>
                                         <div className="col-xs-12 col-sm-6">
@@ -381,7 +401,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                             <div className="evaluation-provision provisional-interpretation">
                                                 <div>
                                                     <i className="icon icon-question-circle"></i>
-                                                    <span>Mark as Provisional Interpretation (optional):</span>
+                                                    <span>Change status to "Provisional Interpretation" <i>(optional)</i>:</span>
                                                     <Input type="checkbox" ref="provisional-interpretation" inputDisabled={disabledCheckbox} checked={provisionalInterpretation} defaultChecked="false"
                                                         labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />
                                                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -1,146 +1,177 @@
 'use strict';
 import React, {PropTypes} from 'react';
 const evidenceCodes = require('./mapping/evidence_code.json');
+const form = require('../../../libs/bootstrap/form');
+const Input = form.Input;
+const Form = form.Form;
+const FormMixin = form.FormMixin;
 
-const EvaluationSummary = ({interpretation}) => {
-    const evaluations = interpretation.evaluations;
+var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
+    mixins: [FormMixin],
 
-    const arrayCriteriaMet = evaluations.filter(filterByStatus);
+    propTypes: {
+        interpretation: React.PropTypes.object
+    },
 
-    return (
-        <div className="container evaluation-summary">
-            <h2><span>Evaluations Summary View</span></h2>
+    getInitialState: function() {
+        return {
+            interpretation: this.props.interpretation,
+            provisionalPathogenicity: null,
+            provisionalReason: null,
+            provisionalInterpretation: false
+        };
+    },
 
-            {(evaluations && evaluations.length) ?
-                <div className="summary-content-wrapper">
-                    <div className="panel panel-info datasource-evaluation-summary">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">Criteria meeting an evaluation strength</h3>
+    componentWillReceiveProps: function(nextProps) {
+        if (nextProps.interpretation && this.props.interpretation) {
+            this.setState({interpretation: nextProps.interpretation});
+        }
+    },
+
+    // Handle value changes in forms
+    handleChange: function(ref, e) {
+        if (ref === 'provisional-pathogenicity' && this.refs[ref].getValue()) {
+            this.setState({provisionalPathogenicity: this.refs[ref].getValue()});
+        }
+        if (ref === 'provisional-reason' && this.refs[ref].getValue()) {
+            this.setState({provisionalReason: this.refs[ref].getValue()});
+        }
+        if (ref === 'provisional-interpretation' && this.refs[ref].getValue()) {
+            this.setState({provisionalInterpretation: this.refs[ref].getValue()});
+        }
+    },
+
+    render: function() {
+        let interpretation = this.state.interpretation;
+        let evaluations = interpretation ? interpretation.evaluations : null;
+        let sortedEvaluations = evaluations ? sortByStrength(evaluations) : null;
+
+        return (
+            <div className="container evaluation-summary">
+                <h2><span>Evaluations Summary View</span></h2>
+
+                {(evaluations && evaluations.length) ?
+                    <div className="summary-content-wrapper">
+                        <div className="panel panel-info datasource-evaluation-summary">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Criteria meeting an evaluation strength</h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    {tableHeader()}
+                                </thead>
+                                {sortedEvaluations.met ?
+                                    <tbody>
+                                        {sortedEvaluations.met.map(function(item, i) {
+                                            return (renderMetCriteriaRow(item, i));
+                                        })}
+                                    </tbody>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No criteria meeting an evaluation strength.</span>
+                                    </div>
+                                }
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                {tableHeader()}
-                            </thead>
-                            {arrayCriteriaMet ?
-                                <tbody>
-                                    {arrayCriteriaMet.map(function(item, i) {
-                                        return (renderMetCriteriaRow(item, i));
-                                    })}
-                                </tbody>
-                                :
-                                <div className="panel-body">
-                                    <span>No criteria meeting an evaluation strength.</span>
-                                </div>
-                            }
-                        </table>
-                    </div>
 
-                    <div className="panel panel-info datasource-evaluation-summary">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">Criteria evaluated as "Not met"</h3>
+                        <div className="panel panel-info datasource-evaluation-summary">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Criteria evaluated as "Not met"</h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    {tableHeader()}
+                                </thead>
+                                {sortedEvaluations.not_met ?
+                                    <tbody>
+                                        {sortedEvaluations.not_met.map(function(item, i) {
+                                            return (renderNotMetCriteriaRow(item, i));
+                                        })}
+                                    </tbody>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No criteria evaluated as "Not met".</span>
+                                    </div>
+                                }
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                {tableHeader()}
-                            </thead>
-                            {(evaluations && evaluations.length) ?
-                                <tbody>
-                                    {evaluations.map(function(item, i) {
-                                        if (item.criteriaStatus && item.criteriaStatus === 'not-met') {
-                                            return (
-                                                <tr key={i} className="row-criteria-not-met">
-                                                    <td className="criteria-class col-md-1">
-                                                        {getCriteriaType(item) === 'benign' ?
-                                                            <span className="benign"><i className="icon icon-check-circle"></i></span>
-                                                            :
-                                                            <span className="pathogenic"><i className="icon icon-check-circle"></i></span>
-                                                        }
-                                                    </td>
-                                                    <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
-                                                    <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
-                                                    <td className="criteria-modified col-md-1">N/A</td>
-                                                    <td className="evaluation-status col-md-2">Not Met</td>
-                                                    <td className="evaluation-description col-md-4">{item.explanation}</td>
-                                                </tr>
-                                            );
-                                        }
-                                    })}
-                                </tbody>
-                            :
-                                <div className="panel-body">
-                                    <span>No criteria evaluated as "Not met".</span>
-                                </div>
-                            }
-                        </table>
-                    </div>
 
-                    <div className="panel panel-info datasource-evaluation-summary">
-                        <div className="panel-heading">
-                            <h3 className="panel-title">Criteria "Not yet evaluated"</h3>
+                        <div className="panel panel-info datasource-evaluation-summary">
+                            <div className="panel-heading">
+                                <h3 className="panel-title">Criteria "Not yet evaluated"</h3>
+                            </div>
+                            <table className="table">
+                                <thead>
+                                    {tableHeader()}
+                                </thead>
+                                {sortedEvaluations.not_evaluated ?
+                                    <tbody>
+                                        {sortedEvaluations.not_evaluated.map(function(item, i) {
+                                            return (renderNotEvalCriteriaRow(item, i));
+                                        })}
+                                    </tbody>
+                                    :
+                                    <div className="panel-body">
+                                        <span>No criteria yet to be evaluated.</span>
+                                    </div>
+                                }
+                            </table>
                         </div>
-                        <table className="table">
-                            <thead>
-                                {tableHeader()}
-                            </thead>
-                            {(evaluations && evaluations.length) ?
-                                <tbody>
-                                    {evaluations.map(function(item, i) {
-                                        if (item.criteriaStatus && item.criteriaStatus === 'not-evaluated') {
-                                            return (
-                                                <tr key={i} className="row-criteria-not-evaluated">
-                                                    <td className="criteria-class col-md-1">
-                                                        {getCriteriaType(item) === 'benign' ?
-                                                            <span className="benign"><i className="icon icon-check-circle"></i></span>
-                                                            :
-                                                            <span className="pathogenic"><i className="icon icon-check-circle"></i></span>
-                                                        }
-                                                    </td>
-                                                    <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
-                                                    <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
-                                                    <td className="criteria-modified col-md-1">N/A</td>
-                                                    <td className="evaluation-status col-md-2">Not Evaluated</td>
-                                                    <td className="evaluation-description col-md-4">{item.explanation}</td>
-                                                </tr>
-                                            );
-                                        }
-                                    })}
-                                </tbody>
-                            :
-                                <div className="panel-body">
-                                    <span>No evaluation found.</span>
-                                </div>
-                            }
-                        </table>
+
+                        <div className="panel panel-info">
+                            <div className="panel-body">
+                                <dl className="inline-dl clearfix">
+                                    <dt>Calculated Pathogenicity:</dt>
+                                    <dd>Likely Benign</dd>
+                                </dl>
+                                <dl className="inline-dl clearfix">
+                                    <dt>Disease:</dt>
+                                    <dd>{interpretation.interpretation_disease ? interpretation.interpretation_disease : 'None'}</dd>
+                                </dl>
+                                <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
+                                    <div className="evaluation-provision provisional-pathogenicity">
+                                        <div className="col-xs-12 col-sm-6">
+                                            <Input type="select" ref="provisional-pathogenicity" label="Select Provisional Pathogenicity:" defaultValue="none"
+                                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange}>
+                                                <option value="Benign">Benign</option>
+                                                <option value="Likely Benign">Likely Benign</option>
+                                                <option value="Uncertain Significance">Uncertain Significance</option>
+                                                <option value="Likely Pathogenic">Likely Pathogenic</option>
+                                                <option value="Pathogenic">Pathogenic</option>
+                                            </Input>
+                                        </div>
+                                        <div className="col-xs-12 col-sm-6">
+                                            <Input type="textarea" ref="provisional-reason" label="Explain Reason(s) for change:" rows="5"
+                                                placeholder="Note: If your selected pathogenicity is different from the Calculated Pathogenicity, provide a reason to explain why."
+                                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange} />
+                                        </div>
+                                    </div>
+                                    <div className="evaluation-provision provisional-interpretation">
+                                        <div className="col-xs-12 col-sm-7">
+                                            <i className="icon icon-question-circle"></i>
+                                            <strong>Mark as Provisional Interpretation</strong>
+                                            <Input type="checkbox" ref="provisional-interpretation" defaultChecked="false"
+                                                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" handleChange={this.handleChange} />
+                                        </div>
+                                    </div>
+                                </Form>
+                            </div>
+                        </div>
+
                     </div>
-                </div>
-            :
-                <div className="summary-content-wrapper"><p>No evaluations found in this interpretation.</p></div>
-            }
-        </div>
-    );
-};
-
-EvaluationSummary.propTypes = {
-    interpretation: PropTypes.object.isRequired
-};
-
-// Method to update interpretation object with provision checkbox value
-function handleClick() {
-    // handle checkbox click event
-}
-
-// Method to filter 'evaluations' array by criteria status
-function filterByStatus(obj) {
-    if (obj.criteriaStatus && obj.criteriaStatus === 'met') {
-        return true;
+                :
+                    <div className="summary-content-wrapper"><p>No evaluations found in this interpretation.</p></div>
+                }
+            </div>
+        );
     }
-}
+});
 
 // Method to render static table header
 function tableHeader() {
     return (
         <tr>
-            <th>B/P</th>
+            <th><span className="label-benign">B</span>/<span className="label-pathogenic">P</span></th>
             <th>Criteria</th>
             <th>Criteria Descriptions</th>
             <th>Modified</th>
@@ -152,35 +183,54 @@ function tableHeader() {
 
 // Method to render "met" criteria table rows
 function renderMetCriteriaRow(item, key) {
-    const strengthLevels = ['very-strong', 'strong', 'moderate', 'supporting'];
-    
-    //strengthLevels.forEach(level => {
-        //if (getCriteriaStrength(item) === level) {
-            //if (item.criteriaStatus && item.criteriaStatus === 'met') {
-            //console.log(item.criteria + " is === " + getCriteriaStrength(item) + ' vs ' + level);
-            return (
-                <tr key={key} className="row-criteria-met" data-evaltype={getCriteriaType(item)}>
-                    <td className="criteria-class col-md-1">
-                        {getCriteriaType(item) === 'benign' ?
-                            <span className="benign"><i className="icon icon-check-circle"></i></span>
-                            :
-                            <span className="pathogenic"><i className="icon icon-check-circle"></i></span>
-                        }
-                    </td>
-                    <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
-                    <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
-                    <td className="criteria-modified col-md-1" data-modlevel={getModifiedLevel(item)}>
-                        {item.criteriaModifier ? 'Yes' : 'No'}
-                    </td>
-                    <td className="evaluation-status col-md-2">
-                        {item.criteriaModifier ? item.criteria + '_' + item.criteriaModifier : getCriteriaStrength(item)}
-                    </td>
-                    <td className="evaluation-description col-md-4">{item.explanation}</td>
-                </tr>
-            );
-            //}
-        //}
-    //});
+    return (
+        <tr key={key} className="row-criteria-met" data-evaltype={getCriteriaType(item)}>
+            <td className="criteria-class col-md-1">
+                <span className={getCriteriaType(item) === 'benign' ? 'benign' : 'pathogenic'}><i className="icon icon-check-circle"></i></span>
+            </td>
+            <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
+            <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
+            <td className="criteria-modified col-md-1" data-modlevel={getModifiedLevel(item)}>
+                {item.criteriaModifier ? 'Yes' : 'No'}
+            </td>
+            <td className="evaluation-status col-md-2">
+                {item.criteriaModifier ? item.criteria + '_' + item.criteriaModifier : getCriteriaStrength(item)}
+            </td>
+            <td className="evaluation-description col-md-4">{item.explanation}</td>
+        </tr>
+    );
+}
+
+// Method to render "not-met" criteria table rows
+function renderNotMetCriteriaRow(item, key) {
+    return (
+        <tr key={key} className="row-criteria-not-met">
+            <td className="criteria-class col-md-1">
+                <span className={getCriteriaType(item) === 'benign' ? 'benign' : 'pathogenic'}><i className="icon icon-times-circle"></i></span>
+            </td>
+            <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
+            <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
+            <td className="criteria-modified col-md-1">N/A</td>
+            <td className="evaluation-status col-md-2">Not Met</td>
+            <td className="evaluation-description col-md-4">{item.explanation}</td>
+        </tr>
+    );
+}
+
+// Method to render "not-evaluated" criteria table rows
+function renderNotEvalCriteriaRow(item, key) {
+    return (
+        <tr key={key} className="row-criteria-not-evaluated">
+            <td className="criteria-class col-md-1">
+                <span className={getCriteriaType(item) === 'benign' ? 'benign' : 'pathogenic'}><i className="icon icon-circle-o"></i></span>
+            </td>
+            <td className={'criteria-code col-md-1 ' + getCriteriaClass(item)}>{item.criteria}</td>
+            <td className="criteria-description col-md-3">{getCriteriaDescription(item)}</td>
+            <td className="criteria-modified col-md-1">N/A</td>
+            <td className="evaluation-status col-md-2">Not Evaluated</td>
+            <td className="evaluation-description col-md-4">{item.explanation}</td>
+        </tr>
+    );
 }
 
 // Method to get critetia type: benign or pathogenic
@@ -244,6 +294,8 @@ function getCriteriaStrength(entry) {
         if (key === entry.criteria) {
             switch (evidenceCodes[key].class) {
                 case 'stand-alone':
+                    strength = 'stand-alone';
+                    break;
                 case 'pathogenic-very-strong':
                     strength = 'very-strong';
                     break;
@@ -338,4 +390,159 @@ function getModifiedLevel(entry) {
     return modifiedLevel;
 }
 
-export default EvaluationSummary;
+// Function to sort evaluations by criteria strength level
+// Sort Order: very strong or stand alone >> strong >> moderate >> supporting
+// Input: array, interpretation.evaluations
+// output: object as
+//      {
+//          met: array of sorted met evaluations,
+//          not_met: array of sorted not-met evaluations,
+//          not_evaluated: array of sorted not-evaluated evaluations
+//      }
+function sortByStrength(evaluations) {
+    let evaluationMet = [];
+    let evaluationNotMet = [];
+    let evaluationNotEvaluated = [];
+
+    for (let evaluation of evaluations) {
+        if (evaluation.criteriaStatus === 'met') {
+            evaluationMet.push(evaluation);
+        } else if (evaluation.criteriaStatus === 'not-met') {
+            evaluationNotMet.push(evaluation);
+        } else {
+            evaluationNotEvaluated.push(evaluation);
+        }
+    }
+
+    let sortedMetList = [];
+    let sortedNotMetList = [];
+    let sortedNotEvaluatedList = [];
+
+    // sort Met
+    if (evaluationMet.length) {
+        // setup count strength values
+        const MODIFIER_VS = 'very-strong';
+        const MODIFIER_SA = 'stand-alone';
+        const MODIFIER_S = 'strong';
+        const MODIFIER_M = 'moderate';
+        const MODIFIER_P = 'supporting';
+
+        // temp storage
+        let vs_sa_level = [];
+        let strong_level = [];
+        let moderate_level = [];
+        let supporting_level = [];
+
+        for (let evaluation of evaluationMet) {
+            let modified = evaluation.criteriaModifier ? evaluation.criteriaModifier : null;
+            if (modified) {
+                if (modified === MODIFIER_VS || modified === MODIFIER_SA) {
+                    vs_sa_level.push(evaluation);
+                } else if (modified === MODIFIER_S) {
+                    strong_level.push(evaluation);
+                } else if (modified === MODIFIER_M) {
+                    moderate_level.push(evaluation);
+                } else if (modified === MODIFIER_P) {
+                    supporting_level.push(evaluation);
+                }
+            } else {
+                if (evaluation.criteria === 'PVS1' || evaluation.criteria === 'BA1') {
+                    vs_sa_level.push(evaluation);
+                } else if (evaluation.criteria[1] === 'S') {
+                    strong_level.push(evaluation);
+                } else if (evaluation.criteria[1] === 'M') {
+                    moderate_level.push(evaluation);
+                } else if (evaluation.criteria[1] === 'P') {
+                    supporting_level.push(evaluation);
+                }
+            }
+        }
+
+        if (vs_sa_level.length) {
+            sortedMetList = sortedMetList .concat(vs_sa_level);
+        }
+        if (strong_level.length) {
+            sortedMetList = sortedMetList.concat(strong_level);
+        }
+        if (moderate_level.length) {
+            sortedMetList = sortedMetList.concat(moderate_level);
+        }
+        if (supporting_level.length) {
+            sortedMetList = sortedMetList.concat(supporting_level);
+        }
+    }
+
+    // sort Not-Met
+    if (evaluationNotMet) {
+        // temp storage
+        let vs_sa_level = [];
+        let strong_level = [];
+        let moderate_level = [];
+        let supporting_level = [];
+
+        for (let evaluation of evaluationNotMet) {
+            if (evaluation.criteria === 'PVS1' || evaluation.criteria === 'BA1') {
+                vs_sa_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'S') {
+                strong_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'M') {
+                moderate_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'P') {
+                supporting_level.push(evaluation);
+            }
+        }
+
+        if (vs_sa_level.length) {
+            sortedNotMetList = sortedNotMetList .concat(vs_sa_level);
+        }
+        if (strong_level.length) {
+            sortedNotMetList = sortedNotMetList.concat(strong_level);
+        }
+        if (moderate_level.length) {
+            sortedNotMetList = sortedNotMetList.concat(moderate_level);
+        }
+        if (supporting_level.length) {
+            sortedNotMetList = sortedNotMetList.concat(supporting_level);
+        }
+    }
+
+    //sort Not-Evaluated
+    if (evaluationNotEvaluated) {
+        // temp storage
+        let vs_sa_level = [];
+        let strong_level = [];
+        let moderate_level = [];
+        let supporting_level = [];
+
+        for (let evaluation of evaluationNotEvaluated) {
+            if (evaluation.criteria === 'PVS1' || evaluation.criteria === 'BA1') {
+                vs_sa_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'S') {
+                strong_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'M') {
+                moderate_level.push(evaluation);
+            } else if (evaluation.criteria[1] === 'P') {
+                supporting_level.push(evaluation);
+            }
+        }
+
+        if (vs_sa_level.length) {
+            sortedNotEvaluatedList = sortedNotEvaluatedList .concat(vs_sa_level);
+        }
+        if (strong_level.length) {
+            sortedNotEvaluatedList = sortedNotEvaluatedList.concat(strong_level);
+        }
+        if (moderate_level.length) {
+            sortedNotEvaluatedList = sortedNotEvaluatedList.concat(moderate_level);
+        }
+        if (supporting_level.length) {
+            sortedNotEvaluatedList = sortedNotEvaluatedList.concat(supporting_level);
+        }
+    }
+
+    return ({
+        met: sortedMetList,
+        not_met: sortedNotMetList,
+        not_evaluated: sortedNotEvaluatedList
+    });
+}

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -363,8 +363,8 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                                 <Input type="select" ref="provisional-pathogenicity" label={<span>Modify Pathogenicity:<i>(optional)</i></span>}
                                                     value={provisionalPathogenicity ? provisionalPathogenicity : ''}
                                                     labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange}>
-                                                    <option value=''>Select an option</option>
-                                                    <option value=''>No modification</option>
+                                                    <option value=''>No Selection</option>
+                                                    <option disabled="disabled"></option>
                                                     <option value="Benign">Benign</option>
                                                     <option value="Likely benign">Likely Benign</option>
                                                     <option value="Uncertain significance">Uncertain Significance</option>

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -20,7 +20,8 @@ var Title = module.exports.Title = React.createClass({
         interpretationUuid: React.PropTypes.string,
         interpretation: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
-        summaryVisible: React.PropTypes.bool
+        summaryVisible: React.PropTypes.bool,
+        getSelectedTab: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -78,6 +79,10 @@ var Title = module.exports.Title = React.createClass({
             this.props.setSummaryVisibility(false);
             if (summaryKey) {
                 window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'summary', null));
+                let tabKey = queryKeyValue('tab', window.location.href);
+                if (tabKey) {
+                    this.props.getSelectedTab(tabKey);
+                }
             }
         }
     },

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -21,13 +21,16 @@ var Title = module.exports.Title = React.createClass({
         interpretation: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
         summaryVisible: React.PropTypes.bool,
-        getSelectedTab: React.PropTypes.func
+        getSelectedTab: React.PropTypes.func,
+        persistProvisionalCheckBox: React.PropTypes.func,
+        disabledProvisionalCheckbox: React.PropTypes.bool
     },
 
     getInitialState: function() {
         return {
             interpretation: null, // parent interpretation object
-            summaryVisible: this.props.summaryVisible
+            summaryVisible: this.props.summaryVisible,
+            disabledProvisionalCheckbox: this.props.disabledProvisionalCheckbox
         };
     },
 
@@ -37,7 +40,10 @@ var Title = module.exports.Title = React.createClass({
         if (typeof nextProps.interpretation !== undefined && !_.isEqual(nextProps.interpretation, this.props.interpretation)) {
             this.setState({interpretation: nextProps.interpretation});
         }
-        this.setState({summaryVisible: nextProps.summaryVisible});
+        this.setState({
+            summaryVisible: nextProps.summaryVisible,
+            disabledProvisionalCheckbox: nextProps.disabledProvisionalCheckbox
+        });
     },
 
     renderSubtitle: function(interpretation, variant) {
@@ -71,12 +77,14 @@ var Title = module.exports.Title = React.createClass({
         let summaryKey = queryKeyValue('summary', window.location.href);
         if (!summaryVisible) {
             this.props.setSummaryVisibility(true);
+            this.props.persistProvisionalCheckBox(this.state.disabledProvisionalCheckbox);
             if (!summaryKey) {
                 window.history.replaceState(window.state, '', addQueryKey(window.location.href, 'summary', 'true'));
             }
         }
         if (summaryVisible) {
             this.props.setSummaryVisibility(false);
+            this.props.persistProvisionalCheckBox(this.state.disabledProvisionalCheckbox);
             if (summaryKey) {
                 window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'summary', null));
                 let tabKey = queryKeyValue('tab', window.location.href);

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -21,16 +21,13 @@ var Title = module.exports.Title = React.createClass({
         interpretation: React.PropTypes.object,
         setSummaryVisibility: React.PropTypes.func,
         summaryVisible: React.PropTypes.bool,
-        getSelectedTab: React.PropTypes.func,
-        persistProvisionalCheckBox: React.PropTypes.func,
-        disabledProvisionalCheckbox: React.PropTypes.bool
+        getSelectedTab: React.PropTypes.func
     },
 
     getInitialState: function() {
         return {
             interpretation: null, // parent interpretation object
-            summaryVisible: this.props.summaryVisible,
-            disabledProvisionalCheckbox: this.props.disabledProvisionalCheckbox
+            summaryVisible: this.props.summaryVisible
         };
     },
 
@@ -41,8 +38,7 @@ var Title = module.exports.Title = React.createClass({
             this.setState({interpretation: nextProps.interpretation});
         }
         this.setState({
-            summaryVisible: nextProps.summaryVisible,
-            disabledProvisionalCheckbox: nextProps.disabledProvisionalCheckbox
+            summaryVisible: nextProps.summaryVisible
         });
     },
 
@@ -77,14 +73,12 @@ var Title = module.exports.Title = React.createClass({
         let summaryKey = queryKeyValue('summary', window.location.href);
         if (!summaryVisible) {
             this.props.setSummaryVisibility(true);
-            this.props.persistProvisionalCheckBox(this.state.disabledProvisionalCheckbox);
             if (!summaryKey) {
                 window.history.replaceState(window.state, '', addQueryKey(window.location.href, 'summary', 'true'));
             }
         }
         if (summaryVisible) {
             this.props.setSummaryVisibility(false);
-            this.props.persistProvisionalCheckBox(this.state.disabledProvisionalCheckbox);
             if (summaryKey) {
                 window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'summary', null));
                 let tabKey = queryKeyValue('tab', window.location.href);

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -108,7 +108,7 @@ var Title = module.exports.Title = React.createClass({
                     <div className="btn-vertical-space">
                         <div className="interpretation-record clearfix">
                             <div className="pull-right">
-                                <Input type="button-button" inputClassName="btn btn-primary pull-right"
+                                <Input type="button-button" inputClassName="btn btn-primary pull-right view-summary"
                                     title={summaryButtonTitle} clickHandler={this.handleSummaryButtonEvent} />
                             </div>
                         </div>

--- a/src/clincoded/static/scss/clincoded/_variables.scss
+++ b/src/clincoded/static/scss/clincoded/_variables.scss
@@ -34,3 +34,4 @@ $pathogenic-supporting: #728b42;
 $pathogenic-moderate: #d36735;
 $pathogenic-strong: #d33535;
 $pathogenic-very-strong: #d33535;
+$stand-alone: #62387e;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2023,9 +2023,14 @@ dl.inline-dl {
         }
     }
 
+    .provisional-static-content-wrapper {
+        margin-bottom: 10px;
+        padding: 0;
+    }
+
     .provisional-form-content-wrapper {
         border: solid 1px #dfdfdf;
-        padding: 15px 20px;
+        padding: 15px 0;
         -webkit-border-radius: 2px;
         -moz-border-radius: 2px;
         border-radius: 2px;
@@ -2039,13 +2044,8 @@ dl.inline-dl {
             padding-left: 0;
         }
 
-        .col-sm-6,
-        .col-sm-7 {
+        .col-sm-6 {
             padding-left: 0;
-        }
-
-        select {
-            /*width: auto;*/
         }
 
         &.provisional-pathogenicity {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1576,6 +1576,20 @@
             color: #fff;
         }
     }
+
+    .stand-alone {
+        color: $stand-alone;
+
+        &:active {
+            color: $stand-alone;
+        }
+
+        &[data-status='met'] {
+            background-color: $stand-alone;
+            border-color: darken(#ccc, 15%);
+            color: #fff;
+        }
+    }
 }
 
 /**
@@ -1603,6 +1617,10 @@
 
 .pathogenic-very-strong {
     color: $pathogenic-very-strong;
+}
+
+.stand-alone {
+    color: $stand-alone;
 }
 
 /**

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1897,6 +1897,14 @@ dl.inline-dl {
     text-overflow: clip;
 }
 
+/* View Summary button */
+.view-summary {
+    &:focus,
+    &:active {
+        outline: none;
+    }
+}
+
 /* Evaluation summary table UIs */
 .evaluation-summary {
     h2 {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2053,6 +2053,15 @@ dl.inline-dl {
             .form-group {
                 margin-bottom: 0;
             }
+
+            label {
+                padding-top: 0;
+            }
+
+            label i {
+                display: block;
+                font-weight: normal;
+            }
         }
 
         &.provisional-interpretation {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1149,9 +1149,13 @@
                 }
             }
 
-            .basic-info .datasource-clinvar-interpretaions  {
+            .basic-info .datasource-clinvar-interpretaions {
                 .clinvar-interpretation-summary {
-                    border-bottom: solid 1px #ddd;
+                    border: solid 1px #ddd;
+                    margin: 15px 15px 12px 15px;
+                    -webkit-border-radius: 2px;
+                    -moz-border-radius: 2px;
+                    border-radius: 2px;
 
                     .reviewStatus:first-letter {
                         text-transform: capitalize;
@@ -1799,11 +1803,11 @@ dl.inline-dl {
             }
 
             &.benign-result:before {
-                color: #57a3de;
+                color: $stand-alone;
             }
 
             &.path-result:before {
-                color: #f4978a;
+                color: $pathogenic-very-strong;
             }
 
             &.calculate-result:before {
@@ -1906,6 +1910,8 @@ dl.inline-dl {
 .view-summary {
     &:focus,
     &:active {
+        border: 1px solid #1b75bc;
+        background-color: #1b75bc;
         outline: none;
     }
 }
@@ -1918,17 +1924,23 @@ dl.inline-dl {
 
     .table tbody td {
         vertical-align: inherit;
+
+        &.criteria-code,
+        &.criteria-modified,
+        &.evaluation-status {
+            line-height: 0;
+        }
     }
 
     .criteria-class {
         font-size: 20px;
 
         .benign {
-            color: #57a3de;
+            color: $stand-alone;
         }
 
         .pathogenic {
-            color: #f4978a;
+            color: $pathogenic-very-strong;
         }
     }
 
@@ -1974,6 +1986,7 @@ dl.inline-dl {
             float: left;
             position: absolute;
             left: 35px;
+            font-size: 135%;
         }
     }
 
@@ -2003,13 +2016,13 @@ dl.inline-dl {
 
     [data-evaltype='benign'] {
         .criteria-modified:after {
-            color: #57a3de;
+            color: $stand-alone;
         }
     }
 
     [data-evaltype='pathogenic'] {
         .criteria-modified:after {
-            color: #f4978a;
+            color: $pathogenic-very-strong;
         }
     }
 
@@ -2019,6 +2032,10 @@ dl.inline-dl {
 
             .provisional-interpretation-status:first-letter {
                 text-transform: capitalize;
+            }
+
+            .modeInheritance {
+                font-style: italic;
             }
         }
     }
@@ -2060,6 +2077,11 @@ dl.inline-dl {
             label i {
                 display: block;
                 font-weight: normal;
+            }
+
+            textarea:required {
+                background-color: #fde8e8;
+                border-color: #ffb2b2;
             }
         }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2011,7 +2011,19 @@ dl.inline-dl {
     .datasource-evaluation-summary-provision {
         dl {
             margin-bottom: 5px;
+
+            .provisional-interpretation-status:first-letter {
+                text-transform: capitalize;
+            }
         }
+    }
+
+    .provisional-form-content-wrapper {
+        border: solid 1px #dfdfdf;
+        padding: 15px 20px;
+        -webkit-border-radius: 2px;
+        -moz-border-radius: 2px;
+        border-radius: 2px;
     }
 
     .evaluation-provision {
@@ -2028,22 +2040,25 @@ dl.inline-dl {
         }
 
         select {
-            width: auto;
+            /*width: auto;*/
         }
 
         &.provisional-pathogenicity {
             .form-group {
-                margin-bottom: 5px;
+                margin-bottom: 0;
             }
         }
 
         &.provisional-interpretation {
+            margin-top: 0;
+
             .col-sm-7 {
                 margin-left: -15px;
             }
 
             .icon-question-circle {
                 cursor: pointer;
+                color: #2697d1;
                 font-size: 120%;
                 margin-right: 8px;
                 position: relative;
@@ -2051,6 +2066,7 @@ dl.inline-dl {
                 &:after {
                     content: "Editing interpretation is permitted after selecting this option";
                     background-color: #000;
+                    background-color: hsla(0, 0%, 20%, 0.9);
                     color: #fff;
                     text-align: center;
                     border-radius: 3px;
@@ -2087,7 +2103,29 @@ dl.inline-dl {
             input[type="checkbox"] {
                 margin-top: 0;
                 position: relative;
-                top: 4px;
+                top: 3px;
+                left: 0px;
+                visibility: hidden;
+
+                &:after,
+                &:checked:after {
+                    font-family: FontAwesome;
+                    font-size: 120%;
+                    display: inline-block;
+                    visibility: visible;
+                }
+
+                &:after {
+                    content: "\f096";
+                }
+
+                &:checked:after {
+                    content: "\f14a";
+                }
+
+                &[disabled] {
+                    color: #bbb;
+                }
             }
         }
     }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1800,7 +1800,7 @@ dl.inline-dl {
             }
 
             &.benign-result:before {
-                color: #92cd9e;
+                color: #57a3de;
             }
 
             &.path-result:before {
@@ -1811,7 +1811,7 @@ dl.inline-dl {
                 content: "\f1ec";
                 font-family: 'FontAwesome';
                 font-size: 15pt;
-                color: #1b75bc;
+                color: #666;
                 top: 8px;
             }
 
@@ -1925,7 +1925,7 @@ dl.inline-dl {
         font-size: 20px;
 
         .benign {
-            color: #92cd9e;
+            color: #57a3de;
         }
 
         .pathogenic {
@@ -2004,7 +2004,7 @@ dl.inline-dl {
 
     [data-evaltype='benign'] {
         .criteria-modified:after {
-            color: #92cd9e;
+            color: #57a3de;
         }
     }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2008,8 +2008,14 @@ dl.inline-dl {
         }
     }
 
+    .datasource-evaluation-summary-provision {
+        dl {
+            margin-bottom: 5px;
+        }
+    }
+
     .evaluation-provision {
-        margin-left: 15px;
+        margin-bottom: 5px;
         margin-right: 0;
 
         label {
@@ -2023,6 +2029,12 @@ dl.inline-dl {
 
         select {
             width: auto;
+        }
+
+        &.provisional-pathogenicity {
+            .form-group {
+                margin-bottom: 5px;
+            }
         }
 
         &.provisional-interpretation {
@@ -2050,7 +2062,7 @@ dl.inline-dl {
                     font-family: "Helvetica";
                     font-weight: bold;
                     z-index: 1;
-                    top: -25px;
+                    top: 25px;
                     left: 0;
                 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1759,4 +1759,76 @@ dl.inline-dl {
             color: #f4978a;
         }
     }
+
+    .evaluation-provision {
+        margin-left: 15px;
+        margin-right: 0;
+
+        label {
+            padding-left: 0;
+        }
+
+        .col-sm-6,
+        .col-sm-7 {
+            padding-left: 0;
+        }
+
+        select {
+            width: auto;
+        }
+
+        &.provisional-interpretation {
+            .col-sm-7 {
+                margin-left: -15px;
+            }
+
+            .icon-question-circle {
+                cursor: pointer;
+                font-size: 120%;
+                margin-right: 8px;
+                position: relative;
+
+                &:after {
+                    content: "Editing interpretation is permitted after selecting this option";
+                    background-color: #000;
+                    color: #fff;
+                    text-align: center;
+                    border-radius: 3px;
+                    padding: 5px 0;
+                    position: absolute;
+                    visibility: hidden;
+                    width: 370px;
+                    font-size: 12px;
+                    font-family: "Helvetica";
+                    font-weight: bold;
+                    z-index: 1;
+                    top: -25px;
+                    left: 0;
+                }
+
+                &:hover:after {
+                    visibility: visible;
+                }
+            }
+
+            .form-group {
+                display: inline-block;
+                margin: 0 0 0 10px;
+
+                .col-sm-7 {
+                    margin-left: 0;
+                }
+
+                .form-error {
+                    display: none;
+                }
+            }
+
+            input[type="checkbox"] {
+                margin-top: 0;
+                position: relative;
+                top: 4px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Known issues:**
1. While on the Summary page, clicking on the browser's **Back** button instead of the "Return to Interpretation" button will cause the page to lose its interpretation state (e.g. such as taking the user back to the "Evidence Only" view).

**Technical details:**
1. The provisional form on the summary page can be saved even when the modified pathogenicity and its reason fields have `null` values.
2. In the use case above, we are at least storing a string value in the `provisional-variant` object for the calculated pathogenicity and a boolean value in the `interpretation` object for the provisional interpretation checkbox.
3. The displayed **Calculated Pathogenicity** uses the in-app state as its primary data source and the stored value as its secondary data source. The in-app state allows the most current calculated value to be displayed, while the stored value provides a fallback in case the in-app state is not present.
4. The displayed **Modified Pathogenicity** uses only the stored `alteredClassification` value in the `provisional-variant` object, regardless the changed selection on the **Modified Pathogenicity** dropdown.
5. The displayed **Provisional Interpretation Status** string is solely determined by the stored boolean value of the provisional interpretation checkbox in the `interpretation` object.
6. When making a selection from the **Modify Pathogenicity** dropdown, a reason needs to be provided in the textarea below. And vice versa. Otherwise, the form can not be submitted.
7. If no associated disease, selecting **Likely Pathogenic** or **Pathogenic** from the **Modify Pathogenicity** will automatically uncheck the provisional checkbox (if it was previously checked) while disabling the checkbox.
8.  If no associated disease, a calculated pathogenicity of **Likely Pathogenic** or **Pathogenic** will automatically uncheck the provisional checkbox (if it was previously checked) while disabling the checkbox.
9. In the **Criteria "Not yet evaluated"** table, the list includes `not-evaluated` criteria stored into the `evaluation` object as well as criteria that have not been evaluated and stored in the db.

**Steps to test:**
1. Login and use 15333 variant_id at the variation selection interface.
2. Start a new interpretation without associating with a disease.
3. Evaluate some criteria so that the calculated pathogenicity is either **Likely Pathogenic** or **Pathogenic**. Click on the **View Summary** button and expect to see the **"Mark as Provisional Interpretation (optional):"** checkbox being disabled.
4. Then select either **Benign**, **Likely Benign** or **Uncertain Significance** from the **Modify Pathogenicity** and expect to see the checkbox being enabled. Also expect to see the **"Explain reason(s) for change"** textarea being highlighted in pink now in alerting the user to provide a reason while the **Save** button is disabled.
5. Now enter some text in the textarea and expect to see the pink highlight goes away as well as the **Save** being enabled.
6. Next, check the provisional interpretation checkbox and save the form. Expect to see a status message displayed as a feedback for the form submission.
7. Further, change the **Modify Pathogenicity** dropdown selection to either **No Selection**, **Likely Pathogenic** or **Pathogenic**. Expect to see the provisional interpretation checkbox being unchecked and disabled.
8. Finally, click the **Return to Interpretation** button and associate the interpretation with a disease. Then click on the **View Summary** button again to return to the summary view. Expect to see the provisional interpretation checkbox being enabled regardless of the calculated/modified pathogenicity.
9. While on the summary page, expect to see the 3 tables listing all the criteria that meet an evaluation strength, were evaluated as "Not met", as well as were "Not yet evaluated".