### PR TITLE
Connects to #1151. PS4 error message bugfix

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -240,7 +240,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                     }
                 } else if (this.props.criteria.indexOf('PS4') > -1) {
                     if (criteriaEvalConflictValues.indexOf(this.refs['PS4-status'].getValue()) > -1) {
-                        manualCheck1 = 'PM4';
+                        manualCheck1 = 'PS4';
                         manualCheck2 = 'PM2';
                     }
                 }


### PR DESCRIPTION
PS4 crosscheck error now references the correct criteria code:
![image](https://cloud.githubusercontent.com/assets/4326866/20731428/3ff075ae-b63f-11e6-9ef9-76cf257d6b01.png)

Testing:

1. Get to VCI and begin interpretation
2. Evaluate 'Met' on PM2 in Population subtab
3. Evaluate 'Met' on PS4 in Segregation/Case subtab, and confirm that the error message references the correct criteria codes