### PR TITLE
Connects to #1039. Handle ClinVar variants that have no gene metadata.

### DIFF
--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -44,6 +44,7 @@ var VariantCurationHub = React.createClass({
             ext_clinvarInterpretationSummary: null,
             ext_myGeneInfo_MyVariant: null,
             ext_myGeneInfo_VEP: null,
+            ext_myGeneInfo_ClinVar: null,
             ext_ensemblGeneId: null,
             ext_geneSynonyms: null,
             ext_singleNucleotide: true,
@@ -123,6 +124,16 @@ var VariantCurationHub = React.createClass({
                         ext_clinvarInterpretationSummary: getClinvarInterpretations(xml),
                         loading_clinvarEutils: false
                     });
+                    // Last alternative to get gene id and symbol from ClinVar
+                    // for API call to mygene.info to retreive gene related data
+                    if (variantData.gene && variantData.gene.id) {
+                        let clinvar_gene_id = variantData.gene.id;
+                        let clinvar_gene_symbol = variantData.gene.symbol;
+                        this.fetchMyGeneInfo(clinvar_gene_symbol, clinvar_gene_id, 'ClinVar');
+                    } else {
+                        // If all else fails, quit trying...
+                        this.setState({loading_myGeneInfo: false});
+                    }
                     this.handleCodonEsearch(variantData);
                     let clinVarRCVs = getClinvarRCVs(xml);
                     return Promise.resolve(clinVarRCVs);
@@ -280,6 +291,8 @@ var VariantCurationHub = React.createClass({
     },
 
     // Method to parse Entrez gene symbol and id from myvariant.info
+    // Primary option to get gene id and symbol for making
+    // API call to mygene.info to retreive gene related data
     parseMyVariantInfo: function(myVariantInfo) {
         let geneSymbol, geneId;
         if (myVariantInfo) {
@@ -313,6 +326,8 @@ var VariantCurationHub = React.createClass({
     },
 
     // Method to parse Entrez gene symbol and id from VEP
+    // Secondary option to get gene id and symbol for making
+    // API call to mygene.info to retreive gene related data
     parseEnsemblHgvsVEP: function(ensemblHgvsVEP) {
         let geneSymbol, geneId;
         if (ensemblHgvsVEP) {
@@ -343,6 +358,8 @@ var VariantCurationHub = React.createClass({
                     this.setState({ext_myGeneInfo_MyVariant: geneObj});
                 } else if (source === 'ensemblHgvsVEP') {
                     this.setState({ext_myGeneInfo_VEP: geneObj});
+                } else if (source === 'ClinVar') {
+                    this.setState({ext_myGeneInfo_ClinVar: geneObj});
                 }
                 this.setState({loading_myGeneInfo: false});
             }).catch(err => {
@@ -417,6 +434,7 @@ var VariantCurationHub = React.createClass({
         var session = (this.props.session && Object.keys(this.props.session).length) ? this.props.session : null;
         var selectedTab = this.state.selectedTab;
         let calculated_pathogenicity = (this.state.calculated_pathogenicity) ? this.state.calculated_pathogenicity : (this.state.autoClassification ? this.state.autoClassification : null);
+        let my_gene_info = (this.state.ext_myGeneInfo_MyVariant) ? this.state.ext_myGeneInfo_MyVariant : (this.state.ext_myGeneInfo_VEP ? this.state.ext_myGeneInfo_VEP : this.state.ext_myGeneInfo_ClinVar);
 
         return (
             <div>
@@ -430,7 +448,7 @@ var VariantCurationHub = React.createClass({
                             href_url={this.props.href} updateInterpretationObj={this.updateInterpretationObj} />
                         <VariantCurationInterpretation variantData={variantData} interpretation={interpretation} editKey={editKey} session={session}
                             href_url={this.props.href_url} updateInterpretationObj={this.updateInterpretationObj} getSelectedTab={this.getSelectedTab}
-                            ext_myGeneInfo={(this.state.ext_myGeneInfo_MyVariant) ? this.state.ext_myGeneInfo_MyVariant : this.state.ext_myGeneInfo_VEP}
+                            ext_myGeneInfo={my_gene_info}
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
                             ext_bustamante={this.state.ext_bustamante}
                             ext_ensemblVariation={this.state.ext_ensemblVariation}

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -174,7 +174,13 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                                 </dl>
                                 <dl className="inline-dl clearfix">
                                     <dt>Ensembl:</dt>
-                                    <dd><a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a></dd>
+                                    <dd>
+                                        {ensemblGeneId ?
+                                            <a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a>
+                                            :
+                                            <a href="http://ensembl.org" target="_blank">Search Ensembl <i className="icon icon-external-link"></i></a>
+                                        }
+                                    </dd>
                                 </dl>
                                 <dl className="inline-dl clearfix">
                                     <dt>GeneCards:</dt>

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -127,9 +127,16 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset, molecularCons
     }
     // Parse <gene> node
     var geneList = dataset.getElementsByTagName('GeneList')[0];
-    var geneNode = geneList.getElementsByTagName('Gene')[0];
-    variant.gene.symbol = geneNode.getAttribute('Symbol');
-    variant.gene.full_name = geneNode.getAttribute('FullName');
+    if (geneList) {
+        var geneNode = geneList.getElementsByTagName('Gene')[0];
+        if (geneNode) {
+            variant.gene.id = geneNode.getAttribute('GeneID');
+            variant.gene.symbol = geneNode.getAttribute('Symbol');
+            variant.gene.full_name = geneNode.getAttribute('FullName');
+            variant.gene.hgnc_id = geneNode.getAttribute('HGNCID');
+        }
+    }
+
     // Evaluate whether a variant has protein change
     // First check whether te <ProteinChange> node exists. If not,
     // then check whether the <HGVS> node with Type="HGVS, protein, RefSeq" attribute exists


### PR DESCRIPTION
**Technical notes:**
1. ClinVar IDs that don't have GRCh37 and GRCh38 hgvs terms would cause the display of content on the Gene-centric tab to stall because it is dependent on the returned data from myvariant.info and/or VEP.
2. ClinVar IDs that don't have any gene related metadata would cause the display of ClinVar RCV table to stall because the parser fails to evaluate the condition of missing `GeneList` node in the returned XML data.

**Steps to test:**
1. Login and use 91723 or 208846 variation id.
2. Proceed to the **Basic Info** tab and expect to see data being displayed in the **ClinVar Interpretation and Supporting Records** table.
3. Proceed to the **Gene-centric** tab. Expect to see data being displayed and the activity indicators are no longer stalled.
4. Return to the variation selection interface and use 65527 or 65922 variant id.
5. Proceed to the **Basic Info** tab and expect to see data being displayed in the **ClinVar Interpretation and Supporting Records** table.
6. Proceed to the **Gene-centric** tab. Expect to see **no** data being displayed and the activity indicators are no longer stalled.