### PR TITLE
Connects to #1076 kd selenium

### DIFF
--- a/src/clincoded/static/components/mixins.js
+++ b/src/clincoded/static/components/mixins.js
@@ -184,8 +184,8 @@ module.exports.Auth0 = {
                 },
                 body: JSON.stringify({
                     "client_id":   "fucNqQ1x5rSFOjXNqtm0NWzzxG1g1xVs", // AUTH0: CLIENT ID
-                    "username":    "clingen.test.curator@genome.stanford.edu", // AUTH0: TEST CURATOR CREDENTIALS
-                    "password":    "curateme",
+                    "username":    "clingen.demo.curator@genome.stanford.edu", // AUTH0: TEST CURATOR CREDENTIALS
+                    "password":    "CLSZ6lJhOAhYBZRgGx5%BdkfgwRt%LnY)EXT",
                     "id_token":    "",
                     "connection":  "Username-Password-Authentication",
                     "grant_type":  "password",

--- a/src/clincoded/tests/data/inserts/user.json
+++ b/src/clincoded/tests/data/inserts/user.json
@@ -1975,5 +1975,20 @@
             "/labs/curator/"
         ],
         "timezone": "US/Pacific"
+    },
+    {
+        "email": "clingen.demo.curator@genome.stanford.edu",
+        "first_name": "ClinGen",
+        "last_name": "Test Curator",
+        "uuid": "7b112e8d-4e72-4336-b789-f7c0b241da01",
+        "groups": [
+            "curator"
+        ],
+        "job_title": "ClinGen Curator",
+        "lab": "/labs/curator/",
+        "submits_for": [
+            "/labs/curator/"
+        ],
+        "timezone": "US/Pacific"
     }
 ]

--- a/src/clincoded/tests/features/browsersteps.py
+++ b/src/clincoded/tests/features/browsersteps.py
@@ -183,6 +183,18 @@ def i_clear_field(browser, name):
     el.clear()
 
 
+@when(parse('I fill in the css element field "{css}" with "{value}"'))
+def i_fill_in_field(browser, css, value):
+    browser.find_by_css(css).fill(value)
+
+
+@when(parse('I clear field the css element field "{css}"'))
+def i_clear_field(browser, css):
+    el = browser.find_by_css(css)
+    assert el, 'Element not found'
+    el.clear()
+
+
 @when(parse('I type "{value}" to "{name}"'))
 def i_type_to(browser, name, value):
     for key in browser.type(name, value, slowly=True):
@@ -244,6 +256,7 @@ def i_press(browser, name):
         ("//*[@id='%(name)s']|"
          "//*[@name='%(name)s']|"
          "//button[contains(text(), '%(name)s')]|"
+         "//span[contains(text(), '%(name)s')]|"
          "//a[contains(text(), '%(name)s')]") % {'name': name})
     assert element, u'Element not found'
     element.first.click()

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -1,0 +1,16 @@
+@select-variant @usefixtures(workbook,admin_user)
+Feature: Select Variant
+
+    Scenario: VCI functional
+        When I visit "/select-variant/"
+        Then I should see "Search and Select Variant"
+        When I wait for 1 seconds
+        And I select "ClinVar Variation ID" from dropdown "form-control"
+        And I wait for 1 seconds
+        And I press "Add ClinVar ID"
+        And I wait for an element with the css selector "body.demo-background.modal-open" to load
+        Then I should see "Enter ClinVar VariationID"
+        # When I fill in "form-control" with "123"
+        # And I press "Retrieve from ClinVar"
+        # And I wait for 10 seconds
+        # Then I should see "p.Lys384Glu"

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -1,16 +1,37 @@
 @select-variant @usefixtures(workbook,admin_user)
 Feature: Select Variant
 
-    Scenario: VCI functional
+    Scenario: VCI select-variant modal ClinVar functionality
         When I visit "/select-variant/"
         Then I should see "Search and Select Variant"
         When I wait for 1 seconds
         And I select "ClinVar Variation ID" from dropdown "form-control"
         And I wait for 1 seconds
         And I press "Add ClinVar ID"
-        And I wait for an element with the css selector "body.demo-background.modal-open" to load
+        And I wait for an element with the css selector ".modal-open" to load
         Then I should see "Enter ClinVar VariationID"
-        # When I fill in "form-control" with "123"
-        # And I press "Retrieve from ClinVar"
-        # And I wait for 10 seconds
-        # Then I should see "p.Lys384Glu"
+        When I fill in the css element field "input.form-control" with "123"
+        When I press "Retrieve from ClinVar"
+        Then I should see an element with the css selector ".resource-metadata" within 30 seconds
+        Then I should see "p.Lys384Glu"
+        When I clear field the css element field "input.form-control"
+        When I fill in the css element field "input.form-control" with "139214"
+        When I press "Retrieve from ClinVar"
+        Then I should see an element with the css selector ".resource-metadata" within 30 seconds
+        Then I should see "NC_000015"
+
+    Scenario: VCI select-variant modal CAR functionality
+        When I visit "/select-variant/"
+        Then I should see "Search and Select Variant"
+        When I wait for 1 seconds
+        And I select "ClinGen Allele Registry ID (CA ID)" from dropdown "form-control"
+        And I wait for 1 seconds
+        And I press "Add CA ID"
+        And I wait for an element with the css selector ".modal-open" to load
+        Then I should see "Enter CA ID"
+        When I fill in the css element field "input.form-control" with "CA003323"
+        When I press "Retrieve from ClinGen Allele Registry"
+        Then I should see an element with the css selector ".resource-metadata" within 30 seconds
+        Then I should see "BRCA1"
+        Then I should see "37644"
+

--- a/src/clincoded/tests/features/test_generics.py
+++ b/src/clincoded/tests/features/test_generics.py
@@ -13,6 +13,7 @@ pytestmark = [
 
 scenarios(
     'title.feature',
+    'select_variant.feature',
     'generics.feature',
     'create_gene_disease.feature',
     'curation_central.feature',


### PR DESCRIPTION
Adds some BDD tests for the select-variant page, and changed the demo login.

To run tests:
`bin/test -m bdd -v -v`
(all bdd tests should run normally...checks the ClinVar and CAR API on the select-variant page)

To test login, click on the "Demo Login" from nav bar.
(logs in as usual)
