### PR TITLE
Connects to #1145. Connects to #1109. Expand extra evidence functionality

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -187,7 +187,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                     : null}
                     {this.state.selectedTab == 'population' ?
                     <div role="tabpanel" className="tab-panel">
-                        <CurationInterpretationPopulation data={variant}
+                        <CurationInterpretationPopulation data={variant} href_url={this.props.href_url}
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -9,6 +9,7 @@ var findDiffKeyValuesMixin = require('./shared/find_diff').findDiffKeyValuesMixi
 var CompleteSection = require('./shared/complete_section').CompleteSection;
 var parseAndLogError = require('../../mixins').parseAndLogError;
 var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
+var extraEvidence = require('./shared/extra_evidence');
 
 var queryKeyValue = globals.queryKeyValue;
 var editQueryValue = globals.editQueryValue;
@@ -681,6 +682,15 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </thead>
                             </table>
                         </div>
+                        {(this.props.data && this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTable category="predictors" subcategory="functional-conservation-splicing-predictors"
+                                href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Functional, Conservation, and Splicing Predictors)</span>}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        : null}
+                        {(this.props.data && !this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="functional-conservation-splicing-predictors"
+                                tableName={<span>Curated Literature Evidence (Functional, Conservation, and Splicing Predictors)</span>} variant={this.props.data} />
+                        : null}
                     </Panel></PanelGroup>
 
                     <PanelGroup accordion><Panel title="Other Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
@@ -693,6 +703,15 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </div>
                             </div>
                         </div>
+                        {(this.props.data && this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTable category="predictors" subcategory="other-variants-in-codon"
+                                href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Other Variants in Same Codon)</span>}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        : null}
+                        {(this.props.data && !this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="other-variants-in-codon"
+                                tableName={<span>Curated Literature Evidence (Other Variants in Same Codon)</span>} variant={this.props.data} />
+                        : null}
                         {(this.props.data && this.state.interpretation) ?
                         <div className="row">
                             <div className="col-sm-12">
@@ -737,6 +756,15 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </thead>
                             </table>
                         </div>
+                        {(this.props.data && this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTable category="predictors" subcategory="null-variant-analysis"
+                                href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Null variant analysis)</span>}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        : null}
+                        {(this.props.data && !this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="null-variant-analysis"
+                                tableName={<span>Curated Literature Evidence (Null variant analysis)</span>} variant={this.props.data} />
+                        : null}
                     </Panel></PanelGroup>
                 </div>
                 : null}
@@ -850,6 +878,15 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </tfoot>
                             </table>
                         </div>
+                        {(this.props.data && this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTable category="predictors" subcategory="molecular-consequence-silent-intron"
+                                href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Molecular Consequence: Silent & Intron)</span>}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        : null}
+                        {(this.props.data && !this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="molecular-consequence-silent-intron"
+                                tableName={<span>Curated Literature Evidence (Molecular Consequence: Silent & Intron)</span>} variant={this.props.data} />
+                        : null}
                     </Panel></PanelGroup>
                 </div>
                 : null}
@@ -893,6 +930,15 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                 </dl>
                             </div>
                         </div>
+                        {(this.props.data && this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTable category="predictors" subcategory="molecular-consequence-inframe-indel"
+                                href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Molecular Consequence: Inframe indel)</span>}
+                                interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                        : null}
+                        {(this.props.data && !this.state.interpretation) ?
+                            <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="molecular-consequence-inframe-indel"
+                                tableName={<span>Curated Literature Evidence (Molecular Consequence: Inframe indel)</span>} variant={this.props.data} />
+                        : null}
                         {(this.props.data && this.state.interpretation) ?
                         <div className="row">
                             <div className="col-sm-12">

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -694,6 +694,16 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                     </Panel></PanelGroup>
 
                     <PanelGroup accordion><Panel title="Other Variants in Same Codon" panelBodyClassName="panel-wide-content" open>
+                        {(this.props.data && this.state.interpretation) ?
+                        <div className="row">
+                            <div className="col-sm-12">
+                                <CurationInterpretationForm renderedFormContent={criteriaMissense2} criteria={['PM5', 'PS1']}
+                                    evidenceData={null} evidenceDataUpdated={true}
+                                    formDataUpdater={criteriaMissense2Update} variantUuid={this.props.data['@id']}
+                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                            </div>
+                        </div>
+                        : null}
                         <div className="panel panel-info datasource-clinvar">
                             <div className="panel-heading"><h3 className="panel-title">ClinVar Variants</h3></div>
                             <div className="panel-content-wrapper">
@@ -711,16 +721,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         {(this.props.data && !this.state.interpretation) ?
                             <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="other-variants-in-codon"
                                 tableName={<span>Curated Literature Evidence (Other Variants in Same Codon)</span>} variant={this.props.data} />
-                        : null}
-                        {(this.props.data && this.state.interpretation) ?
-                        <div className="row">
-                            <div className="col-sm-12">
-                                <CurationInterpretationForm renderedFormContent={criteriaMissense2} criteria={['PM5', 'PS1']}
-                                    evidenceData={null} evidenceDataUpdated={true}
-                                    formDataUpdater={criteriaMissense2Update} variantUuid={this.props.data['@id']}
-                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                            </div>
-                        </div>
                         : null}
                     </Panel></PanelGroup>
                 </div>
@@ -893,6 +893,16 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 {this.state.selectedSubtab == 'indel' ?
                 <div role="tabpanel" className="tab-panel">
                     <PanelGroup accordion><Panel title="Molecular Consequence: Inframe indel" panelBodyClassName="panel-wide-content" open>
+                        {(this.props.data && this.state.interpretation) ?
+                        <div className="row">
+                            <div className="col-sm-12">
+                                <CurationInterpretationForm renderedFormContent={criteriaIndel1} criteria={['BP3', 'PM4']}
+                                    evidenceData={null} evidenceDataUpdated={true} criteriaCrossCheck={[['BP3', 'PM4']]}
+                                    formDataUpdater={criteriaIndel1Update} variantUuid={this.props.data['@id']} formChangeHandler={criteriaIndel1Change}
+                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                            </div>
+                        </div>
+                        : null}
                         <div className="panel panel-info">
                             <div className="panel-heading"><h3 className="panel-title">LinkOut to external resources</h3></div>
                             <div className="panel-body">
@@ -938,16 +948,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         {(this.props.data && !this.state.interpretation) ?
                             <extraEvidence.ExtraEvidenceTableViewAll category="predictors" subcategory="molecular-consequence-inframe-indel"
                                 tableName={<span>Curated Literature Evidence (Molecular Consequence: Inframe indel)</span>} variant={this.props.data} />
-                        : null}
-                        {(this.props.data && this.state.interpretation) ?
-                        <div className="row">
-                            <div className="col-sm-12">
-                                <CurationInterpretationForm renderedFormContent={criteriaIndel1} criteria={['BP3', 'PM4']}
-                                    evidenceData={null} evidenceDataUpdated={true} criteriaCrossCheck={[['BP3', 'PM4']]}
-                                    formDataUpdater={criteriaIndel1Update} variantUuid={this.props.data['@id']} formChangeHandler={criteriaIndel1Change}
-                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
-                            </div>
-                        </div>
                         : null}
                     </Panel></PanelGroup>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -57,6 +57,15 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                             </div>
                         </div>
                     : null}
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="experimental" subcategory="hotspot-functiona-domain"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Hotspot or functional domain)</span>}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="experimental" subcategory="hotspot-functiona-domain"
+                            tableName={<span>Curated Literature Evidence (Hotspot or functional domain)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
                 <PanelGroup accordion><Panel title="Experimental Studies" panelBodyClassName="panel-wide-content" open>
                     {(this.props.data && this.state.interpretation) ?

--- a/src/clincoded/static/components/variant_central/interpretation/functional.js
+++ b/src/clincoded/static/components/variant_central/interpretation/functional.js
@@ -74,6 +74,10 @@ var CurationInterpretationFunctional = module.exports.CurationInterpretationFunc
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Experimental Studies)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="experimental" subcategory="experimental-studies"
+                            tableName={<span>Curated Literature Evidence (Experimental Studies)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 {this.state.interpretation ?

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -11,6 +11,7 @@ var CompleteSection = require('./shared/complete_section').CompleteSection;
 var parseAndLogError = require('../../mixins').parseAndLogError;
 var parseClinvar = require('../../../libs/parse-resources').parseClinvar;
 var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
+var extraEvidence = require('./shared/extra_evidence');
 
 var external_url_map = globals.external_url_map;
 var dbxref_prefix_map = globals.dbxref_prefix_map;
@@ -58,7 +59,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         ext_ensemblVariation: React.PropTypes.object,
         ext_singleNucleotide: React.PropTypes.bool,
         loading_myVariantInfo: React.PropTypes.bool,
-        loading_ensemblVariation: React.PropTypes.bool
+        loading_ensemblVariation: React.PropTypes.bool,
+        href_url: React.PropTypes.object
     },
 
     getInitialState: function() {
@@ -857,6 +859,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             }
                         </div>
                     </div>
+
+                    {(this.props.data && this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTable category="population" subcategory="population"
+                            href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Population)</span>}
+                            interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="population" subcategory="population"
+                            tableName={<span>Curated Literature Evidence (Population)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 {this.state.interpretation ?

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -82,6 +82,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Case-control)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="case-control"
+                            tableName={<span>Curated Literature Evidence (Case-control)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Segregation data" panelBodyClassName="panel-wide-content" open>
@@ -99,6 +103,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="segreagtion-data"
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Segregation data)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="segreagtion-data"
+                            tableName={<span>Curated Literature Evidence (Segregation data)</span>} variant={this.props.data} />
                     : null}
                 </Panel></PanelGroup>
 
@@ -118,6 +126,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (<i>de novo</i> occurrence)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="de-novo"
+                            tableName={<span>Curated Literature Evidence (<i>de novo</i> occurrence)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title={<h4>Allele data (<i>cis/trans</i>)</h4>} panelBodyClassName="panel-wide-content" open>
@@ -135,6 +147,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="allele-data"
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Allele Data (<i>cis/trans</i>))</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="allele-data"
+                            tableName={<span>Curated Literature Evidence (Allele Data (<i>cis/trans</i>))</span>} variant={this.props.data} />
                     : null}
                 </Panel></PanelGroup>
 
@@ -154,6 +170,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Alternate mechanism for disease)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="alternate-mechanism"
+                            tableName={<span>Curated Literature Evidence (Alternate mechanism for disease)</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Specificity of phenotype" panelBodyClassName="panel-wide-content" open>
@@ -171,6 +191,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="specificity-of-phenotype"
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Specificity of phenotype)</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                    : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="specificity-of-phenotype"
+                            tableName={<span>Curated Literature Evidence (Specificity of phenotype)</span>} variant={this.props.data} />
                     : null}
                 </Panel></PanelGroup>
 

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -60,6 +60,10 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                             href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Observed in healthy adult(s))</span>}
                             interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     : null}
+                    {(this.props.data && !this.state.interpretation) ?
+                        <extraEvidence.ExtraEvidenceTableViewAll category="case-segregation" subcategory="observed-in-healthy"
+                            tableName={<span>Curated Literature Evidence (Observed in healthy adult(s))</span>} variant={this.props.data} />
+                    : null}
                 </Panel></PanelGroup>
 
                 <PanelGroup accordion><Panel title="Case-control" panelBodyClassName="panel-wide-content" open>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -402,7 +402,7 @@ var ExtraEvidenceTableViewAll = module.exports.ExtraEvidenceTableViewAll = React
                                 relevantEvidenceList.map(evidence => {
                                     return (this.renderInterpretationExtraEvidence(evidence));
                                 })
-                            : <span>&nbsp;&nbsp;No evidence added.</span>}
+                            : <tr><td colSpan="3"><span>&nbsp;&nbsp;No evidence added.</span></td></tr>}
                         </tbody>
                     </table>
                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/extra_evidence.js
@@ -292,14 +292,6 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                             : null}
                             <tr>
                                 <td colSpan="3">
-                                    {!this.state.tempEvidence ?
-                                        <span>
-                                            <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} buttonClass="btn-primary"
-                                                buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
-
-                                            &nbsp;&nbsp;Select "Add PMID" to curate and save a piece of evidence from a published article.
-                                        </span>
-                                    : null}
                                     {this.state.tempEvidence ?
                                         <div>
                                             <PmidSummary article={this.state.tempEvidence} className="alert alert-info" pmidLinkout />
@@ -319,9 +311,98 @@ var ExtraEvidenceTable = module.exports.ExtraEvidenceTable = React.createClass({
                                                 </div>
                                             </Form>
                                         </div>
-                                    : null}
+                                    :
+                                        <span>
+                                            <AddResourceId resourceType="pubmed" protocol={this.props.href_url.protocol} parentObj={parentObj} buttonClass="btn-primary"
+                                                buttonText="Add PMID" modalButtonText="Add Article" updateParentForm={this.updateTempEvidence} buttonOnly={true} />
+
+                                            &nbsp;&nbsp;Select "Add PMID" to curate and save a piece of evidence from a published article.
+                                        </span>
+                                    }
                                 </td>
                             </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        );
+    }
+});
+
+
+// Class to render the extra evidence table in VCI in view-only, view-all mode
+var ExtraEvidenceTableViewAll = module.exports.ExtraEvidenceTableViewAll = React.createClass({
+    mixins: [RestMixin, FormMixin, CuratorHistory],
+
+    propTypes: {
+        tableName: React.PropTypes.object, // table name as HTML object
+        category: React.PropTypes.string, // category (usually the tab) the evidence is part of
+        subcategory: React.PropTypes.string, // subcategory (usually the panel) the evidence is part of
+        variant: React.PropTypes.object, // parent variant object
+    },
+
+    contextTypes: {
+        fetch: React.PropTypes.func // Function to perform a search
+    },
+
+    getInitialState: function() {
+        return {
+            variant: this.props.variant // parent variant object
+        };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+        // Update variant object when received
+        if (nextProps.variant) {
+            this.setState({variant: nextProps.variant});
+        }
+    },
+
+    renderInterpretationExtraEvidence: function(extra_evidence) {
+        // for rendering the evidence in tabular format
+        return (
+            <tr key={extra_evidence.uuid}>
+                <td className="col-md-5"><PmidSummary article={extra_evidence.articles[0]} pmidLinkout /></td>
+                <td className="col-md-5">{extra_evidence.evidenceDescription}</td>
+                <td className="col-md-2">{extra_evidence.submitted_by.title}</td>
+            </tr>
+        );
+    },
+
+    render: function() {
+        let relevantEvidenceList = [];
+        if (this.state.variant && this.state.variant.associatedInterpretations) {
+            this.state.variant.associatedInterpretations.map(interpretation => {
+                if (interpretation.extra_evidence_list) {
+                    interpretation.extra_evidence_list.map(extra_evidence => {
+                        if (extra_evidence.subcategory === this.props.subcategory) {
+                            relevantEvidenceList.push(extra_evidence);
+                        }
+                    });
+                }
+            });
+        }
+
+        return (
+            <div className="panel panel-info">
+                <div className="panel-heading"><h3 className="panel-title">{this.props.tableName}</h3></div>
+                <div className="panel-content-wrapper">
+                    <table className="table">
+                        {relevantEvidenceList.length > 0 ?
+                            <thead>
+                                <tr>
+                                    <th>Article</th>
+                                    <th>Evidence</th>
+                                    <th>Submitted by</th>
+                                </tr>
+                            </thead>
+                        : null}
+                        <tbody>
+                            {relevantEvidenceList.length > 0 ?
+                                relevantEvidenceList.map(evidence => {
+                                    return (this.renderInterpretationExtraEvidence(evidence));
+                                })
+                            : <span>&nbsp;&nbsp;No evidence added.</span>}
                         </tbody>
                     </table>
                 </div>

--- a/src/clincoded/types/__init__.py
+++ b/src/clincoded/types/__init__.py
@@ -125,6 +125,10 @@ class Variant(Item):
         'associatedInterpretations.transcripts',
         'associatedInterpretations.proteins',
         'associatedInterpretations.provisional_variant',
+        'associatedInterpretations.extra_evidence_list',
+        'associatedInterpretations.extra_evidence_list.submitted_by',
+        'associatedInterpretations.extra_evidence_list.articles',
+        'associatedInterpretations.extra_evidence_list.articles.submitted_by'
     ]
     rev = {
         'associatedPathogenicities': ('pathogenicity', 'variant'),


### PR DESCRIPTION
Adds a new class to the extra evidence module that displays a view-only view-all mode for extra evidence, to be used on Evidence View mode only. Also adds extra evidence tables to many more sections of the VCI.

![image](https://cloud.githubusercontent.com/assets/4326866/20273316/a7fd8ad4-aa45-11e6-9f84-0a7afe890306.png)

Testing:

1. Enter VCI, enter interpretation mode
2. Enter extra evidence in a number of places
3. Enter VCI for same variant as another user
4. In Evidence View mode, confirm that the extra evidence added as the previous owner is visible
5. Enter interpretation mode, and add extra evidence in a number of overlapping and non-overlapping places
6. Go back to Evidence View mode, and confirm that the extra evidence tables have updated properly with the new entries