### PR TITLE
Connects to #1073. VCI UI bugs.

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -728,24 +728,24 @@ function carQueryResource() {
 }
 function carRenderResourceResult() {
     return(
-        <div>
+        <div className="resource-metadata">
             <span className="p-break">{this.state.tempResource.clinvarVariantTitle}</span>
             {this.state.tempResource && this.state.tempResource.hgvsNames ?
                 <div className="row">
                     <div className="row">
-                        <span className="col-sm-5 col-md-3 control-label"><label>CA ID</label></span>
-                        <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong> <i className="icon icon-external-link"></i></a></span>
+                        <span className="col-xs-4 col-md-4 control-label"><label>CA ID</label></span>
+                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong> <i className="icon icon-external-link"></i></a></span>
                     </div>
                     {this.state.tempResource.clinvarVariantId ?
                         <div className="row">
-                            <span className="col-sm-5 col-md-3 control-label"><label>ClinVar Variant ID</label></span>
-                            <span className="col-sm-7 col-md-9 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                            <span className="col-xs-4 col-md-4 control-label"><label>ClinVar Variant ID</label></span>
+                            <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
                         </div>
                     : null}
                     {this.state.tempResource.hgvsNames ?
                         <div className="row">
-                            <span className="col-sm-5 col-md-3 control-label"><label>HGVS terms</label></span>
-                            <span className="col-sm-7 col-md-9 text-no-input">
+                            <span className="col-xs-4 col-md-4 control-label"><label>HGVS terms</label></span>
+                            <span className="col-xs-8 col-md-8 text-no-input">
                                 {variantHgvsRender(this.state.tempResource.hgvsNames)}
                             </span>
                         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -648,7 +648,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         } else {
             return (
                 <h3 className="panel-title">1000 Genomes
-                    <a href="#credit-vep" className="label label-primary">VEP</a>
+                    <a href="#credit-vep" className="credit-vep" title="VEP"><span>VEP</span></a>
                 </h3>
             );
         }


### PR DESCRIPTION
**Steps to test -- variation selection modal:**
1. Login and use **CA003323** CAR id to retrieve variant metadata for the display in the modal.
2. Try various browser window widths and expect to see the display of variant metadata in the selection modal to be consistently having the labels on the left and the metadata on the right. And no text would be clipped within the mobile viewport width.

**Steps to test -- VEP attribution icon:**
1. Login and use **37644** for selecting the variant.
2. Proceed to the **Population** tab and expect to see the **Ve!P** icon replacing the **VEP** label in the header of the **1000 Genomes** table, even when there is population data displayed in the table.