### PR TITLE
Connects to #1098 kl bug caid

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -667,7 +667,7 @@ function carValidateForm() {
     var formInput = this.getFormValue('resourceId');
 
     // valid if the input begins with 'CA', followed by 6 numbers
-    if (valid && !formInput.match(/^CA[0-9]{6}$/)) {
+    if (valid && !formInput.match(/^CA[0-9]+$/)) {
         valid = false;
         this.setFormErrors('resourceId', 'Invalid CA ID');
     }


### PR DESCRIPTION
This PR fixes a bug that CA id must have 6 digits only, ticket #1098. It's fixed by editing a pattern (line 670) in function `carValidateForm` in file `/src/clincoded/static/components/add_external_resource.js`.

**Test**
* Start VCI
* Select `ClinGen Allele Registry ID (CAID)'`, enter "CA10575430" and expect to see
![screen shot 2016-10-27 at 11 27 35 am](https://cloud.githubusercontent.com/assets/9206696/19782424/ad9a53de-9c42-11e6-90d9-f692c95be6b1.png)

**End of Test**