### PR TITLE
Connects to #1037. Updated SNV variant note text.

### DIFF
--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -88,7 +88,7 @@ var SelectVariant = React.createClass({
                                 </div>
                                 <div className="row">
                                     <div className="alert alert-danger">
-                                        Note: <strong>This version of the interface currently supports SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs.
+                                        Note: <strong>This version of the interface currently returns evidence for SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs. However, the interface supports the evaluation/interpretation of any variant.
                                     </div>
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />


### PR DESCRIPTION
**Steps to test:**
1. Login and proceed to the variation selection interface.
2. Expect to see the **red** note being displayed as the following screenshot.
![image](https://cloud.githubusercontent.com/assets/6956310/18986469/c8981334-86b1-11e6-8dcc-20db00a6b81b.png)
