### PR TITLE
Connects to #1028. Non-HPO MoI term display on summary page

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -86,19 +86,20 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
     renderModeInheritanceLink: function(modeInheritance) {
         if (modeInheritance) {
             let start = modeInheritance.indexOf('(');
-            var end = modeInheritance.indexOf(')');
+            let end = modeInheritance.indexOf(')');
+            let hpoNumber;
             if (start && end) {
-                let hpoNumber = modeInheritance.substring(start+1, end);
-                if (hpoNumber && hpoNumber.indexOf('HP:') > -1) {
-                    let hpoLink = 'http://compbio.charite.de/hpoweb/showterm?id=' + hpoNumber;
-                    return (
-                        <a href={hpoLink} target="_blank">{modeInheritance}</a>
-                    );
-                } else {
-                    return (
-                        <span>{modeInheritance}</span>
-                    );
-                }
+                hpoNumber = modeInheritance.substring(start+1, end);
+            }
+            if (hpoNumber && hpoNumber.indexOf('HP:') > -1) {
+                let hpoLink = 'http://compbio.charite.de/hpoweb/showterm?id=' + hpoNumber;
+                return (
+                    <a href={hpoLink} target="_blank">{modeInheritance}</a>
+                );
+            } else {
+                return (
+                    <span>{modeInheritance}</span>
+                );
             }
         }
     },

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -94,6 +94,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                     return (
                         <a href={hpoLink} target="_blank">{modeInheritance}</a>
                     );
+                } else {
+                    return (
+                        <span>{modeInheritance}</span>
+                    );
                 }
             }
         }


### PR DESCRIPTION
**Technical note:**
A bug was discovered for the MoI term display on summary page. When a non-HPO MoI term was selected, the display was blank for the MoI term on the summary page.

**Steps to test:**
1. Login and use 15333 variant_id.
2. Start a new interpretation and add a non-HPO mode of inheritance (e.g. "codominant" or "other"). Proceed to the summary page and expect to see it being displayed next to the MoI term.
3. Return to interpretation and change to a HPO mode of inheritance (e.g. with HP:XXXXXX). Proceed to the summary page and expect to see it being displayed as a link next to the MoI term.
4. Return to interpretation and remove the MoI. Proceed to the summary page and expect to see "None" being displayed next to the MoI term.