### PR TITLE
Connects to #1043. Landing page CSS fix.

### DIFF
--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2236,7 +2236,7 @@ dl.inline-dl {
         border: solid 1px #ddd;
         border-radius: 4px;
         padding: 10px 35px 20px 35px;
-        height: 325px;
+        min-height: 325px;
     }
 }
 


### PR DESCRIPTION
**Technical note:**
Quick patch to adjust landing page bottom 2 panel border box height so that they extend to enclose content within smaller window width.

**Known issue:**
Due to time constraint, the boxes of 2 bottom panels are not in equal height when in smaller window width. Will address it in the next release.

**Steps to test:**
1. Go to landing page and try various smaller window width.
2. Expect to see the border boxes of bottom 2 panels to extend to enclose their content.