### PR TITLE
Connects to #1054. ClinVar variant missing HGVS metadata

### DIFF
--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -103,25 +103,27 @@ function parseClinvarExtended(variant, allele, hgvs_list, dataset, molecularCons
         }
     }
     // Parse <HGVS> nodes
-    var HGVSnodes = hgvs_list.getElementsByTagName('HGVS');
-    if (HGVSnodes) {
-        for (let x of HGVSnodes) {
-            // Used for transcript tables on "Basic Information" tab in VCI
-            // Type property for identifying the nucleotide change transcripts
-            // and protein change transcripts
-            var hgvsObj = {
-                "HGVS": x.textContent,
-                "Change": x.getAttribute('Change'),
-                "AccessionVersion": x.getAttribute('AccessionVersion'),
-                "Type": x.getAttribute('Type')
-            };
-            // nucleotide change
-            if (x.getAttribute('Type') === 'HGVS, coding, RefSeq') {
-                variant.RefSeqTranscripts.NucleotideChangeList.push(hgvsObj);
-            }
-            // protein change
-            if (x.getAttribute('Type') === 'HGVS, protein, RefSeq') {
-                variant.RefSeqTranscripts.ProteinChangeList.push(hgvsObj);
+    if (hgvs_list) {
+        var HGVSnodes = hgvs_list.getElementsByTagName('HGVS');
+        if (HGVSnodes) {
+            for (let x of HGVSnodes) {
+                // Used for transcript tables on "Basic Information" tab in VCI
+                // Type property for identifying the nucleotide change transcripts
+                // and protein change transcripts
+                var hgvsObj = {
+                    "HGVS": x.textContent,
+                    "Change": x.getAttribute('Change'),
+                    "AccessionVersion": x.getAttribute('AccessionVersion'),
+                    "Type": x.getAttribute('Type')
+                };
+                // nucleotide change
+                if (x.getAttribute('Type') === 'HGVS, coding, RefSeq') {
+                    variant.RefSeqTranscripts.NucleotideChangeList.push(hgvsObj);
+                }
+                // protein change
+                if (x.getAttribute('Type') === 'HGVS, protein, RefSeq') {
+                    variant.RefSeqTranscripts.ProteinChangeList.push(hgvsObj);
+                }
             }
         }
     }


### PR DESCRIPTION
**Technical notes:**
Added conditional statement in the `parseClinvarExtended()` method in the `parse-resources.js` file to evaluate the existence of HGVS metadata in the returned ClinVar variant response. Currently, such ClinVar variants would cause the the fetching process to fail and thus stall other scripts to execute.

**Steps to test:**
1. Login and use 242361 or 243041 at the variation selection interface.
2. Proceed to the **Basic Info** tab. Expect to see RCV data being displayed in the **ClinVar Interpretation and Supporting Records** table.