### PR TITLE
Connects to #1022. Update NCBI API and external http requests to https.

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -402,14 +402,14 @@ function pubmedQueryResource() {
     // for pinging and parsing data from PubMed
     this.saveFormValue('resourceId', this.state.inputValue);
     if (pubmedValidateForm.call(this)) {
-        var url = this.props.protocol + external_url_map['PubMedSearch'];
+        var url = external_url_map['PubMedSearch'];
         var data;
         var id = this.state.inputValue;
         this.getRestData('/articles/' + id).then(article => {
             // article already exists in db
             this.setState({queryResourceBusy: false, tempResource: article, resourceFetched: true});
         }, () => {
-            var url = this.props.protocol + external_url_map['PubMedSearch'];
+            var url = external_url_map['PubMedSearch'];
             // PubMed article not in our DB; go out to PubMed itself to retrieve it as XML
             this.getRestDataXml(external_url_map['PubMedSearch'] + id).then(xml => {
                 var data = parsePubmed(xml);
@@ -540,7 +540,7 @@ function clinvarQueryResource() {
     // for pinging and parsing data from ClinVar
     this.saveFormValue('resourceId', this.state.inputValue);
     if (clinvarValidateForm.call(this)) {
-        var url = this.props.protocol + external_url_map['ClinVarEutils'];
+        var url = external_url_map['ClinVarEutils'];
         var data;
         var id = this.state.inputValue;
         this.getRestDataXml(url + id).then(xml => {
@@ -682,7 +682,7 @@ function carQueryResource() {
             data = parseCAR(json);
             if (data.clinvarVariantId) {
                 // if the CAR result has a ClinVar variant ID, query ClinVar with it, and use its data
-                url = this.props.protocol + external_url_map['ClinVarEutils'];
+                url = external_url_map['ClinVarEutils'];
                 this.getRestDataXml(url + data.clinvarVariantId).then(xml => {
                     var data_cv = parseClinvar(xml);
                     if (data_cv.clinvarVariantId) {

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -136,12 +136,12 @@ module.exports.dbxref_prefix_map = {
     "HGNC": "http://www.genecards.org/cgi-bin/carddisp.pl?gene=",
     // ENSEMBL link only works for human
     "ENSEMBL": "http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=",
-    "GeneID": "http://www.ncbi.nlm.nih.gov/gene/",
-    "GEO": "http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
+    "GeneID": "https://www.ncbi.nlm.nih.gov/gene/",
+    "GEO": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
     "Caltech": "http://jumpgate.caltech.edu/library/",
     "FlyBase": "http://flybase.org/cgi-bin/quicksearch_solr.cgi?caller=quicksearch&tab=basic_tab&data_class=FBgn&species=Dmel&search_type=all&context=",
     "WormBase": "http://www.wormbase.org/species/c_elegans/gene/",
-    "RefSeq": "http://www.ncbi.nlm.nih.gov/gene/?term=",
+    "RefSeq": "https://www.ncbi.nlm.nih.gov/gene/?term=",
     // UCSC links need assembly (&db=) and accession (&hgt_mdbVal1=) added to url
     "UCSC-ENCODE-mm9": "http://genome.ucsc.edu/cgi-bin/hgTracks?tsCurTab=advancedTab&tsGroup=Any&tsType=Any&hgt_mdbVar1=dccAccession&hgt_tSearch=search&hgt_tsDelRow=&hgt_tsAddRow=&hgt_tsPage=&tsSimple=&tsName=&tsDescr=&db=mm9&hgt_mdbVal1=",
     "UCSC-ENCODE-hg19": "http://genome.ucsc.edu/cgi-bin/hgTracks?tsCurTab=advancedTab&tsGroup=Any&tsType=Any&hgt_mdbVar1=dccAccession&hgt_tSearch=search&hgt_tsDelRow=&hgt_tsAddRow=&hgt_tsPage=&tsSimple=&tsName=&tsDescr=&db=hg19&hgt_mdbVal1=",
@@ -149,28 +149,28 @@ module.exports.dbxref_prefix_map = {
     "UCSC-GB-mm9": "http://genome.cse.ucsc.edu/cgi-bin/hgTrackUi?db=mm9&g=",
     "UCSC-GB-hg19": "http://genome.cse.ucsc.edu/cgi-bin/hgTrackUi?db=hg19&g=",
     // Dataset, experiment, and document references
-    "PMID": "http://www.ncbi.nlm.nih.gov/pubmed/?term=",
-    "PMCID": "http://www.ncbi.nlm.nih.gov/pmc/articles/",
+    "PMID": "https://www.ncbi.nlm.nih.gov/pubmed/?term=",
+    "PMCID": "https://www.ncbi.nlm.nih.gov/pmc/articles/",
     "doi": "http://dx.doi.org/doi:"
 };
 
 module.exports.external_url_map = {
-    'PubMedSearch': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=PubMed&retmode=xml&id=',
+    'PubMedSearch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=PubMed&retmode=xml&id=',
     'PubMed': 'https://www.ncbi.nlm.nih.gov/pubmed/',
     'OrphaNet': 'http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=',
     'OrphanetHome': 'http://www.orpha.net/',
     'HGNC': 'http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=',
     'HGNCFetch': '//rest.genenames.org/fetch/symbol/',
     'HGNCHome': 'http://www.genenames.org/',
-    'Entrez': 'http://www.ncbi.nlm.nih.gov/gene/',
-    'MedGen': 'http://www.ncbi.nlm.nih.gov/medgen/',
+    'Entrez': 'https://www.ncbi.nlm.nih.gov/gene/',
+    'MedGen': 'https://www.ncbi.nlm.nih.gov/medgen/',
     'OMIM': 'http://omim.org/',
     'OMIMEntry': 'http://www.omim.org/entry/',
-    'ClinVar': 'http://www.ncbi.nlm.nih.gov/clinvar/',
-    'ClinVarSearch': 'http://www.ncbi.nlm.nih.gov/clinvar/variation/',
-    'ClinVarEfetch': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar',
-    'ClinVarEutils': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=',
-    'ClinVarEsearch': '//eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?',
+    'ClinVar': 'https://www.ncbi.nlm.nih.gov/clinvar/',
+    'ClinVarSearch': 'https://www.ncbi.nlm.nih.gov/clinvar/variation/',
+    'ClinVarEfetch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar',
+    'ClinVarEutils': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&rettype=variation&id=',
+    'ClinVarEsearch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?',
     'HPO': 'http://compbio.charite.de/hpoweb/showterm?id=',
     'HPOBrowser': 'http://compbio.charite.de/hpoweb/showterm?id=HP:0000118',
     'Uberon': 'http://uberon.github.io/',
@@ -184,7 +184,7 @@ module.exports.external_url_map = {
     'CL': 'http://www.ontobee.org/browser/index.php?o=CL',
     'CLSearch': 'http://www.ontobee.org/browser/rdf.php?o=CL&iri=http://purl.obolibrary.org/obo/',
     'EFO': 'http://www.ebi.ac.uk/efo/',
-    'dbSNP': 'http://www.ncbi.nlm.nih.gov/snp/',
+    'dbSNP': 'https://www.ncbi.nlm.nih.gov/snp/',
     'CAR': 'http://reg.genome.network/site/cg-registry',
     'CARallele': '//reg.genome.network/allele/',
     'CAR-test': 'http://reg.test.genome.network/site/registry',
@@ -194,7 +194,7 @@ module.exports.external_url_map = {
     'EnsemblVariation': '//rest.ensembl.org/variation/human/',
     'EnsemblPopulationPage': 'http://ensembl.org/Homo_sapiens/Variation/Population?db=core;v=',
     'UCSCGenomeBrowser': '//genome.ucsc.edu/cgi-bin/hgTracks',
-    'NCBIVariationViewer': '//www.ncbi.nlm.nih.gov/variation/view/',
+    'NCBIVariationViewer': 'https://www.ncbi.nlm.nih.gov/variation/view/',
     'MyVariantInfo': '//myvariant.info/v1/variant/',
     'MyGeneInfo': '//mygene.info/v3/query?q=',
     'EXAC': '//exac.broadinstitute.org/variant/',
@@ -212,7 +212,7 @@ module.exports.external_url_map = {
     'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
     'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
     'Bustamante': '//predictvar.bustamante-lab.net/variant/position/',
-    'MeSH': 'http://www.ncbi.nlm.nih.gov/mesh?term='
+    'MeSH': 'https://www.ncbi.nlm.nih.gov/mesh?term='
 };
 
 

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -110,7 +110,7 @@ var VariantCurationHub = React.createClass({
             if (variant.clinvarVariantId) {
                 this.setState({clinvar_id: variant.clinvarVariantId});
                 // Get ClinVar data via the parseClinvar method defined in parse-resources.js
-                this.getRestDataXml(this.props.href_url.protocol + external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
+                this.getRestDataXml(external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
                     // Passing 'true' option to invoke 'mixin' function
                     // To extract more ClinVar data for 'Basic Information' tab
                     var variantData = parseClinvar(xml, true);
@@ -133,7 +133,7 @@ var VariantCurationHub = React.createClass({
                         let clinvarInterpretations = [];
                         let Urls = [];
                         for (let RCV of RCVs.values()) {
-                            Urls.push(this.props.href_url.protocol + external_url_map['ClinVarEfetch'] + '&rettype=clinvarset&id=' + RCV);
+                            Urls.push(external_url_map['ClinVarEfetch'] + '&rettype=clinvarset&id=' + RCV);
                         }
                         return this.getRestDatasXml(Urls).then(xml => {
                             xml.forEach(result => {
@@ -358,7 +358,7 @@ var VariantCurationHub = React.createClass({
         let symbol = response.gene.symbol;
         if (aminoAcidLocation && symbol) {
             let term = aminoAcidLocation.substr(0, aminoAcidLocation.length-1);
-            this.getRestData(this.props.href_url.protocol + external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
+            this.getRestData(external_url_map['ClinVarEsearch'] + 'db=clinvar&term=' + term + '+%5Bvariant+name%5D+and+' + symbol + '&retmode=json').then(result => {
                 // pass in these additional values, in case receiving component needs them
                 result.vci_term = term;
                 result.vci_symbol = symbol;

--- a/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/credit.js
@@ -16,8 +16,8 @@ export function renderDataCredit(source) {
                     Xin J, Mark A, Afrasiabi C, Tsueng G, Juchler M, Gopal N, Stupp GS, Putman TE, Ainscough BJ,
                     Griffith OL, Torkamani A, Whetzel PL, Mungall CJ, Mooney SD, Su AI, Wu C (2016)
                     High-performance web services for querying gene and variant annotation. Genome Biology 17(1):1-7.
-                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a>&nbsp;
-                PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
+                    PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/27154141" target="_blank">27154141</a>&nbsp;
+                PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
                 DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>
                 </div>
             </div>
@@ -33,8 +33,8 @@ export function renderDataCredit(source) {
                     PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4858870/" target="_blank">PMC4858870</a>&nbsp;
                     DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0953-9" target="_blank">10.1186/s13059-016-0953-9</a>.&nbsp;
                     Wu C, MacLeod I, Su AI (2013) BioGPS and MyGene.info: organizing online, gene-centric information. Nucl. Acids Res. 41(D1): D561-D565.
-                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/23175613" target="_blank">23175613</a>&nbsp;
-                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531157/" target="_blank">PMC3531157</a>&nbsp;
+                    PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/23175613" target="_blank">23175613</a>&nbsp;
+                    PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531157/" target="_blank">PMC3531157</a>&nbsp;
                     DOI: <a href="http://nar.oxfordjournals.org/content/41/D1/D561" target="_blank">10.1093/nar/gks1114</a>
                 </div>
             </div>
@@ -47,8 +47,8 @@ export function renderDataCredit(source) {
                     The Ensembl Variant Effect Predictor (<a href="http://www.ensembl.org/Homo_sapiens/Tools/VEP" target="_blank">www.ensembl.org/Homo_sapiens/Tools/VEP</a>)
                     McLaren W, Gil L, Hunt SE, Riat HS, Ritchie GR, Thormann A, Flicek P, Cunningham F.
                     Genome Biol. 2016 Jun 6;17(1):122.
-                    PMID: <a href="http://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a>&nbsp;
-                    PMCID: <a href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a>&nbsp;
+                    PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/27268795" target="_blank">27268795</a>&nbsp;
+                    PMCID: <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4893825/" target="_blank">PMC4893825</a>&nbsp;
                     DOI: <a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4" target="_blank">10.1186/s13059-016-0974-4</a>
                 </div>
             </div>

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -43,7 +43,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                     {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
                             {clinVarId ?
-                                <dd>ClinVar VariationID:&nbsp;<a href={external_url_map['ClinVarEsearch'] + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
+                                <dd>ClinVar VariationID:&nbsp;<a href={external_url_map['ClinVarSearch'] + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
                                 :
                                 null
                             }

--- a/src/clincoded/static/components/variant_central/record_variant.js
+++ b/src/clincoded/static/components/variant_central/record_variant.js
@@ -43,7 +43,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                     {clinVarId || carId ?
                         <dl className="inline-dl clearfix">
                             {clinVarId ?
-                                <dd>ClinVar VariationID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/clinvar/variation/' + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
+                                <dd>ClinVar VariationID:&nbsp;<a href={external_url_map['ClinVarEsearch'] + clinVarId} target="_blank" title={'ClinVar page for ' + clinVarId + ' in a new window'}>{clinVarId}</a></dd>
                                 :
                                 null
                             }
@@ -53,7 +53,7 @@ var CurationRecordVariant = module.exports.CurationRecordVariant = React.createC
                                 null
                             }
                             {dbSNPId ?
-                                <dd>dbSNP ID:&nbsp;<a href={'http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=' + dbSNPId.replace('rs', '')} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{dbSNPId}</a></dd>
+                                <dd>dbSNP ID:&nbsp;<a href={'https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=' + dbSNPId.replace('rs', '')} target="_blank" title={'dbSNP page for ' + dbSNPId + ' in a new window'}>{dbSNPId}</a></dd>
                                 :
                                 null
                             }


### PR DESCRIPTION
**Technical details:**
1. Removed instances of `this.props.protocol +` and `this.props.href_url.protocol +` associated with NCBI API and external http requests.
2. Changed all instance of `http` to `https` associated with NCBI in `global.js`.
3. Prepend `https` to URL mappings associated with NCBI in `global.js`.

**Steps to test:**
1. Open Chrome Dev Tools console.
2. Login and use 15333 variant_id at the variation selection interface. Expect to see a list of HGVS terms being returned in the modal. Also expect to see no XHR error for the _Eutils_ API call in the console.
3. Click the **Save and View Evidence** button and proceed to the **Basic Info** tab. Expect to see data being displayed in the **ClinVar Interpretation and Supporting Records** and **ClinVar Primary Transcript** tables. Also expect to see no XHR error for the _Eutils_ API call in the console.
4. Proceed to **Predictors** tab and expect to see the **Additional ClinVar variants found in the same codon: 12** message displayed in the **ClinVar Variants** codon table. And clicking on the next link to it will take you to the expected page.
5. Proceed to the **Gene-centric** tab and click on the **Search ClinVar for variants in this gene** link. Expect to be taken to the intended page.
6. Click through various linkouts, such as the **ClinVar VariationID** and **Variation Viewer** links in the top green header, as well as the PMID links in the attributions at the bottom of tabs. Expect to be taken to the intended pages.