### PR TITLE
Connects to #1032. Deleting disease in modal.

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -27,7 +27,9 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
         session: React.PropTypes.object,
         interpretation: React.PropTypes.object,
         editKey: React.PropTypes.string,
-        updateInterpretationObj: React.PropTypes.func
+        updateInterpretationObj: React.PropTypes.func,
+        calculatedAssertion: React.PropTypes.string,
+        provisionalPathogenicity: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -116,7 +118,8 @@ var VariantCurationActions = module.exports.VariantCurationActions = React.creat
                             <InheritanceModalButton variantData={this.props.variantData} session={this.props.session} hasAssociatedInheritance={this.state.hasAssociatedInheritance}
                                 interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj} />
                             <DiseaseModalButton variantData={this.props.variantData} session={this.props.session} hasAssociatedDisease={this.state.hasAssociatedDisease}
-                                interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj} />
+                                interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj}
+                                calculatedAssertion={this.props.calculatedAssertion} provisionalPathogenicity={this.props.provisionalPathogenicity} />
                         </div>
                     </div>
                     :
@@ -148,7 +151,9 @@ var DiseaseModalButton = React.createClass({
         session: React.PropTypes.object,
         interpretation: React.PropTypes.object,
         editKey: React.PropTypes.string,
-        updateInterpretationObj: React.PropTypes.func
+        updateInterpretationObj: React.PropTypes.func,
+        calculatedAssertion: React.PropTypes.string,
+        provisionalPathogenicity: React.PropTypes.string
     },
 
     render: function() {
@@ -162,7 +167,8 @@ var DiseaseModalButton = React.createClass({
         return (
             <Modal title={associateDiseaseModalTitle} wrapperClassName="modal-associate-disease">
                 <button className="btn btn-primary pull-right" modal={<AssociateDisease closeModal={this.closeModal} data={this.props.variantData} session={this.props.session}
-                    interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj} />}>{associateDiseaseButtonTitle}</button>
+                    interpretation={this.props.interpretation} editKey={this.props.editkey} updateInterpretationObj={this.props.updateInterpretationObj}
+                    calculatedAssertion={this.props.calculatedAssertion} provisionalPathogenicity={this.props.provisionalPathogenicity} />}>{associateDiseaseButtonTitle}</button>
             </Modal>
         );
     }
@@ -212,7 +218,9 @@ var AssociateDisease = React.createClass({
         closeModal: React.PropTypes.func, // Function to call to close the modal
         interpretation: React.PropTypes.object, // interpretation object
         editKey: React.PropTypes.bool, // edit flag
-        updateInterpretationObj: React.PropTypes.func
+        updateInterpretationObj: React.PropTypes.func,
+        calculatedAssertion: React.PropTypes.string,
+        provisionalPathogenicity: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -328,6 +336,15 @@ var AssociateDisease = React.createClass({
                     // if the interpretation object does not have a disease object, create it
                     if ('disease' in flatInterpretation) {
                         delete flatInterpretation['disease'];
+                        let provisionalPathogenicity = this.props.provisionalPathogenicity;
+                        let calculatedAssertion = this.props.calculatedAssertion;
+                        if (provisionalPathogenicity === 'Likely pathogenic' || provisionalPathogenicity === 'Pathogenic') {
+                            flatInterpretation['markAsProvisional'] = false;
+                        } else if (!provisionalPathogenicity) {
+                            if (calculatedAssertion === 'Likely pathogenic' || calculatedAssertion === 'Pathogenic' ) {
+                                flatInterpretation['markAsProvisional'] = false;
+                            }
+                        }
 
                         // Update the intepretation object partially with the new disease property value
                         this.putRestData('/interpretation/' + this.props.interpretation.uuid, flatInterpretation).then(result => {

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -427,7 +427,8 @@ var VariantCurationHub = React.createClass({
                     <div>
                         <CurationInterpretationCriteria interpretation={interpretation} selectedTab={selectedTab} />
                         <VariantCurationActions variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
-                            href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj} />
+                            href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj}
+                            calculatedAssertion={calculated_pathogenicity} provisionalPathogenicity={this.state.provisionalPathogenicity} />
                         <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                             href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} getSelectedTab={this.getSelectedTab}
                             ext_myGeneInfo={(this.state.ext_myGeneInfo_MyVariant) ? this.state.ext_myGeneInfo_MyVariant : this.state.ext_myGeneInfo_VEP}


### PR DESCRIPTION
**Technical notes:**
Added conditional checks on the current modified and calculated pathogenicity upon deleting the associated disease. If either the following conditions are met, the updated code sets the `markAsProvisional` field to `false` during form submission:
1. modified pathogenicity === "Likely pathogenic" || "Pathogenic".
2. If modified pathogenicity value is `null`, but calculated pathogenicity === "Likely pathogenic" || "Pathogenic".

**Steps to test:**
1. Login and use 15333 variant_id.
2. Start a new interpretation. Evaluate various criteria so that the calculated pathogenicity is either "Likely pathogenic" or "Pathogenic". And add an associated disease.
3. Proceed to the summary page. Check the provisional checkbox and **Save** the form. Notice that the provisional status being updated to "Provisional".
4. Return to interpretation and delete the associated disease. Upon closing the modal, expect to see the provisional status in the static green header being updated to "In Progress".
5. Proceed to the summary page and expect to see the provisional status being updated to "In Progress".
6. Select either "Likely pathogenic" or "Pathogenic" from the **Modify Pathogenicity** dropdown. **Save** the form and return to interpretation.
7. Add a disease and change the calculated pathogenicity to be neither "Likely pathogenic" nor "Pathogenic".
8. Proceed to summary page and check the provisional checkbox. **Save** the form. Notice that the provisional status being updated to "Provisional".
9. Return to interpretation and delete the associated disease. Upon closing the modal, expect to see the provisional status in the static green header being updated to "In Progress".