### PR TITLE
Connects to #1132. Rework of landing page demo note implementation.

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -92,7 +92,8 @@ var App = module.exports = React.createClass({
             var ContentView = globals.content_views.lookup(context, current_action);
             content = <ContentView {...this.props} context={context} href={this.state.href}
                 loadingComplete={this.state.loadingComplete} session={this.state.session}
-                portal={this.state.portal} navigate={this.navigate} href_url={href_url} />;
+                portal={this.state.portal} navigate={this.navigate} href_url={href_url}
+                demoVersion={this.state.demoWarning} />;
         }
         var errors = this.state.errors.map(function (error) {
             return <div className="alert alert-error"></div>;

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -20,19 +20,13 @@ var SignIn = module.exports.SignIn = React.createClass({
 });
 
 var Home = module.exports.Home = React.createClass({
+    propTypes: {
+        demoVersion: React.PropTypes.bool
+    },
+
     getInitialState: function() {
-        var demoWarning = false;
-        var productionWarning = false;
-        if (/production.clinicalgenome.org/.test(url.parse(this.props.href).hostname)) {
-            // check if production URL. Enable productionWarning if it is.
-            productionWarning = true;
-        } else if (!/^(www\.)?curation.clinicalgenome.org/.test(url.parse(this.props.href).hostname)) {
-            // if neither production nor curation URL, enable demoWarning.
-            demoWarning = true;
-        }
         return {
-            demoWarning: demoWarning,
-            productionWarning: productionWarning
+            demoVersion: this.props.demoVersion
         };
     },
 
@@ -54,7 +48,7 @@ var Home = module.exports.Home = React.createClass({
                         </div>
                     </div>
                     <div className="row demo-access-note">
-                        {this.state.demoWarning ?
+                        {this.state.demoVersion ?
                             <div>Explore a demo version of the ClinGen interfaces by clicking on the "Demo Login" button located in the header above.</div>
                             :
                             <div>Explore a demo version of the ClinGen interfaces at <a href="https://curation-test.clinicalgenome.org/">curation-test.clinicalgenome.org <i className="icon icon-external-link"></i></a></div>


### PR DESCRIPTION
**Technical note:**
The code that sets the `demoWarning` state in the `home.js` (`Home` component) is a duplicate of `getInitialState` code block in the `app.js` (app level). Furthermore, the `demoWarning` state has already been set at the app level.

So, in this rework, the implementation is to pass the `demoWarning` state from the app level to the child `Home` component level so that the duplicate code can be removed.

Steps to test:
1) Add the following entries in the `/etc/hosts` file:

```
127.0.0.1    curation.clinicalgenome.org
127.0.0.1    curation-test.clinicalgenome.org
127.0.0.1    production.clinicalgenome.org
```

2) Go to **curation-test.clinicalgenome.org:6543** and expect to see the dark blue message in the light blue panel.
3) Go to **curation.clinicalgenome.org:6543** and expect to see the dark blue message in the light blue panel. Also expect to see a different message with an external link to the **curation-test.clinicalgenome.org** site.