### PR TITLE
Connects to #1024. Connects to #1004. Connects to #1008.

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -242,6 +242,9 @@ var NavbarUser = React.createClass({
             <Nav navbarStyles='navbar-user' styles='navbar-right nav-user'>
                 {this.props.portal.navUser.map(function(menu) {
                     if (menu.url || menu.title === 'space') {
+                        if (menu.id === 'help') {
+                            return <NavItem key={menu.id} href={menu.url} icon={menu.icon} title={menu.title} target={menu.target}>{menu.title}</NavItem>;
+                        }
                         // Normal menu item; disabled if user is not logged in
                         if (session && session['auth.userid']) {
                             return <NavItem key={menu.id} href={menu.url} icon={menu.icon} title={menu.title} target={menu.target}>{menu.title}</NavItem>;

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -28,12 +28,38 @@ var Home = module.exports.Home = React.createClass({
                     <div className="row">
                         <div className="col-sm-12">
                             <div className="project-info site-title">
-                                <h1>ClinGen Curator Interface</h1>
-                                <p>Access to this interface is currently restricted to ClinGen curators. To access publicly available information, please visit the <a href="http://clinicalgenome.org">ClinGen portal</a>.</p>
-                                <p>If you are a ClinGen curator, you may <a href='mailto:clingen-helpdesk@lists.stanford.edu'>request an account</a>.</p>
+                                <h1>ClinGen Curator Interfaces</h1>
+                                <h4>Variant Curation &#8226; Gene Curation</h4>
+                                <p className="lead">Access to these interfaces is currently restricted to ClinGen curators. If you are a ClinGen curator, you may request an account at <a href="mailto:clingen-helpdesk@lists.stanford.edu">clingen-helpdesk@lists.stanford.edu <i className="icon icon-envelope"></i></a>.</p>
+                                <p className="lead">ClinGen is a National Institutes of Health (NIH)-funded resource dedicated to building an authoritative central resource that defines the clinical relevance of genes and variants for use in precision medicine and research. One of the key goals of ClinGen is to implement an evidence-based consensus for curating genes and variants. For more information on the ClinGen resource, please visit the ClinGen portal at <a href="https://www.clinicalgenome.org" target="_blank">clinicalgenome.org <i className="icon icon-external-link"></i></a>.</p>
                             </div>
                         </div>
                     </div>
+                    <div className="row">
+                        <div className="col-sm-6">
+                            <h2>Variant Curation</h2>
+                            <h3>Which changes in the gene cause disease?</h3>
+                            <p>
+                                The ClinGen variant curation process combines clinical, genetic, population, and functional evidence with expert review to classify variants into 1 of 5 categories according to the <a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" target="_blank">ACMG guidelines <i className="icon icon-file-pdf-o"></i></a>.
+                            </p>
+                            <p><strong>Pathogenic &#8226; Likely Pathogenic &#8226; Uncertain &#8226; Likely Benign &#8226; Benign</strong></p>
+                            <p className="help-document">
+                                <a className="btn btn-primary" href="/static/help/clingen-variant-curation-help.pdf" target="_blank" role="button">Learn more »</a>
+                            </p>
+                        </div>
+                        <div className="col-sm-6">
+                            <h2>Gene Curation</h2>
+                            <h3>Does variation in this gene cause disease?</h3>
+                            <p>
+                                The ClinGen gene curation process combines an appraisal of genetic and experimental data in the scientific literature with expert review to classify gene-disease pairs into 1 of 6 categories according to the <a href="https://www.clinicalgenome.org/site/assets/files/2657/current_clinical_validity_classifications.pdf" target="_blank">Gene-Disease Clinical Validity Classification <i className="icon icon-file-pdf-o"></i></a> framework.
+                            </p>
+                            <p><strong>Definitive &#8226; Strong &#8226; Moderate &#8226; Limited &#8226; Disputed &#8226; Refuted</strong></p>
+                        </div>
+                    </div>
+                    <hr/>
+                    <footer>
+                        <p>&copy; 2016 <a href="https://www.clinicalgenome.org" target="_blank">ClinGen</a> - All rights reserved</p>
+                    </footer>
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -37,23 +37,27 @@ var Home = module.exports.Home = React.createClass({
                     </div>
                     <div className="row">
                         <div className="col-sm-6">
-                            <h2>Variant Curation</h2>
-                            <h3>Which changes in the gene cause disease?</h3>
-                            <p>
-                                The ClinGen variant curation process combines clinical, genetic, population, and functional evidence with expert review to classify variants into 1 of 5 categories according to the <a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" target="_blank">ACMG guidelines <i className="icon icon-file-pdf-o"></i></a>.
-                            </p>
-                            <p><strong>Pathogenic &#8226; Likely Pathogenic &#8226; Uncertain &#8226; Likely Benign &#8226; Benign</strong></p>
-                            <p className="help-document">
-                                <a className="btn btn-primary" href="/static/help/clingen-variant-curation-help.pdf" target="_blank" role="button">Learn more »</a>
-                            </p>
+                            <div className="promo">
+                                <h2>Variant Curation</h2>
+                                <h3>Which changes in the gene cause disease?</h3>
+                                <p>
+                                    The ClinGen variant curation process combines clinical, genetic, population, and functional evidence with expert review to classify variants into 1 of 5 categories according to the <a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" target="_blank">ACMG guidelines <i className="icon icon-file-pdf-o"></i></a>.
+                                </p>
+                                <p><strong>Pathogenic &#8226; Likely Pathogenic &#8226; Uncertain &#8226; Likely Benign &#8226; Benign</strong></p>
+                                <p className="help-document">
+                                    <a className="btn btn-primary" href="/static/help/clingen-variant-curation-help.pdf" target="_blank" role="button">Learn more »</a>
+                                </p>
+                            </div>
                         </div>
                         <div className="col-sm-6">
-                            <h2>Gene Curation</h2>
-                            <h3>Does variation in this gene cause disease?</h3>
-                            <p>
-                                The ClinGen gene curation process combines an appraisal of genetic and experimental data in the scientific literature with expert review to classify gene-disease pairs into 1 of 6 categories according to the <a href="https://www.clinicalgenome.org/site/assets/files/2657/current_clinical_validity_classifications.pdf" target="_blank">Gene-Disease Clinical Validity Classification <i className="icon icon-file-pdf-o"></i></a> framework.
-                            </p>
-                            <p><strong>Definitive &#8226; Strong &#8226; Moderate &#8226; Limited &#8226; Disputed &#8226; Refuted</strong></p>
+                            <div className="promo">
+                                <h2>Gene Curation</h2>
+                                <h3>Does variation in this gene cause disease?</h3>
+                                <p>
+                                    The ClinGen gene curation process combines an appraisal of genetic and experimental data in the scientific literature with expert review to classify gene-disease pairs into 1 of 6 categories according to ClinGen's <a href="https://www.clinicalgenome.org/site/assets/files/2657/current_clinical_validity_classifications.pdf" target="_blank">Gene-Disease Clinical Validity Classification <i className="icon icon-file-pdf-o"></i></a> framework.
+                                </p>
+                                <p><strong>Definitive &#8226; Strong &#8226; Moderate &#8226; Limited &#8226; Disputed &#8226; Refuted</strong></p>
+                            </div>
                         </div>
                     </div>
                     <hr/>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -70,7 +70,7 @@ var SelectVariant = React.createClass({
                                         <option value="ClinVar Variation ID">ClinVar Variation ID</option>
                                         <option value="ClinGen Allele Registry ID (CA ID)">ClinGen Allele Registry ID (CA ID)</option>
                                     </Input>
-                                    <p className="col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4 input-note-below-no-bottom"><strong>Note:</strong> Select ID type based on above instructions. Use the ClinVar VariationID whenever possible.</p>
+                                    <p className="col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4 input-note-below-no-bottom"><strong>Note:</strong> Select ID type based on the instructions below. Use the ClinVar VariationID whenever possible.</p>
                                     {this.state.variantIdType == "ClinVar Variation ID" ?
                                     <div className="row col-sm-7 col-md-8 col-sm-offset-5 col-md-offset-4">
                                         <AddResourceId resourceType="clinvar" wrapperClass="modal-buttons-wrapper" protocol={this.props.href_url.protocol}

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -36,7 +36,7 @@ var validTabs = ['missense', 'lof', 'silent-intron', 'indel'];
 var computationStatic = {
     conservation: {
         _order: ['phylop7way', 'phylop20way', 'phastconsp7way', 'phastconsp20way', 'gerp', 'siphy'],
-        _labels: {'phylop7way': 'phyloP7way', 'phylop20way': 'phyloP20way', 'phastconsp7way': 'phastCons7way', 'phastconsp20way': 'phastCons20way', 'gerp': 'GERP++', 'siphy': 'SiPhy'}
+        _labels: {'phylop7way': 'phyloP100way', 'phylop20way': 'phyloP20way', 'phastconsp7way': 'phastCons100way', 'phastconsp20way': 'phastCons20way', 'gerp': 'GERP++', 'siphy': 'SiPhy'}
     },
     other_predictors: {
         _order: ['sift', 'polyphen2_hdiv', 'polyphen2_hvar', 'lrt', 'mutationtaster', 'mutationassessor', 'fathmm', 'provean', 'metasvm', 'metalr', 'cadd', 'fathmm_mkl', 'fitcons'],
@@ -200,8 +200,8 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (response.results[0]) {
             if (response.results[0].predictions) {
                 let predictions = response.results[0].predictions;
-                computationObj.clingen.revel.score = (predictions.revel) ? parseFloat(predictions.revel.score) : null;
-                computationObj.clingen.cftr.score = (predictions.CFTR) ? parseFloat(predictions.CFTR.score): null;
+                computationObj.clingen.revel.score = (predictions.revel) ? this.numToString(predictions.revel.score) : null;
+                computationObj.clingen.cftr.score = (predictions.CFTR) ? this.numToString(predictions.CFTR.score): null;
                 computationObj.clingen.cftr.visible = (predictions.CFTR) ? true : false;
             }
             // update computationObj, and set flag indicating that we have clingen predictors data
@@ -244,7 +244,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         }
         if (response.cadd) {
             let cadd = response.cadd;
-            computationObj.other_predictors.cadd.score = parseFloat(cadd.rawscore);
+            computationObj.other_predictors.cadd.score = this.numToString(cadd.rawscore);
             // update computationObj, and set flag indicating that we have other predictors data
             this.setState({hasOtherPredData: true, computationObj: computationObj});
         }
@@ -290,15 +290,25 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             let computationObj = this.state.computationObj;
             let dbnsfp = response.dbnsfp;
             // get scores from dbnsfp
-            computationObj.conservation.phylop7way = (dbnsfp.phylo.p7way) ? parseFloat(dbnsfp.phylo.p7way.vertebrate) : parseFloat(dbnsfp.phylo.p100way.vertebrate);
-            computationObj.conservation.phylop20way = parseFloat(dbnsfp.phylo.p20way.mammalian);
-            computationObj.conservation.phastconsp7way = (dbnsfp.phastcons['7way']) ? parseFloat(dbnsfp.phastcons['7way'].vertebrate) : parseFloat(dbnsfp.phastcons['100way'].vertebrate);
-            computationObj.conservation.phastconsp20way = parseFloat(dbnsfp.phastcons['20way'].mammalian);
-            computationObj.conservation.gerp = parseFloat(dbnsfp['gerp++'].rs);
-            computationObj.conservation.siphy = parseFloat(dbnsfp.siphy_29way.logodds);
+            computationObj.conservation.phylop7way = (dbnsfp.phylo.p7way) ? this.numToString(dbnsfp.phylo.p7way.vertebrate) : this.numToString(dbnsfp.phylo.p100way.vertebrate);
+            computationObj.conservation.phylop20way = this.numToString(dbnsfp.phylo.p20way.mammalian);
+            computationObj.conservation.phastconsp7way = (dbnsfp.phastcons['7way']) ? this.numToString(dbnsfp.phastcons['7way'].vertebrate) : this.numToString(dbnsfp.phastcons['100way'].vertebrate);
+            computationObj.conservation.phastconsp20way = this.numToString(dbnsfp.phastcons['20way'].mammalian);
+            computationObj.conservation.gerp = this.numToString(dbnsfp['gerp++'].rs);
+            computationObj.conservation.siphy = this.numToString(dbnsfp.siphy_29way.logodds);
             // update computationObj, and set flag indicating that we have conservation analysis data
             this.setState({hasConservationData: true, computationObj: computationObj});
         }
+    },
+
+    // Method to handle conservation scores
+    numToString: function(num) {
+        let result;
+        if (num !== '' && num !== null) {
+            let score = parseFloat(num);
+            result = (!isNaN(score)) ? score.toString() : null;
+        }
+        return result;
     },
 
     // method to render a row of data for the clingen predictors table

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2184,3 +2184,51 @@ dl.inline-dl {
         }
     }
 }
+
+.homepage-main-box {
+    h1, h2 {
+        font-weight: 500;
+        margin-top: 20px;
+        margin-bottom: 10px;
+    }
+
+    h1 {
+        font-size: 3.0em;
+    }
+
+    h2 {
+        font-size: 30px;
+    }
+
+    .lead {
+        font-size: 19px;
+    }
+
+    .project-info {
+        background-color: #eee;
+        border-radius: 6px;
+        margin-top: 30px;
+        margin-bottom: 30px;
+        padding: 25px 60px;
+    }
+
+    h3 {
+        border-top: solid 1px #eee;
+        border-bottom: solid 1px #eee;
+        font-style: italic;
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+
+    h4 {
+        margin-bottom: 20px;
+    }
+
+    .help-document {
+        margin-top: 20px;
+
+        .btn {
+            border-radius: 4px;
+        }
+    }
+}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2231,4 +2231,11 @@ dl.inline-dl {
             border-radius: 4px;
         }
     }
+
+    .col-sm-6 .promo {
+        border: solid 1px #ddd;
+        border-radius: 4px;
+        padding: 10px 35px 20px 35px;
+        height: 325px;
+    }
 }

--- a/src/clincoded/static/scss/fontawesome/_icons.scss
+++ b/src/clincoded/static/scss/fontawesome/_icons.scss
@@ -220,7 +220,7 @@
 .#{$fa-css-prefix}-sort-desc:before { content: $fa-var-sort-desc; }
 //.#{$fa-css-prefix}-sort-up:before,
 .#{$fa-css-prefix}-sort-asc:before { content: $fa-var-sort-asc; }
-//.#{$fa-css-prefix}-envelope:before { content: $fa-var-envelope; }
+.#{$fa-css-prefix}-envelope:before { content: $fa-var-envelope; }
 //.#{$fa-css-prefix}-linkedin:before { content: $fa-var-linkedin; }
 //.#{$fa-css-prefix}-rotate-left:before,
 //.#{$fa-css-prefix}-undo:before { content: $fa-var-undo; }
@@ -461,7 +461,7 @@
 //.#{$fa-css-prefix}-deviantart:before { content: $fa-var-deviantart; }
 //.#{$fa-css-prefix}-soundcloud:before { content: $fa-var-soundcloud; }
 //.#{$fa-css-prefix}-database:before { content: $fa-var-database; }
-//.#{$fa-css-prefix}-file-pdf-o:before { content: $fa-var-file-pdf-o; }
+.#{$fa-css-prefix}-file-pdf-o:before { content: $fa-var-file-pdf-o; }
 //.#{$fa-css-prefix}-file-word-o:before { content: $fa-var-file-word-o; }
 //.#{$fa-css-prefix}-file-excel-o:before { content: $fa-var-file-excel-o; }
 //.#{$fa-css-prefix}-file-powerpoint-o:before { content: $fa-var-file-powerpoint-o; }


### PR DESCRIPTION
**Technical notes:**
1. In the process of addressing #1004, I noticed that the **phastCons100way** score being displayed as "--" rather than "0". So I added a method to convert individual number scores to strings so that 0s are not interpreted as `null`.

**Steps to test:**
1. On the landing page, expect to see the `help` icon button at the top nav next to the **Login** button without logging in.
2. On the landing page, also expect to see the new content/layout. Click on various links and expect to be taken to the intended pages.
3. Login and proceed to the variation selection page. Expect to see the updated note with "...the instructions below..." rather then "...above instructions..." right below the selection dropdown.
4. Use 54321 variant_id and proceed to the **Predictors** tab. In the **Conservation Analysis** table, expect to see **phyloP100way** and **phastCons100way** labels (instead of _phyloP7way_ and _phastCons7way_) in the **Source** column. Also expect to see the "0" score being displayed for the **phastCons100way** label (instead of "--").