### PR TITLE
Connects to #1104. Adding adjectives to mode of inheritance.

### DIFF
--- a/src/clincoded/schemas/gdm.json
+++ b/src/clincoded/schemas/gdm.json
@@ -108,6 +108,12 @@
             "description": "boolean switch to set if the gdm avaliable for curation.",
             "type": "boolean",
             "default": true
+        },
+        "modeInheritanceAdjective": {
+            "title": "Adjective",
+            "description": "Adjective for Mode of Inheritance",
+            "type": "string",
+            "default": ""
         }
     },
     "columns": {

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -125,6 +125,12 @@
                 "type": "string",
                 "linkTo": "extra_evidence"
             }
+        },
+        "modeInheritanceAdjective": {
+            "title": "Adjective",
+            "description": "Adjective for Mode of Inheritance",
+            "type": "string",
+            "default": ""
         }
     },
     "columns": {

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -30,6 +30,8 @@ var CreateGeneDisease = React.createClass({
     getInitialState: function() {
         return {
             gdm: {},
+            adjectives: [],
+            adjectiveDisabled: true,
             adjectiveRequired: false
         };
     },
@@ -39,7 +41,39 @@ var CreateGeneDisease = React.createClass({
         if (ref === 'hpo') {
             //Only show option to select moi adjective if user selects 'X-linked inheritance'
             let selected = this.refs[ref].getValue();
-            selected.indexOf('X-linked inheritance') > -1 ? this.setState({adjectiveRequired: true}) : this.setState({adjectiveRequired: false});
+            if (selected.indexOf('X-linked inheritance') > -1) {
+                this.setState({
+                    adjectiveDisabled: false,
+                    adjectiveRequired: true,
+                    adjectives: modesOfInheritance['X-linked inheritance (HP:0001417)']
+                });
+            } else if (selected.indexOf('Autosomal dominant inheritance') > -1) {
+                this.setState({
+                    adjectiveDisabled: false,
+                    adjectiveRequired: false,
+                    adjectives: modesOfInheritance['Autosomal dominant inheritance (HP:0000006)']
+                });
+            } else if (selected.indexOf('Autosomal recessive inheritance') > -1) {
+                this.setState({
+                    adjectiveDisabled: false,
+                    adjectiveRequired: false,
+                    adjectives: modesOfInheritance['Autosomal recessive inheritance (HP:0000007)']
+                });
+            } else if (selected.indexOf('Mitochondrial inheritance') > -1) {
+                this.setState({
+                    adjectiveDisabled: false,
+                    adjectiveRequired: false,
+                    adjectives: modesOfInheritance['Mitochondrial inheritance (HP:0001427)']
+                });
+            } else if (selected.indexOf('Other') > -1) {
+                this.setState({
+                    adjectiveDisabled: false,
+                    adjectiveRequired: false,
+                    adjectives: modesOfInheritance['Other']
+                });
+            } else {
+                this.setState({adjectiveDisabled: true, adjectiveRequired: false});
+            }
         }
     },
 
@@ -147,7 +181,10 @@ var CreateGeneDisease = React.createClass({
     },
 
     render: function() {
+        let adjectives = this.state.adjectives;
+        let adjectiveDisabled = this.state.adjectiveDisabled;
         let adjectiveRequired = this.state.adjectiveRequired;
+        const moiKeys = Object.keys(modesOfInheritance);
 
         return (
             <div className="container">
@@ -167,19 +204,19 @@ var CreateGeneDisease = React.createClass({
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="hpo" required>
                                     <option value="select" disabled="disabled">Select</option>
                                     <option value="" disabled="disabled"></option>
-                                    {modesOfInheritance.map(function(modeOfInheritance, i) {
+                                    {moiKeys.map(function(modeOfInheritance, i) {
                                         return <option key={i} value={modeOfInheritance}>{modeOfInheritance}</option>;
                                     })}
                                 </Input>
                                 <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue="none"
                                     error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective"
-                                    required={adjectiveRequired ? true : false} inputDisabled={adjectiveRequired ? false : true}>
+                                    required={adjectiveRequired} inputDisabled={adjectiveDisabled}>
                                     <option value="none" disabled="disabled">Select</option>
                                     <option disabled="disabled"></option>
-                                    <option value="Dominant">Dominant</option>
-                                    <option value="Recessive">Recessive</option>
-                                    <option value="Primarily recessive with milder female expression">Primarily recessive with milder female expression</option>
+                                    {adjectives.map(function(adjective, i) {
+                                        return <option key={i} value={adjective}>{adjective}</option>;
+                                    })}
                                 </Input>
                                 <Input type="submit" inputClassName="btn-default pull-right" id="submit" />
                             </div>

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -31,8 +31,7 @@ var CreateGeneDisease = React.createClass({
         return {
             gdm: {},
             adjectives: [],
-            adjectiveDisabled: true,
-            adjectiveRequired: false
+            adjectiveDisabled: true
         };
     },
 
@@ -49,26 +48,25 @@ var CreateGeneDisease = React.createClass({
             /* Everything else, disable adjective menu.           */
             /******************************************************/
             if (selected.indexOf('X-linked inheritance') > -1) {
-                this.handleAdjectives(false, true, modesOfInheritance['X-linked inheritance (HP:0001417)']);
+                this.handleAdjectives(false, modesOfInheritance['X-linked inheritance (HP:0001417)']);
             } else if (selected.indexOf('Autosomal dominant inheritance') > -1) {
-                this.handleAdjectives(false, false, modesOfInheritance['Autosomal dominant inheritance (HP:0000006)']);
+                this.handleAdjectives(false, modesOfInheritance['Autosomal dominant inheritance (HP:0000006)']);
             } else if (selected.indexOf('Autosomal recessive inheritance') > -1) {
-                this.handleAdjectives(false, false, modesOfInheritance['Autosomal recessive inheritance (HP:0000007)']);
+                this.handleAdjectives(false, modesOfInheritance['Autosomal recessive inheritance (HP:0000007)']);
             } else if (selected.indexOf('Mitochondrial inheritance') > -1) {
-                this.handleAdjectives(false, false, modesOfInheritance['Mitochondrial inheritance (HP:0001427)']);
+                this.handleAdjectives(false, modesOfInheritance['Mitochondrial inheritance (HP:0001427)']);
             } else if (selected.indexOf('Other') > -1) {
-                this.handleAdjectives(false, false, modesOfInheritance['Other']);
+                this.handleAdjectives(false, modesOfInheritance['Other']);
             } else {
-                this.handleAdjectives(true, false, []);
+                this.handleAdjectives(true, []);
             }
         }
     },
 
     // Helper method for the 'handleChange' method to minimize repetitive code
-    handleAdjectives: function(adjectiveDisabled, adjectiveRequired, adjectives) {
+    handleAdjectives: function(adjectiveDisabled, adjectives) {
         this.setState({
             adjectiveDisabled: adjectiveDisabled,
-            adjectiveRequired: adjectiveRequired,
             adjectives: adjectives
         }, () => {this.refs.moiAdjective.setValue('none');});
     },
@@ -170,7 +168,6 @@ var CreateGeneDisease = React.createClass({
     render: function() {
         let adjectives = this.state.adjectives;
         let adjectiveDisabled = this.state.adjectiveDisabled;
-        let adjectiveRequired = this.state.adjectiveRequired;
         const moiKeys = Object.keys(modesOfInheritance);
 
         return (
@@ -196,9 +193,8 @@ var CreateGeneDisease = React.createClass({
                                     })}
                                 </Input>
                                 <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue="none"
-                                    error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
-                                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective"
-                                    required={adjectiveRequired} inputDisabled={adjectiveDisabled}>
+                                    error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')} inputDisabled={adjectiveDisabled}
+                                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective">
                                     <option value="none" disabled="disabled">Select</option>
                                     <option disabled="disabled"></option>
                                     {adjectives.map(function(adjective, i) {

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -147,6 +147,8 @@ var CreateGeneDisease = React.createClass({
     },
 
     render: function() {
+        let adjectiveRequired = this.state.adjectiveRequired;
+
         return (
             <div className="container">
                 <h1>{this.props.context.title}</h1>
@@ -169,17 +171,16 @@ var CreateGeneDisease = React.createClass({
                                         return <option key={i} value={modeOfInheritance}>{modeOfInheritance}</option>;
                                     })}
                                 </Input>
-                                {this.state.adjectiveRequired ?
-                                    <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue="select"
-                                        error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
-                                        labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective" required>
-                                        <option value="select" disabled="disabled">Select</option>
-                                        <option disabled="disabled"></option>
-                                        <option value="Dominant">Dominant</option>
-                                        <option value="Recessive">Recessive</option>
-                                        <option value="Primarily recessive with milder female expression">Primarily recessive with milder female expression</option>
-                                    </Input>
-                                : null}
+                                <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue="none"
+                                    error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
+                                    labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective"
+                                    required={adjectiveRequired ? true : false} inputDisabled={adjectiveRequired ? false : true}>
+                                    <option value="none" disabled="disabled">Select</option>
+                                    <option disabled="disabled"></option>
+                                    <option value="Dominant">Dominant</option>
+                                    <option value="Recessive">Recessive</option>
+                                    <option value="Primarily recessive with milder female expression">Primarily recessive with milder female expression</option>
+                                </Input>
                                 <Input type="submit" inputClassName="btn-default pull-right" id="submit" />
                             </div>
                         </Form>

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -39,42 +39,38 @@ var CreateGeneDisease = React.createClass({
     // Handle value changes in modeInheritance dropdown selection
     handleChange: function(ref, e) {
         if (ref === 'hpo') {
-            //Only show option to select moi adjective if user selects 'X-linked inheritance'
             let selected = this.refs[ref].getValue();
+            /******************************************************/
+            /* If 'X-linked inheritance' is selected,             */
+            /* enable adjective menu and set it a required field. */
+            /* If 'Autosomal dominant inheritance' is selected,   */
+            /* or 'Autosomal recessive inheritance is selected,   */
+            /* enable adjective menu only & set it not required.  */
+            /* Everything else, disable adjective menu.           */
+            /******************************************************/
             if (selected.indexOf('X-linked inheritance') > -1) {
-                this.setState({
-                    adjectiveDisabled: false,
-                    adjectiveRequired: true,
-                    adjectives: modesOfInheritance['X-linked inheritance (HP:0001417)']
-                });
+                this.handleAdjectives(false, true, modesOfInheritance['X-linked inheritance (HP:0001417)']);
             } else if (selected.indexOf('Autosomal dominant inheritance') > -1) {
-                this.setState({
-                    adjectiveDisabled: false,
-                    adjectiveRequired: false,
-                    adjectives: modesOfInheritance['Autosomal dominant inheritance (HP:0000006)']
-                });
+                this.handleAdjectives(false, false, modesOfInheritance['Autosomal dominant inheritance (HP:0000006)']);
             } else if (selected.indexOf('Autosomal recessive inheritance') > -1) {
-                this.setState({
-                    adjectiveDisabled: false,
-                    adjectiveRequired: false,
-                    adjectives: modesOfInheritance['Autosomal recessive inheritance (HP:0000007)']
-                });
+                this.handleAdjectives(false, false, modesOfInheritance['Autosomal recessive inheritance (HP:0000007)']);
             } else if (selected.indexOf('Mitochondrial inheritance') > -1) {
-                this.setState({
-                    adjectiveDisabled: false,
-                    adjectiveRequired: false,
-                    adjectives: modesOfInheritance['Mitochondrial inheritance (HP:0001427)']
-                });
+                this.handleAdjectives(false, false, modesOfInheritance['Mitochondrial inheritance (HP:0001427)']);
             } else if (selected.indexOf('Other') > -1) {
-                this.setState({
-                    adjectiveDisabled: false,
-                    adjectiveRequired: false,
-                    adjectives: modesOfInheritance['Other']
-                });
+                this.handleAdjectives(false, false, modesOfInheritance['Other']);
             } else {
-                this.setState({adjectiveDisabled: true, adjectiveRequired: false});
+                this.handleAdjectives(true, false, []);
             }
         }
+    },
+
+    // Helper method for the 'handleChange' method to minimize repetitive code
+    handleAdjectives: function(adjectiveDisabled, adjectiveRequired, adjectives) {
+        this.setState({
+            adjectiveDisabled: adjectiveDisabled,
+            adjectiveRequired: adjectiveRequired,
+            adjectives: adjectives
+        }, () => {this.refs.moiAdjective.setValue('none');});
     },
 
     // Form content validation
@@ -104,18 +100,16 @@ var CreateGeneDisease = React.createClass({
         this.saveFormValue('hgncgene', this.refs.hgncgene.getValue().toUpperCase());
         this.saveFormValue('orphanetid', this.refs.orphanetid.getValue());
         this.saveFormValue('hpo', this.refs.hpo.getValue());
-        if (this.state.adjectiveRequired) {
-            this.saveFormValue('moiAdjective', this.refs.moiAdjective.getValue());
+        let moiAdjectiveValue = this.refs.moiAdjective.getValue();
+        if (moiAdjectiveValue && moiAdjectiveValue !== 'none') {
+            this.saveFormValue('moiAdjective', moiAdjectiveValue);
         }
         if (this.validateForm()) {
             // Get the free-text values for the Orphanet ID and the Gene ID to check against the DB
             var orphaId = this.getFormValue('orphanetid').match(/^ORPHA([0-9]{1,6})$/i)[1];
             var geneId = this.getFormValue('hgncgene');
             var mode = this.getFormValue('hpo');
-            let adjective;
-            if (this.state.adjectiveRequired) {
-                adjective = this.getFormValue('moiAdjective');
-            }
+            let adjective = this.getFormValue('moiAdjective');
 
             // Get the disease and gene objects corresponding to the given Orphanet and Gene IDs in parallel.
             // If either error out, set the form error fields
@@ -132,20 +126,13 @@ var CreateGeneDisease = React.createClass({
                 ).then(gdmSearch => {
                     if (gdmSearch.total === 0) {
                         // Matching GDM not found. Create a new GDM
-                        let newGdm = {};
-                        if (this.state.adjectiveRequired) {
-                            newGdm = {
-                                gene: geneId,
-                                disease: orphaId,
-                                modeInheritance: mode,
-                                modeInheritanceAdjective: adjective
-                            };
-                        } else {
-                            newGdm = {
-                                gene: geneId,
-                                disease: orphaId,
-                                modeInheritance: mode
-                            };
+                        let newGdm = {
+                            gene: geneId,
+                            disease: orphaId,
+                            modeInheritance: mode
+                        };
+                        if (adjective && adjective.length) {
+                            newGdm['modeInheritanceAdjective'] = adjective;
                         }
 
                         // Post the new GDM to the DB. Once promise returns, go to /curation-central page with the UUID

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -198,7 +198,7 @@ var CreateGeneDisease = React.createClass({
                                     <option value="none" disabled="disabled">Select</option>
                                     <option disabled="disabled"></option>
                                     {adjectives.map(function(adjective, i) {
-                                        return <option key={i} value={adjective}>{adjective}</option>;
+                                        return <option key={i} value={adjective}>{adjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</option>;
                                     })}
                                 </Input>
                                 <Input type="submit" inputClassName="btn-default pull-right" id="submit" />

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -170,7 +170,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                             }
                                         </span>
                                     </h1>
-                                    <h2><i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></h2>
+                                    <h2><i>{modeInheritanceAdjective ? mode + ' (' + modeInheritanceAdjective + ')' : mode}</i></h2>
                                 </span>
                         </div>
                     </div>

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1866,7 +1866,7 @@ function flattenCaseControl(casecontrol) {
 }
 
 
-var interpretationSimpleProps = ["modeInheritance", "active", "date_created", "completed_sections", "markAsProvisional"];
+var interpretationSimpleProps = ["modeInheritance", "active", "date_created", "completed_sections", "markAsProvisional", "modeInheritanceAdjective"];
 
 function flattenInterpretation(interpretation) {
     // First copy simple properties before fixing the special properties

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1726,7 +1726,7 @@ function flattenExperimental(experimental) {
 
 
 var gdmSimpleProps = [
-    "date_created", "modeInheritance", "omimId", "draftClassification", "finalClassification", "active"
+    "date_created", "modeInheritance", "omimId", "draftClassification", "finalClassification", "active", "modeInheritanceAdjective"
 ];
 
 function flattenGdm(gdm) {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -94,6 +94,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var gene = this.props.gdm.gene;
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
+            // Display selected MOI adjective if any. Otherwise, display selected MOI.
             var modeInheritanceAdjective = this.props.gdm.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
             var pmid = this.props.pmid;
             var i, j, k;

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -94,6 +94,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var gene = this.props.gdm.gene;
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
+            var modeInheritanceAdjective = this.props.gdm.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
             var pmid = this.props.pmid;
             var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.
@@ -168,7 +169,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                             }
                                         </span>
                                     </h1>
-                                    <h2><i>{mode}</i></h2>
+                                    <h2><i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></h2>
                                 </span>
                         </div>
                     </div>

--- a/src/clincoded/static/components/mapping/modes_of_inheritance.json
+++ b/src/clincoded/static/components/mapping/modes_of_inheritance.json
@@ -1,11 +1,31 @@
-[
-    "Autosomal dominant inheritance (HP:0000006)",
-    "Autosomal recessive inheritance (HP:0000007)",
-    "Unknown",
-    "Mitochondrial inheritance (HP:0001427)",
-    "Multifactorial inheritance (HP:0001426)",
-    "Somatic mutation (HP:0001428)",
-    "X-linked inheritance (HP:0001417)",
-    "Y-linked inheritance (HP:0001450)",
-    "Other"
-]
+{
+    "Autosomal dominant inheritance (HP:0000006)": [
+        "Autosomal dominant inheritance with maternal imprinting (HP:0012275)",
+        "Autosomal dominant inheritance with paternal imprinting (HP:0012274)",
+        "Sex-limited autosomal dominant (HP:0001470)",
+        "Autosomal dominant with genetic anticipation",
+        "Autosomal dominant inheritance, primarily or exclusively de novo",
+        "Autosomal dominant contiguous gene syndrome (HP:0001452)"
+    ],
+    "Autosomal recessive inheritance (HP:0000007)": [
+        "Autosomal recessive with genetic anticipation",
+        "Sex-limited autosomal recessive"
+    ],
+    "Mitochondrial inheritance (HP:0001427)": [
+        "Mitochondrial inheritance, primarily or exclusively homoplasmic",
+        "Mitochondrial inheritance, primarily or exclusively heteroplasmic"
+    ],
+    "X-linked inheritance (HP:0001417)": [
+        "X-linked dominant inheritance (HP:0001423)",
+        "X-linked recessive inheritance (HP:0001419)",
+        "X-linked primarily recessive with milder female expression"
+    ],
+    "Y-linked inheritance (HP:0001450)": [],
+    "Somatic mutation (HP:0001428)": [],
+    "Multifactorial inheritance (HP:0001426)": [],
+    "Other": [
+        "Codominant inheritance",
+        "Semidominant inheritance"
+    ],
+    "Unknown": []
+}

--- a/src/clincoded/static/components/mapping/modes_of_inheritance.json
+++ b/src/clincoded/static/components/mapping/modes_of_inheritance.json
@@ -2,13 +2,13 @@
     "Autosomal dominant inheritance (HP:0000006)": [
         "with maternal imprinting (HP:0012275)",
         "with paternal imprinting (HP:0012274)",
-        "Sex-limited (HP:0001470)",
+        "sex-limited (HP:0001470)",
         "with genetic anticipation",
         "primarily or exclusively de novo"
     ],
     "Autosomal recessive inheritance (HP:0000007)": [
         "with genetic anticipation",
-        "Sex-limited"
+        "sex-limited"
     ],
     "Mitochondrial inheritance (HP:0001427)": [
         "primarily or exclusively homoplasmic",

--- a/src/clincoded/static/components/mapping/modes_of_inheritance.json
+++ b/src/clincoded/static/components/mapping/modes_of_inheritance.json
@@ -20,10 +20,10 @@
         "X-linked recessive inheritance (HP:0001419)",
         "X-linked primarily recessive with milder female expression"
     ],
-    "Y-linked inheritance (HP:0001450)": [],
-    "Somatic mutation (HP:0001428)": [],
-    "Multifactorial inheritance (HP:0001426)": [],
     "Other": [
+        "Y-linked inheritance (HP:0001450)",
+        "Somatic mutation (HP:0001428)",
+        "Multifactorial inheritance (HP:0001426)",
         "Codominant inheritance",
         "Semidominant inheritance"
     ],

--- a/src/clincoded/static/components/mapping/modes_of_inheritance.json
+++ b/src/clincoded/static/components/mapping/modes_of_inheritance.json
@@ -1,24 +1,23 @@
 {
     "Autosomal dominant inheritance (HP:0000006)": [
-        "Autosomal dominant inheritance with maternal imprinting (HP:0012275)",
-        "Autosomal dominant inheritance with paternal imprinting (HP:0012274)",
-        "Sex-limited autosomal dominant (HP:0001470)",
-        "Autosomal dominant with genetic anticipation",
-        "Autosomal dominant inheritance, primarily or exclusively de novo",
-        "Autosomal dominant contiguous gene syndrome (HP:0001452)"
+        "with maternal imprinting (HP:0012275)",
+        "with paternal imprinting (HP:0012274)",
+        "Sex-limited (HP:0001470)",
+        "with genetic anticipation",
+        "primarily or exclusively de novo"
     ],
     "Autosomal recessive inheritance (HP:0000007)": [
-        "Autosomal recessive with genetic anticipation",
-        "Sex-limited autosomal recessive"
+        "with genetic anticipation",
+        "Sex-limited"
     ],
     "Mitochondrial inheritance (HP:0001427)": [
-        "Mitochondrial inheritance, primarily or exclusively homoplasmic",
-        "Mitochondrial inheritance, primarily or exclusively heteroplasmic"
+        "primarily or exclusively homoplasmic",
+        "primarily or exclusively heteroplasmic"
     ],
     "X-linked inheritance (HP:0001417)": [
-        "X-linked dominant inheritance (HP:0001423)",
-        "X-linked recessive inheritance (HP:0001419)",
-        "X-linked primarily recessive with milder female expression"
+        "dominant (HP:0001423)",
+        "recessive (HP:0001419)",
+        "primarily recessive with milder female expression"
     ],
     "Other": [
         "Y-linked inheritance (HP:0001450)",

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -540,6 +540,10 @@ var AssociateInheritance = React.createClass({
                 flatInterpretation.modeInheritance = modeInheritance;
                 if (adjective && adjective.length) {
                     flatInterpretation['modeInheritanceAdjective'] = adjective;
+                } else {
+                    if ('modeInheritanceAdjective' in flatInterpretation) {
+                        delete flatInterpretation['modeInheritanceAdjective'];
+                    }
                 }
             }
 
@@ -605,14 +609,13 @@ var AssociateInheritance = React.createClass({
                                 return <option key={i} value={modeOfInheritance}>{modeOfInheritance}</option>;
                             })}
                         </Input>
-                         <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue='none'
+                         <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue='none' inputDisabled={adjectiveDisabled}
                             error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
-                            labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective"
-                            inputDisabled={adjectiveDisabled}>
+                            labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective">
                             <option value="none" disabled="disabled">Select</option>
                             <option disabled="disabled"></option>
                             {adjectives.map(function(adjective, i) {
-                                return <option key={i} value={adjective}>{adjective}</option>;
+                                return <option key={i} value={adjective}>{adjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</option>;
                             })}
                         </Input>
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -82,34 +82,37 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
     // Method to display either mode of inheritance adjective,
     // or just mode of inheritance if no adjective
     renderSelectedModeInheritance: function(interpretation) {
-        let moi = '';
-        if (interpretation.modeInheritanceAdjective) {
-            moi = interpretation.modeInheritanceAdjective;
-        } else if (interpretation.modeInheritance) {
+        let moi = '', moiAdjective = '';
+
+        if (interpretation.modeInheritance) {
             moi = interpretation.modeInheritance;
+            if (interpretation.modeInheritanceAdjective) {
+                moiAdjective = interpretation.modeInheritanceAdjective;
+            }
         }
         return (
-            <span>{moi && moi.length ? this.renderModeInheritanceLink(moi) : 'None'}</span>
+            <span>{moi && moi.length ? this.renderModeInheritanceLink(moi, moiAdjective) : 'None'}</span>
         );
     },
 
     // Method to construct mode of inheritance linkout
-    renderModeInheritanceLink: function(modeInheritance) {
+    renderModeInheritanceLink: function(modeInheritance, modeInheritanceAdjective) {
         if (modeInheritance) {
             let start = modeInheritance.indexOf('(');
             let end = modeInheritance.indexOf(')');
             let hpoNumber;
+            let adjective = modeInheritanceAdjective && modeInheritanceAdjective.length ? ' (' + modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] + ')' : null;
             if (start && end) {
                 hpoNumber = modeInheritance.substring(start+1, end);
             }
             if (hpoNumber && hpoNumber.indexOf('HP:') > -1) {
                 let hpoLink = 'http://compbio.charite.de/hpoweb/showterm?id=' + hpoNumber;
                 return (
-                    <a href={hpoLink} target="_blank">{modeInheritance}</a>
+                    <span><a href={hpoLink} target="_blank">{modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</a>{adjective}</span>
                 );
             } else {
                 return (
-                    <span>{modeInheritance}</span>
+                    <span>{modeInheritance + adjective}</span>
                 );
             }
         }

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -79,6 +79,20 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
         });
     },
 
+    // Method to display either mode of inheritance adjective,
+    // or just mode of inheritance if no adjective
+    renderSelectedModeInheritance: function(interpretation) {
+        let moi = '';
+        if (interpretation.modeInheritanceAdjective) {
+            moi = interpretation.modeInheritanceAdjective;
+        } else if (interpretation.modeInheritance) {
+            moi = interpretation.modeInheritance;
+        }
+        return (
+            <span>{moi && moi.length ? this.renderModeInheritanceLink(moi) : 'None'}</span>
+        );
+    },
+
     // Method to construct mode of inheritance linkout
     renderModeInheritanceLink: function(modeInheritance) {
         if (modeInheritance) {
@@ -382,7 +396,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
                                             </dl>
                                             <dl className="inline-dl clearfix">
                                                 <dt>Mode of Inheritance:</dt>
-                                                <dd className="modeInheritance">{interpretation.modeInheritance ? this.renderModeInheritanceLink(interpretation.modeInheritance) : 'None'}</dd>
+                                                <dd className="modeInheritance">{this.renderSelectedModeInheritance(interpretation)}</dd>
                                             </dl>
                                         </div>
                                     </div>

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -48,11 +48,11 @@ var Title = module.exports.Title = React.createClass({
         let modeInheritanceAdjective = interpretation && interpretation.modeInheritanceAdjective ? interpretation.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
         if (interpretation) {
             if (interpretation.disease && interpretation.disease.term && interpretation.modeInheritance) {
-                associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong> - <i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></span>;
+                associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong> - <i>{modeInheritanceAdjective ? mode + ' (' + modeInheritanceAdjective + ')' : mode}</i></span>;
             } else if (interpretation.disease && interpretation.disease.term) {
                 associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong></span>;
             } else if (interpretation.modeInheritance) {
-                associatedDisease = <span>This interpretation is associated with <strong>no disease</strong> - <i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></span>;
+                associatedDisease = <span>This interpretation is associated with <strong>no disease</strong> - <i>{modeInheritanceAdjective ? mode + ' (' + modeInheritanceAdjective + ')' : mode}</i></span>;
             } else {
                 associatedDisease = 'This interpretation is not yet associated with a disease or mode of inheritance';
             }

--- a/src/clincoded/static/components/variant_central/title.js
+++ b/src/clincoded/static/components/variant_central/title.js
@@ -45,13 +45,14 @@ var Title = module.exports.Title = React.createClass({
     renderSubtitle: function(interpretation, variant) {
         var associatedDisease = 'Evidence View';
         let mode = interpretation && interpretation.modeInheritance ? interpretation.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
+        let modeInheritanceAdjective = interpretation && interpretation.modeInheritanceAdjective ? interpretation.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
         if (interpretation) {
             if (interpretation.disease && interpretation.disease.term && interpretation.modeInheritance) {
-                associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong> - <i>{mode}</i></span>;
+                associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong> - <i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></span>;
             } else if (interpretation.disease && interpretation.disease.term) {
                 associatedDisease = <span>This interpretation is associated with <strong>{interpretation.disease.term}</strong></span>;
             } else if (interpretation.modeInheritance) {
-                associatedDisease = <span>This interpretation is associated with <strong>no disease</strong> - <i>{mode}</i></span>;
+                associatedDisease = <span>This interpretation is associated with <strong>no disease</strong> - <i>{modeInheritanceAdjective ? modeInheritanceAdjective : mode}</i></span>;
             } else {
                 associatedDisease = 'This interpretation is not yet associated with a disease or mode of inheritance';
             }

--- a/src/clincoded/tests/features/create_gene_disease.feature
+++ b/src/clincoded/tests/features/create_gene_disease.feature
@@ -10,6 +10,26 @@ Feature: Create Gene Disease
         When I visit "/create-gene-disease/"
         And I fill in "hgncgene" with "DICER1"
         And I fill in "orphanetid" with "ORPHA15"
+
+        #
+        # note: different mode of inheritance selections should have different mode adjectives/modifiers in the dropdown
+        #
+        And I select "Autosomal dominant inheritance (HP:0000006)" from dropdown "form-control hpo"
+        And I select "with maternal imprinting (HP:0012275)" from dropdown "form-control moiAdjective"
+
+        And I select "Autosomal recessive inheritance (HP:0000007)" from dropdown "form-control hpo"
+        And I select "with genetic anticipation" from dropdown "form-control moiAdjective"
+
+        And I select "Mitochondrial inheritance (HP:0001427)" from dropdown "form-control hpo"
+        And I select "primarily or exclusively homoplasmic" from dropdown "form-control moiAdjective"
+
+        And I select "X-linked inheritance (HP:0001417)" from dropdown "form-control hpo"
+        And I select "dominant (HP:0001423)" from dropdown "form-control moiAdjective"
+
         And I select "Other" from dropdown "form-control hpo"
+        And I select "Y-linked inheritance (HP:0001450)" from dropdown "form-control moiAdjective"
+
+        And I select "Unknown" from dropdown "form-control hpo"
+
         And I click the element with the css selector ".btn-default"
         Then I should not see "Required"


### PR DESCRIPTION
**Technical notes:**
1. This PR is primarily for the changes made to the mode of inheritance, in which adjectives are added to the following core MOIs: `Autosomal dominant inheritance (HP:0000006)`, `Autosomal recessive inheritance (HP:0000007)`, `Mitochondrial inheritance (HP:0001427)`, `X-linked inheritance (HP:0001417)` and `Other`.
2. The changes made to the mode of inheritance also include moving the following core MOIs to be adjectives under the `Other` core MOI: `Y-linked inheritance (HP:0001450)`, `Somatic mutation (HP:0001428)` and `Multifactorial inheritance (HP:0001426)`.
3. The mode of inheritance changes will affect the GDM creation in GCI as well as the MOI association with interpretation in VCI.
4. Curators are not required to select an adjective for any given core MOIs (although they could).
5. HPO terms in any given adjectives have been suppressed from the display only.
6. `modeInheritance` and `modeInheritanceAdjective` are used to store the core MOI and adjective values separately.

**Steps to test:**
1. Login and proceed to **Create New Gene Disease Record** page (e.g. ^/create-gene-disease/).
2. After entering the required **HGNC gene symbol** and **Orphanet ID**, select any core MOIs from the **Mode of Inheritance** dropdown options (except "Unknown") and expect to see the **adjectives** dropdown menu to be enabled with their respective lists of options.
3. When an adjective is selected for a given core MOI, save the GDM and expect to see the adjective being appended to the core MOI in parentheses as the subtitle on the subsequent record page (e.g. Curation-Central).
4. Now go to the VCI's variation selection interface and use 12345 as the ClinVar ID.
5. Start a new interpretation on the subsequent VCI's evidence view page, and then select some criteria modifiers so that pathogenicity can be calculated.
6. Click on the **Inheritance+** button and bring up the modal. Similarly, select any core MOIs from the **Mode of Inheritance** dropdown options (except "Unknown") and expect to see the **adjectives** dropdown menu to be enabled with their respective lists of options.
7. When an adjective is selected for a given core MOI, save the modal and expect to see the adjective being appended to the core MOI in parentheses in the subtitle on the VCI page.
8. Click on the **View Summary** button and proceed to the VCI interpretation summary page. Expect to see the adjective being appended to the core MOI in parentheses in the provision panel. If the core MOI has an HPO term, it is displayed as an external linkout. Otherwise, it is displayed as plain text.
9. Click on the **Return to Interpretation** button to go back to the VCI interpretation interface. Bring up the mode of inheritance modal again. Expect to see the previously selected core MOI and its adjective being shown in the modal dropdown menus. Also expect to be able to change to other core MOIs and/or adjectives in the modal.