### PR TITLE
Patch for #905 and #954/#1030

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -188,7 +188,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                     flatInterpretation.extra_evidence_list.splice(flatInterpretation.extra_evidence_list.indexOf(deleteTargetId), 1);
 
                     // update the interpretation object
-                    return this.putRestData('/interpretation/' + this.state.interpretation.uuid, flatInterpretation).then(data => {
+                    return this.putRestData('/interpretation/' + this.state.interpretation.uuid + '?render=false', flatInterpretation).then(data => {
                         return this.recordHistory('modify-hide', data['@graph'][0]).then(editHistory => {
                             return Promise.resolve(data['@graph'][0]);
                         });

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -177,7 +177,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
             status: 'deleted'
         };
 
-        this.putRestData(evidence['@id'], extra_evidence).then(result => {
+        this.putRestData(evidence['@id'] + '?render=false', extra_evidence).then(result => {
             return this.recordHistory('delete-hide', result['@graph'][0]).then(deleteHistory => {
                 return this.getRestData('/interpretation/' + this.state.interpretation.uuid).then(interpretation => {
                     // get updated interpretation object, then flatten it
@@ -188,7 +188,7 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                     flatInterpretation.extra_evidence_list.splice(flatInterpretation.extra_evidence_list.indexOf(deleteTargetId), 1);
 
                     // update the interpretation object
-                    return this.putRestData('/interpretation/' + this.state.interpretation.uuid + '?render=false', flatInterpretation).then(data => {
+                    return this.putRestData('/interpretation/' + this.state.interpretation.uuid, flatInterpretation).then(data => {
                         return this.recordHistory('modify-hide', data['@graph'][0]).then(editHistory => {
                             return Promise.resolve(data['@graph'][0]);
                         });

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -694,7 +694,7 @@ var VariantAddHistory = React.createClass({
 
         return (
             <div>
-                <span>Variant <strong>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.hgvsNames.GRCh37 ? variant.hgvsNames.GRCh37 : variant.hgvsNames.GRCh38)}</strong> added</span>
+                <span>Variant <strong>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : variant.hgvsNames.GRCh37)}</strong> added</span>
                 <span>; {moment(history.date_created).format("YYYY MMM DD, h:mm a")}</span>
             </div>
         );

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -694,7 +694,7 @@ var VariantAddHistory = React.createClass({
 
         return (
             <div>
-                <span>Variant <strong>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : variant.hgvsNames.GRCh37)}</strong> added</span>
+                <span>Variant <strong><a href={"/variant-central/?variant=" + variant.uuid}>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : variant.hgvsNames.GRCh37)}</a></strong> added</span>
                 <span>; {moment(history.date_created).format("YYYY MMM DD, h:mm a")}</span>
             </div>
         );


### PR DESCRIPTION
#### Connects to #905:

Variant added history item now links to VCI evidence view.

Testing:

1. Add variant via VCI. Confirm that dashboard entry for variant add links to VCI properly.
2. Add variant via GCI (family, individual, experimental). Confirm that dashboard entry for variant add links to VCI properly.

#### Connects to #954/#1030:

Non-admin users can delete extra evidence in VCI now.

Testing:

1. Login as non-admin account
2. Get to VCI, begin interpretation, then add PMIDs as extra evidence
3. Confirm that deleting these evidence items work