### PR TITLE
Connects to #1049. CSS styling fixes.

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -565,18 +565,18 @@ function clinvarQueryResource() {
 }
 function clinvarRenderResourceResult() {
     return(
-        <div>
+        <div className="resource-metadata">
             <span className="p-break">{this.state.tempResource.clinvarVariantTitle}</span>
             {this.state.tempResource && this.state.tempResource.hgvsNames ?
                 <div className="row">
                     <div className="row">
-                        <span className="col-sm-5 col-md-3 control-label"><label>ClinVar Variant ID</label></span>
-                        <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                        <span className="col-xs-4 col-md-4 control-label"><label>ClinVar Variant ID</label></span>
+                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
                     </div>
                     {this.state.tempResource.hgvsNames ?
                         <div className="row">
-                            <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>
-                            <span className="col-sm-7 col-md-9 text-no-input">
+                            <span className="col-xs-4 col-md-4 control-label"><label>HGVS terms</label></span>
+                            <span className="col-xs-8 col-md-8 text-no-input">
                                 {variantHgvsRender(this.state.tempResource.hgvsNames)}
                             </span>
                         </div>

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2232,18 +2232,6 @@ dl.inline-dl {
         }
     }
 
-    @media screen and (min-width: $screen-sm-min) {
-        .row:not(:first-child) {
-            display: table;
-
-            .col-sm-6 {
-                display: table-cell;
-                float: none;
-                vertical-align: top;
-            }
-        }
-    }
-
     .col-sm-6 {
         margin-bottom: 30px;
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2232,11 +2232,38 @@ dl.inline-dl {
         }
     }
 
-    .col-sm-6 .promo {
-        border: solid 1px #ddd;
-        border-radius: 4px;
-        padding: 10px 35px 20px 35px;
-        min-height: 325px;
+    @media screen and (min-width: $screen-sm-min) {
+        .row:not(:first-child) {
+            display: table;
+
+            .col-sm-6 {
+                display: table-cell;
+                float: none;
+                vertical-align: top;
+            }
+        }
+    }
+
+    .col-sm-6 {
+        margin-bottom: 30px;
+
+        .promo {
+            border: solid 1px #ddd;
+            border-radius: 4px;
+            padding: 10px 35px 20px 35px;
+
+            @media screen and (min-width: $screen-lg-min) {
+                min-height: 325px;
+            }
+
+            @media screen and (min-width: $screen-md-min) and (max-width: $screen-lg-min) {
+                min-height: 395px;
+            }
+
+            @media screen and (min-width: $screen-sm-min) and (max-width: $screen-md-min) {
+                min-height: 416px;
+            }
+        }
     }
 }
 
@@ -2270,6 +2297,33 @@ table.login-users-interpretations {
 
             span.no-broken-item {
                 display: inline-block;
+            }
+        }
+    }
+}
+
+.form-variant-select {
+    .resource-metadata {
+        &>.row {
+            margin-left: 12px;
+            margin-right: 12px;
+
+            .row {
+                margin-bottom: 5px;
+
+                .control-label {
+                    padding-right: 10px;
+                }
+
+                .text-no-input {
+                    padding-left: 10px;
+                }
+
+                @media screen and (max-width: $screen-sm-min) {
+                    .text-no-input {
+                        padding-top: 0;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Steps to test -- landing page:**
1. Go to landing page and try various browser window widths.
2. Expect to see the 2 bottom panels' border boxes are in equal height until the 2 panels stack within the mobile viewport width.

**Steps to test -- variation selection modal:**
1. Login and use 55602 variant_id to retrieve variant metadata for the display in the modal.
2. Try various browser window widths and expect to see the display of variant metadata in the selection modal to be consistently having the labels on the left and the metadata on the right. And no text would be clipped within the mobile viewport width.