### PR TITLE
Connects to #1135. No scoring option available to non-proband individuals.

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1740,7 +1740,7 @@ var FamilyVariant = function() {
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                             handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group other-variant-desc" />
                         {curator.renderMutalyzerLink()}
-                        {this.state.variantCount > 0 && i === 0 ?
+                        {this.state.variantInfo[i] && i === 0 ?
                             <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
                                 value={probandIndividual && probandIndividual.recessiveZygosity ? probandIndividual.recessiveZygosity : 'none'} handleChange={this.handleChange}
                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1740,7 +1740,7 @@ var FamilyVariant = function() {
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                             handleChange={this.handleChange} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group other-variant-desc" />
                         {curator.renderMutalyzerLink()}
-                        {this.state.variantInfo[i] && i === 0 ?
+                        {this.state.variantCount > 0 && i === 0 ?
                             <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
                                 value={probandIndividual && probandIndividual.recessiveZygosity ? probandIndividual.recessiveZygosity : 'none'} handleChange={this.handleChange}
                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1048,7 +1048,7 @@ var IndividualCuration = React.createClass({
                                                 {IndividualAdditional.call(this)}
                                             </Panel>
                                         </PanelGroup>
-                                        {this.state.proband || this.state.proband_selected ?
+                                        {(this.state.family && this.state.proband_selected) || (!this.state.family && this.state.proband_selected) ?
                                             <PanelGroup accordion>
                                                 <Panel title={<LabelPanelTitle individual={individual} labelText="Score Proband" />} open>
                                                     {IndividualScore.call(this)}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1511,7 +1511,7 @@ var IndividualVariantInfo = function() {
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}
-                                {this.state.variantInfo[i] && i === 0 ?
+                                {this.state.variantCount > 0 && i === 0 ?
                                     <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
                                         value={individual && individual.recessiveZygosity ? individual.recessiveZygosity : 'none'} handleChange={this.handleChange}
                                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1511,7 +1511,7 @@ var IndividualVariantInfo = function() {
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}
-                                {this.state.variantCount > 0 && i === 0 ?
+                                {this.state.variantInfo[i] && i === 0 ?
                                     <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
                                         value={individual && individual.recessiveZygosity ? individual.recessiveZygosity : 'none'} handleChange={this.handleChange}
                                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1911,14 +1911,17 @@ var IndividualViewer = React.createClass({
                             </dl>
                         </Panel>
 
-                        <Panel title={<LabelPanelTitleView individual={individual} labelText="Score Proband" />} panelClassName="panel-data">
-                            <dl className="dl-horizontal">
-                                <div>
-                                    <dt>Score Status</dt>
-                                    <dd>{scores && scores.length ? scores[0].scoreStatus : null}</dd>
-                                </div>
-                            </dl>
-                        </Panel>
+                        {(associatedFamily && individual.proband) || (!associatedFamily && individual.proband) ?
+                            <Panel title={<LabelPanelTitleView individual={individual} labelText="Score Proband" />} panelClassName="panel-data">
+                                <dl className="dl-horizontal">
+                                    <div>
+                                        <dt>Score Status</dt>
+                                        <dd>{scores && scores.length ? scores[0].scoreStatus : null}</dd>
+                                    </div>
+                                </dl>
+                            </Panel>
+                        : null}
+
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**Technical notes:**
The Proband scoring option/data should be only available to:
1. A Proband individual who is associated with a family.
2. An individual who is a Proband but not associated with a family.

**Steps to test:**
1. Login and add a new PMID from a new or pre-existing GDM.
2. Add a new family. Saving the form by filling out only the **required** fields, but PLEASE add at least 1 variant and associate it with a Proband individual.
3. On the intermediate page upon saving the family form page, proceed to adding a Non-Proband individual to the family.
4. On the Non-Proband individual form page, expect to see **NO** individual score panel being displayed at the bottom of the page.
5. Save the form page and return to the Curation-Central page. Click on the "Edit" link below the Proband individual associated with the family. On the Proband individual form page, expect to see the individual score panel being displayed at the bottom of the page.
6. Return to the Curation-Central page and add a new individual without an associated family. On the individual form page, by selecting the "Yes" option for the Proband question, expect to see the individual score panel being displayed at the bottom of the page. Also expect the see **NO** score panel being displayed if the selection is changed to either "No" or "No Selection" for the Proband question.
7. Upon saving the form page, return to the  Curation-Central page. Click on the "View" links of the various individuals (with or without family association). On the view pages, expect to see the score panel being displayed at the bottom of the page only for the Proband individuals (with or without family association).