### PR TITLE
Connects to #1046. Gene-centric tab stalls on missing uniprot data.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -197,7 +197,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                     <div className="panel-heading"><h3 className="panel-title">Protein Resources</h3></div>
                     <div className="panel-content-wrapper">
                         {this.state.loading_myGeneInfo ? showActivityIndicator('Retrieving data... ') : null}
-                        {(myGeneInfo && myGeneInfo.uniprot['Swiss-Prot']) ?
+                        {(myGeneInfo && myGeneInfo.uniprot && myGeneInfo.uniprot['Swiss-Prot']) ?
                             <div className="panel-body">
                                 <dl className="inline-dl clearfix">
                                     <dt>UniProtKB:</dt>


### PR DESCRIPTION
**Technical note:**
Added condition to prevent Gene-centric tab to stall when uniprot data is absence in mygene.info response.

**Steps to test:**
1. Login and use 10505 variant_id.
2. Proceed to the **Basic Info** tab and then click through other tabs all the way to the **Gene-centric** tab.
3. Expect to see individual tabs dispalying their own content and none of them is stalled or hung.