### PR TITLE
Connects to #1093. GCI family and individual pages.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2037,7 +2037,7 @@ var renderPhenotype = module.exports.renderPhenotype = function(objList, title, 
 var renderMutalyzerLink = module.exports.renderMutalyzerLink = function() {
     return (
         <p className="col-sm-7 col-sm-offset-5 mutalyzer-link">
-            (e.g. HGVS, RCV, rs ID)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer</a>.
+            (e.g. CA ID whenever possible; otherwise RCV, rs ID, or HGVS)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer <i className="icon icon-external-link"></i></a>.
         </p>
     );
 };

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2037,7 +2037,7 @@ var renderPhenotype = module.exports.renderPhenotype = function(objList, title, 
 var renderMutalyzerLink = module.exports.renderMutalyzerLink = function() {
     return (
         <p className="col-sm-7 col-sm-offset-5 mutalyzer-link">
-            (e.g. CA ID whenever possible; otherwise RCV, rs ID, or HGVS)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer <i className="icon icon-external-link"></i></a>.
+            (e.g. CA ID whenever possible; otherwise RCV, rs ID, or HGVS)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer <i className="icon icon-external-link"></i></a>
         </p>
     );
 };

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2172,7 +2172,7 @@ var FamilyViewer = React.createClass({
                         <Panel title="Family - Variant(s) Segregating with Proband" panelClassName="panel-data">
                             {variants.map(function(variant, i) {
                                 return (
-                                    <div className="variant-view-panel" key={variant.uuid}>
+                                    <div className="variant-view-panel" key={variant.uuid ? variant.uuid : i}>
                                         <h5>Variant {i + 1}</h5>
                                         {variant.clinvarVariantId ?
                                             <div>
@@ -2198,12 +2198,20 @@ var FamilyViewer = React.createClass({
                                                 </dl>
                                             </div>
                                         : null }
-                                        {family.individualIncluded && family.individualIncluded[0].recessiveZygosity && i === 0 ?
+                                        {family.individualIncluded && family.individualIncluded.length && i === 0 ?
                                             <div>
-                                                <dl className="dl-horizontal">
-                                                    <dt>If Recessive, select variant zygosity</dt>
-                                                    <dd>{family.individualIncluded[0].recessiveZygosity}</dd>
-                                                </dl>
+                                                {family.individualIncluded.map(function(ind, index) {
+                                                    return (
+                                                        <div key={index}>
+                                                            {ind.proband && ind.recessiveZygosity ?
+                                                                <dl className="dl-horizontal">
+                                                                    <dt>If Recessive, select variant zygosity</dt>
+                                                                    <dd>{ind.recessiveZygosity}</dd>
+                                                                </dl>
+                                                            : null}
+                                                        </div>
+                                                    );
+                                                })}
                                             </div>
                                         : null }
                                     </div>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1605,13 +1605,13 @@ var FamilySegregation = function() {
     return (
         <div className="row section section-family-segregation">
             <h3><i className="icon icon-chevron-right"></i> Tested Individuals</h3>
-            <Input type="number" ref="SEGnumberOfAffectedWithGenotype" label={<span><strong>For Dominant AND Recessive:</strong><br/>Number of AFFECTED individuals <i>WITH</i> genotype?</span>}
+            <Input type="number" yesInteger={true} ref="SEGnumberOfAffectedWithGenotype" label={<span><strong>For Dominant AND Recessive:</strong><br/>Number of AFFECTED individuals <i>WITH</i> genotype?</span>}
                 value={segregation.numberOfAffectedWithGenotype} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfAffectedWithGenotype')}
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfAffectedWithGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" required />
-            <Input type="number" ref="SEGnumberOfUnaffectedWithoutBiallelicGenotype" label={<span><strong>For Recessive Only:</strong><br/>Number of UNAFFECTED individuals <i>WITHOUT</i> the biallelic genotype? (required for recessive)</span>}
+            <Input type="number" yesInteger={true} ref="SEGnumberOfUnaffectedWithoutBiallelicGenotype" label={<span><strong>For Recessive Only:</strong><br/>Number of UNAFFECTED individuals <i>WITHOUT</i> the biallelic genotype? (required for recessive)</span>}
                 value={segregation.numberOfUnaffectedWithoutBiallelicGenotype} minVal={2} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfUnaffectedWithoutBiallelicGenotype')}
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfUnaffectedWithoutBiallelicGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
-            <Input type="number" ref="SEGnumberOfSegregationsForThisFamily" label="Number of segregations reported for this Family:"
+            <Input type="number" yesInteger={true} ref="SEGnumberOfSegregationsForThisFamily" label="Number of segregations reported for this Family:"
                 value={segregation.numberOfSegregationsForThisFamily} handleChange={this.handleChange}
                 error={this.getFormError('SEGnumberOfSegregationsForThisFamily')} clearError={this.clrFormErrors.bind(null, 'SEGnumberOfSegregationsForThisFamily')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
@@ -1809,7 +1809,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelOtherVariant = React.createClass({
     render: function() {
-        return <span>Other description <span className="normal">(only when ClinVar VariationID is not available):</span></span>;
+        return <span>Other description when a ClinVar VariationID does not exist <span className="normal">(important: use CA ID registered with <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> whenever possible)</span>:</span>;
     }
 });
 

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -93,12 +93,12 @@ var SelectVariant = React.createClass({
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />
                                         <ol className="instructions">
-                                            <li>Search <a href={external_url_map['ClinVar']} target="_blank">ClinVar</a> for variant.</li>
+                                            <li>Search <a href={external_url_map['ClinVar']} target="_blank">ClinVar <i className="icon icon-external-link"></i></a> for variant.</li>
                                             <li>If found in ClinVar, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                            <li>If not found in ClinVar, search the <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> with a valid HGVS term for that variant.
+                                            <li>If not found in ClinVar, search the <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> with a valid HGVS term for that variant.
                                             <ol type="a">
-                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
+                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
+                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
                                             </ol>
                                             </li>
                                         </ol>


### PR DESCRIPTION
**Technical notes:**
1. Fixed a bug in which removing a variant of 2 from the family page does not trigger an update on the associated Proband's variant count (same for adding a variant on the family page).
2. Fixed a bug in which changing "Hemizygous" (or "Homozygous") to "No Selection" for zygosity does not trigger an update in the Proband's current zygosity field.

**Known issue:**
1. On the family view page, in the **Family - Variant(s) Segregating with Proband** panel, we seemingly only show variants associated with a Proband. If no Proband in the family, the declared `variants` variable defaults to `[{}]` which always has count of 1, regardless of the absence of object keys. As a result, the rendering would still display the header (which can also be seen in curation-test instance). Need to revisit this later to improve the implementation logic and possibly the business logic as well.

**Steps to test:**
1. Login and add a new PMID from a new or pre-existing GDM.
2. Add a new family. Saving the form by filling out only the **required** fields, but PLEASE add 2 variants and associate them with a Proband.
3. Edit the family page by removing a variant (e.g. select "Hemizygous") and return to the Curation-Central page. Expect to see the variant count under the associated Proband also equals to 1 in the Curation Palette.
4. Edit the family page by changing the zygosity selection to "No Selection" and save the form. Return to family edit and expect to see the zygosity selection remains to be "No Selection".
5. While on the family edit page, enter decimal numbers to the either one of the first 3 questions in the Family Segregation panel. Save the form and expect to see error message below the form fields .
6. Delete the associated Proband and proceed to the family view page. Expect to see NO zygosity question displayed in the Family variant(s) panel.