### PR TITLE
Connects to #1052. Summary page component code update.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -36,8 +36,8 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
 
     componentDidMount: function() {
         if (this.props.interpretation && this.props.calculatedAssertion) {
-            // FIXME: Figure out why this is needed while the same method is already invoked
-            // in the componentWillReceiveProps lifecycle method
+            // Uncheck pre-existing marked provisional checkbox and disable it if needed,
+            // given the calculated/modified pathogenicity
             this.handleProvisionalCheckBox(this.state.provisionalPathogenicity);
             // Reset form values to last saved values
             let interpretation = this.props.interpretation;
@@ -77,9 +77,6 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                 this.refs['provisional-reason'].setValue(this.state.provisionalReason);
             }
         });
-        // FIXME: Figure out why this is needed while the same method is already invoked
-        // in the componentDidMount lifecycle method
-        this.handleProvisionalCheckBox(this.state.provisionalPathogenicity, true);
     },
 
     // Method to construct mode of inheritance linkout
@@ -104,8 +101,10 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         }
     },
 
-    // Method to set provisional checkbox state given the modified or calculated pathogenicity
-    handleProvisionalCheckBox: function(pathogenicity, reset) {
+    // Method to set the boolean value to the 'markAsProvisional' property
+    // in the event in which the associated disease is deleted while either
+    // the calculated or modified pathogenicity are 'Likely Pathogenic' or 'Pathogenic'
+    handleProvisionalCheckBox: function(pathogenicity) {
         if (!this.props.interpretation.disease) {
             let assertion = this.props.calculatedAssertion;
             if (assertion === 'Likely pathogenic' || assertion === 'Pathogenic') {
@@ -116,49 +115,18 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                 } else {
                     this.props.setProvisionalEvaluation('provisional-interpretation', false);
                     this.setState({disabledCheckbox: true});
-                    // In addition to uncheck pre-existing marked provisional checkbox and disable it,
-                    // also reset provision ('markAsProvisional') in db
-                    if (reset) {
-                        this.handleProvisionReset();
-                    }
                 }
             } else {
                 if(pathogenicity === 'Likely pathogenic' ||
                    pathogenicity === 'Pathogenic') {
                     this.props.setProvisionalEvaluation('provisional-interpretation', false);
                     this.setState({disabledCheckbox: true});
-                    // In addition to uncheck pre-existing marked provisional checkbox and disable it,
-                    // also reset provision ('markAsProvisional') in db
-                    if (reset) {
-                        this.handleProvisionReset();
-                    }
                 } else {
                     this.setState({disabledCheckbox: false});
                 }
             }
         } else {
             this.setState({disabledCheckbox: false});
-        }
-    },
-
-    // Method to set a false boolean value to the 'markAsProvisional' property
-    // in the event in which the associated disease is deleted while either
-    // the calculated or modified pathogenicity are 'Likely Pathogenic' or 'Pathogenic'
-    // FIXME: Hacky and single use case
-    handleProvisionReset: function() {
-        const interpretation = this.state.interpretation;
-        const provisionalInterpretation = this.state.provisionalInterpretation;
-        if (interpretation && interpretation.markAsProvisional) {
-            // Flattened interpretation object
-            let flatInterpretationObj = curator.flatten(interpretation);
-            // Set 'markAsProvisional' property value in the flatten interpretation object
-            flatInterpretationObj.markAsProvisional = false;
-            // Update the interpretation object with a false boolean checkbox value
-            this.putRestData('/interpretation/' + interpretation.uuid, flatInterpretationObj).then(obj => {
-                this.props.updateInterpretationObj();
-            }).catch(err => {
-                console.log(err);
-            });
         }
     },
 


### PR DESCRIPTION
**Technical notes:**
In **R7**, `handleProvisionReset()` method and `this.handleProvisionalCheckBox()` method invocation (in the `componentWillReceiveProps` lifecycle method) were added in the **Summary** page component to reset the `markAsProvisional` field in the `interpretation` object when an associated disease is deleted given the modified/calculated pathogenicity being either **Likely pathogenic** or **Pathogenic**.

Given the changes made later in #1036, the method and handling described above are no longer needed.

**Steps to test:**
1. Login and use 15333 variant_id at the variation selection interface.
2. Start a new interpretation. Evaluate various criteria so that the calculated pathogenicity is either "Likely pathogenic" or "Pathogenic". And add an associated disease.
3. Proceed to the **Summary** page. Check the provisional checkbox and **Save** the form. Notice that the provisional status being updated to "Provisional".
4. Return to interpretation and delete the associated disease. Upon closing the modal, expect to see the provisional status in the static green header being updated to "In Progress".
5. Proceed to the **Summary** page and expect to see the provisional status being updated to "In Progress" as well. Also expect to see the provisional checkbox having been _unchecked_ and disabled.
6. Select either "Likely pathogenic" or "Pathogenic" from the **Modify Pathogenicity** dropdown. **Save** the form and return to interpretation.
7. Add a disease and change the calculated pathogenicity to be neither "Likely pathogenic" nor "Pathogenic".
8. Proceed to summary page and check the provisional checkbox. **Save** the form. Notice that the provisional status being updated to "Provisional".
9. Return to interpretation and delete the associated disease. Upon closing the modal, expect to see the provisional status in the static green header again being updated to "In Progress".