### PR TITLE
Connects to #957. Connects to #1136. Add CAR and Variant Clear support to GCI

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -49,6 +49,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
         clearButtonClass: React.PropTypes.string, // specify any special css classes for the button
         buttonOnly: React.PropTypes.bool, // specify whether or not only the button should be rendered (no form-group)
         clearButtonRender: React.PropTypes.bool, // specify whether or not the Clear button should be rendered
+        editButtonRenderHide: React.PropTypes.bool, // specify whether or not the Edit button should be hidden
         parentObj: React.PropTypes.object // parent object; used to see if a duplicate entry exists
     },
 
@@ -104,7 +105,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
         if (this.props.buttonOnly) {
             return (
                 <div className={"inline-button-wrapper" + (this.props.wrapperClass ? " " + this.props.wrapperClass : "")}>
-                    {this.buttonRender()}
+                    {this.props.editButtonRenderHide && this.props.initialFormValue ? null : this.buttonRender()}
                     {this.props.clearButtonRender && this.props.initialFormValue ?
                         this.clearButtonRender()
                     : null}
@@ -116,7 +117,7 @@ var AddResourceId = module.exports.AddResourceId = React.createClass({
                     <span className="col-sm-5 control-label">{this.props.labelVisible ? this.props.label : null}</span>
                     <span className="col-sm-7">
                         <div className={"inline-button-wrapper" + (this.props.wrapperClass ? " " + this.props.wrapperClass : "")}>
-                            {this.buttonRender()}
+                            {this.props.editButtonRenderHide && this.props.initialFormValue ? null : this.buttonRender()}
                             {this.props.clearButtonRender && this.props.initialFormValue ?
                                 this.clearButtonRender()
                             : null}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2195,7 +2195,7 @@ var ExperimentalDataVariant = function() {
                                 error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                             <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Experimental'], 'variantList': this.state.variantInfo}}
-                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
+                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} clearButtonClass="btn-inline-spacer"
                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                 updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                             <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC || this.cv.othersAssessed}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -446,6 +446,7 @@ var ExperimentalCuration = React.createClass({
                                     'clinvarVariantId': variants[i].clinvarVariantId ? variants[i].clinvarVariantId : null,
                                     'clinvarVariantTitle': variants[i].clinvarVariantTitle ? variants[i].clinvarVariantTitle : null,
                                     'carId': variants[i].carId ? variants[i].carId : null,
+                                    'grch38': variants[i].hgvsNames && variants[i].hgvsNames.GRCh38 ? variants[i].hgvsNames.GRCh38 : null,
                                     'uuid': variants[i].uuid
                                 };
                             }
@@ -1104,6 +1105,7 @@ var ExperimentalCuration = React.createClass({
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
                 'carId': data.carId ? data.carId : null,
+                'grch38': data.hgvsNames && data.hgvsNames.GRCh38 ? data.hgvsNames.GRCh38 : null,
                 'uuid': data.uuid
             };
         } else {
@@ -2059,8 +2061,14 @@ var ExperimentalDataVariant = function() {
                                     : null}
                                     {this.state.variantInfo[i].carId ?
                                         <div className="row">
-                                            <span className="col-sm-5 control-label"><label>CAR ID:</label></span>
-                                            <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].carId}</span>
+                                            <span className="col-sm-5 control-label"><label>{<LabelCARVariant />}</label></span>
+                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                        </div>
+                                    : null}
+                                    {this.state.variantInfo[i].grch38 ?
+                                        <div className="row">
+                                            <span className="col-sm-5 control-label"><label>{<LabelCARVariantTitle />}</label></span>
+                                            <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
                                         </div>
                                     : null}
                                 </div>
@@ -2105,13 +2113,25 @@ var ExperimentalDataVariant = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:</span>;
+        return <span><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:</span>;
     }
 });
 
 var LabelClinVarVariantTitle = React.createClass({
     render: function() {
         return <span><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Preferred Title:</span>;
+    }
+});
+
+var LabelCARVariant = React.createClass({
+    render: function() {
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+    }
+});
+
+var LabelCARVariantTitle = React.createClass({
+    render: function() {
+        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2065,7 +2065,7 @@ var ExperimentalDataVariant = function() {
                                             <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                         </div>
                                     : null}
-                                    {this.state.variantInfo[i].grch38 ?
+                                    {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelCARVariantTitle />}</label></span>
                                             <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2050,7 +2050,7 @@ var ExperimentalDataVariant = function() {
                                     {this.state.variantInfo[i].clinvarVariantId ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
+                                            <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
                                         </div>
                                     : null}
                                     {this.state.variantInfo[i].clinvarVariantTitle ?
@@ -2062,7 +2062,7 @@ var ExperimentalDataVariant = function() {
                                     {this.state.variantInfo[i].carId ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelCARVariant />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
                                         </div>
                                     : null}
                                     {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2072,14 +2072,14 @@ var ExperimentalDataVariant = function() {
                                 <div className="form-group">
                                     <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                     <span className="col-sm-7">
-                                        {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                        {!this.state.variantInfo[i] || (this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId) ?
                                             <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                 buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                 updateParentForm={this.updateVariantId} buttonOnly={true} />
                                         : null}
                                         {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                        {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
+                                        {!this.state.variantInfo[i] || (this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId) ?
                                             <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                 buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2125,7 +2125,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelCARVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2068,7 +2068,7 @@ var ExperimentalDataVariant = function() {
                                     {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelCARVariantTitle />}</label></span>
-                                            <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
+                                            <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38} (GRCh38)</span>
                                         </div>
                                     : null}
                                 </div>
@@ -2131,7 +2131,7 @@ var LabelCARVariant = React.createClass({
 
 var LabelCARVariantTitle = React.createClass({
     render: function() {
-        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
+        return <span><strong>Genomic HGVS Title:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2079,7 +2079,7 @@ var ExperimentalDataVariant = function() {
                                         {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                         {!this.state.variantInfo[i] ?
                                             <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                                buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                 updateParentForm={this.updateVariantId} buttonOnly={true} />
                                         : null}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1088,7 +1088,7 @@ var ExperimentalCuration = React.createClass({
     },
 
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
-    updateClinvarVariantId: function(data, fieldNum) {
+    updateVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
         var addVariantDisabled;
         if (data) {
@@ -1103,7 +1103,8 @@ var ExperimentalCuration = React.createClass({
             newVariantInfo[fieldNum] = {
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
-                'carId': data.carId ? data.carId : null
+                'carId': data.carId ? data.carId : null,
+                'uuid': data.uuid
             };
         } else {
             // Reset the form and display values
@@ -2074,13 +2075,13 @@ var ExperimentalDataVariant = function() {
                                         <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                             buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                            updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                            updateParentForm={this.updateVariantId} buttonOnly={true} />
                                         {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                         {!this.state.variantInfo[i] ?
                                             <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                 buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                                updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                                updateParentForm={this.updateVariantId} buttonOnly={true} />
                                         : null}
                                     </span>
                                 </div>

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -441,7 +441,7 @@ var ExperimentalCuration = React.createClass({
                         stateObj.variantInfo = {};
 
                         for (var i = 0; i < variants.length; i++) {
-                            if (variants[i].clinvarVariantId) {
+                            if (variants[i].clinvarVariantId || variants[i].carId) {
                                 stateObj.variantInfo[i] = {
                                     'clinvarVariantId': variants[i].clinvarVariantId ? variants[i].clinvarVariantId : null,
                                     'clinvarVariantTitle': variants[i].clinvarVariantTitle ? variants[i].clinvarVariantTitle : null,
@@ -2072,15 +2072,17 @@ var ExperimentalDataVariant = function() {
                                 <div className="form-group">
                                     <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                     <span className="col-sm-7">
-                                        <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                            buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                            updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                        {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                            <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                        : null}
                                         {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                        {!this.state.variantInfo[i] ?
+                                        {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
                                             <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                 buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}
                                                 updateParentForm={this.updateVariantId} buttonOnly={true} />
                                         : null}
                                     </span>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -338,10 +338,11 @@ var FamilyCuration = React.createClass({
                         stateObj.variantInfo = {};
                         // For each incoming variant, set the form value
                         for (var i = 0; i < segregation.variants.length; i++) {
-                            if (segregation.variants[i].clinvarVariantId) {
+                            if (segregation.variants[i].clinvarVariantId || segregation.variants[i].carId) {
                                 stateObj.variantInfo[i] = {
                                     'clinvarVariantId': segregation.variants[i].clinvarVariantId,
                                     'clinvarVariantTitle': segregation.variants[i].clinvarVariantTitle,
+                                    'carId': segregation.variants[i].carId ? segregation.variants[i].carId : null,
                                     'uuid': segregation.variants[i].uuid // Needed for links to variant assessment/curation
                                 };
                             }
@@ -1667,15 +1668,17 @@ var FamilyVariant = function() {
                             <div className="form-group">
                                 <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                 <span className="col-sm-7">
-                                    <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
-                                        buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                        initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                        updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                    {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                        <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
+                                            buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                            updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                    : null}
                                     {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                    {!this.state.variantInfo[i] ?
+                                    {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
                                         <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
                                             buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}
                                             updateParentForm={this.updateVariantId} buttonOnly={true} />
                                     : null}
                                 </span>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1658,7 +1658,7 @@ var FamilyVariant = function() {
                                         <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                     </div>
                                 : null}
-                                {this.state.variantInfo[i].grch38 ?
+                                {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?
                                     <div className="row">
                                         <span className="col-sm-5 control-label"><label><LabelCARVariantTitle /></label></span>
                                         <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1638,14 +1638,24 @@ var FamilyVariant = function() {
                     <div key={i} className="variant-panel">
                         {this.state.variantInfo[i] ?
                             <div className="variant-resources">
-                                <div className="row variant-data-source">
-                                    <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
-                                    <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
-                                </div>
-                                <div className="row">
-                                    <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                    <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
-                                </div>
+                                {this.state.variantInfo[i].clinvarVariantId ?
+                                    <div className="row variant-data-source">
+                                        <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
+                                        <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
+                                    </div>
+                                : null}
+                                {this.state.variantInfo[i].clinvarVariantTitle ?
+                                    <div className="row">
+                                        <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
+                                        <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                    </div>
+                                : null}
+                                {this.state.variantInfo[i].carId ?
+                                    <div className="row">
+                                        <span className="col-sm-5 control-label"><label>CAR ID:</label></span>
+                                        <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].carId}</span>
+                                    </div>
+                                : null}
                                 <div className="row variant-assessment">
                                     <span className="col-sm-5 control-label"><label></label></span>
                                     <span className="col-sm-7 text-no-input">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1668,14 +1668,14 @@ var FamilyVariant = function() {
                             <div className="form-group">
                                 <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                 <span className="col-sm-7">
-                                    {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                    {!this.state.variantInfo[i] || (this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId) ?
                                         <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
                                             buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                             updateParentForm={this.updateVariantId} buttonOnly={true} />
                                     : null}
                                     {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                    {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
+                                    {!this.state.variantInfo[i] || (this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId) ?
                                         <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
                                             buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1734,7 +1734,7 @@ var FamilyVariant = function() {
                             error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                             labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                         <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
-                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
+                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} clearButtonClass="btn-inline-spacer"
                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                             updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                         <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} inputDisabled={this.state.variantOption[i] === VAR_SPEC}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1655,7 +1655,7 @@ var FamilyVariant = function() {
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
                                         <span className="col-sm-5 control-label"><label><LabelCARVariant variantRequired={this.state.variantRequired} /></label></span>
-                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
                                     </div>
                                 : null}
                                 {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1562,8 +1562,10 @@ var FamilySegregation = function() {
 // Display the Family variant panel. The number of copies depends on the variantCount state variable.
 var FamilyVariant = function() {
     var family = this.state.family;
+    var gdm = this.state.gdm;
     var segregation = family && family.segregation ? family.segregation : null;
     var variants = segregation && segregation.variants;
+    var annotation = this.state.annotation;
     let probandIndividual = this.state.probandIndividual ? this.state.probandIndividual : null;
     let gdmUuid = this.state.gdm && this.state.gdm.uuid ? this.state.gdm.uuid : null;
     let pmidUuid = this.state.annotation && this.state.annotation.article.pmid ? this.state.annotation.article.pmid : null;
@@ -1610,7 +1612,9 @@ var FamilyVariant = function() {
                         null
                     }
                 </div>
-            : null }
+            :
+                <p>The proband associated with this Family can be edited here: <a href={"/individual-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&individual=" + probandIndividual.uuid}>Edit {probandIndividual.label}</a></p>
+            }
             <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
                 error={this.getFormError('SEGrecessiveZygosity')} clearError={this.clrFormErrors.bind(null, 'SEGrecessiveZygosity')}
                 value={probandIndividual && probandIndividual.recessiveZygosity ? probandIndividual.recessiveZygosity : 'none'} handleChange={this.handleChange}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1661,7 +1661,7 @@ var FamilyVariant = function() {
                                 {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?
                                     <div className="row">
                                         <span className="col-sm-5 control-label"><label><LabelCARVariantTitle /></label></span>
-                                        <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
+                                        <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38} (GRCh38)</span>
                                     </div>
                                 : null}
                                 <div className="row variant-assessment">
@@ -1729,7 +1729,7 @@ var LabelCARVariant = React.createClass({
 
 var LabelCARVariantTitle = React.createClass({
     render: function() {
-        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
+        return <span><strong>Genomic HGVS Title:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1191,6 +1191,7 @@ var FamilyCuration = React.createClass({
 
         // Set state
         this.setState({variantInfo: newVariantInfo, variantOption: currVariantOption, addVariantDisabled: addVariantDisabled});
+        this.clrFormErrors('SEGrecessiveZygosity');
     },
 
     // Determine whether a Family is associated with a Group

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1674,7 +1674,7 @@ var FamilyVariant = function() {
                                     {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                     {!this.state.variantInfo[i] ?
                                         <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
-                                            buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                            buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                             updateParentForm={this.updateVariantId} buttonOnly={true} />
                                     : null}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1028,7 +1028,7 @@ var FamilyCuration = React.createClass({
     },
 
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
-    updateClinvarVariantId: function(data, fieldNum) {
+    updateVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
         var addVariantDisabled;
         if (data) {
@@ -1043,7 +1043,8 @@ var FamilyCuration = React.createClass({
             newVariantInfo[fieldNum] = {
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
-                'carId': data.carId ? data.carId : null
+                'carId': data.carId ? data.carId : null,
+                'uuid': data.uuid
             };
         } else {
             // Reset the form and display values
@@ -1669,13 +1670,13 @@ var FamilyVariant = function() {
                                     <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
                                         buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                         initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                        updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                        updateParentForm={this.updateVariantId} buttonOnly={true} />
                                     {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                     {!this.state.variantInfo[i] ?
                                         <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
                                             buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                             initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                            updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                            updateParentForm={this.updateVariantId} buttonOnly={true} />
                                     : null}
                                 </span>
                             </div>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -343,6 +343,7 @@ var FamilyCuration = React.createClass({
                                     'clinvarVariantId': segregation.variants[i].clinvarVariantId,
                                     'clinvarVariantTitle': segregation.variants[i].clinvarVariantTitle,
                                     'carId': segregation.variants[i].carId ? segregation.variants[i].carId : null,
+                                    'grch38': segregation.variants[i].hgvsNames && segregation.variants[i].hgvsNames.GRCh38 ? segregation.variants[i].hgvsNames.GRCh38 : null,
                                     'uuid': segregation.variants[i].uuid // Needed for links to variant assessment/curation
                                 };
                             }
@@ -1045,6 +1046,7 @@ var FamilyCuration = React.createClass({
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
                 'carId': data.carId ? data.carId : null,
+                'grch38': data.hgvsNames && data.hgvsNames.GRCh38 ? data.hgvsNames.GRCh38 : null,
                 'uuid': data.uuid
             };
         } else {
@@ -1652,8 +1654,14 @@ var FamilyVariant = function() {
                                 : null}
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
-                                        <span className="col-sm-5 control-label"><label>CAR ID:</label></span>
-                                        <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].carId}</span>
+                                        <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
+                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                    </div>
+                                : null}
+                                {this.state.variantInfo[i].grch38 ?
+                                    <div className="row">
+                                        <span className="col-sm-5 control-label"><label><LabelCARVariantTitle /></label></span>
+                                        <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
                                     </div>
                                 : null}
                                 <div className="row variant-assessment">
@@ -1703,13 +1711,25 @@ var FamilyVariant = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 
 var LabelClinVarVariantTitle = React.createClass({
     render: function() {
         return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Preferred Title:</strong></span>;
+    }
+});
+
+var LabelCARVariant = React.createClass({
+    render: function() {
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+    }
+});
+
+var LabelCARVariantTitle = React.createClass({
+    render: function() {
+        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -337,7 +337,6 @@ var FamilyCuration = React.createClass({
                         stateObj.addVariantDisabled = false;
                         stateObj.variantInfo = {};
                         // For each incoming variant, set the form value
-                        var currVariantOption = [];
                         for (var i = 0; i < segregation.variants.length; i++) {
                             if (segregation.variants[i].clinvarVariantId) {
                                 stateObj.variantInfo[i] = {
@@ -347,7 +346,6 @@ var FamilyCuration = React.createClass({
                                 };
                             }
                         }
-                        stateObj.variantOption = currVariantOption;
                     } else if (stateObj.probandIndividual) {
                         // No variants in this family, but it does have a proband individual. Open one empty variant panel
                         stateObj.variantCount = 1;
@@ -1032,7 +1030,6 @@ var FamilyCuration = React.createClass({
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
     updateClinvarVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
-        var currVariantOption = this.state.variantOption;
         var addVariantDisabled;
         if (data) {
             // Enable/Disable Add Variant button as needed
@@ -1063,7 +1060,7 @@ var FamilyCuration = React.createClass({
             }
         });
         // If not entered at all, proband individua is not required and must be no error messages at individual fields.
-        if (noVariantData) {
+        if (noVariantData && this.refs['individualname']) {
             if (this.refs['individualname'].getValue() || this.refs['individualorphanetid'].getValue() || this.refs['SEGrecessiveZygosity'].getValue() !== 'none') {
                 this.setState({individualRequired: true, variantRequired: true});
             } else {
@@ -1078,7 +1075,7 @@ var FamilyCuration = React.createClass({
         }
 
         // Set state
-        this.setState({variantInfo: newVariantInfo, variantOption: currVariantOption, addVariantDisabled: addVariantDisabled});
+        this.setState({variantInfo: newVariantInfo, addVariantDisabled: addVariantDisabled});
         this.clrFormErrors('individualorphanetid');
         this.clrFormErrors('SEGrecessiveZygosity');
     },

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1723,7 +1723,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelCARVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1654,7 +1654,7 @@ var FamilyVariant = function() {
                                 : null}
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
-                                        <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
+                                        <span className="col-sm-5 control-label"><label><LabelCARVariant variantRequired={this.state.variantRequired} /></label></span>
                                         <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                     </div>
                                 : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -221,8 +221,9 @@ var IndividualCuration = React.createClass({
                         if (variants[i].clinvarVariantId) {
                             currVariantOption[i] = VAR_SPEC;
                             stateObj.variantInfo[i] = {
-                                'clinvarVariantId': variants[i].clinvarVariantId,
-                                'clinvarVariantTitle': variants[i].clinvarVariantTitle,
+                                'clinvarVariantId': variants[i].clinvarVariantId ? variants[i].clinvarVariantId : null,
+                                'clinvarVariantTitle': variants[i].clinvarVariantTitle ? variants[i].clinvarVariantTitle : null,
+                                'carId': variants[i].carId ? variants[i].carId : null,
                                 'uuid': variants[i].uuid
                             };
                         } else if (variants[i].otherDescription) {
@@ -792,7 +793,11 @@ var IndividualCuration = React.createClass({
             }
             // Update the form and display values with new data
             this.refs['VARclinvarid' + fieldNum].setValue(data['uuid']);
-            newVariantInfo[fieldNum] = {'clinvarVariantId': data.clinvarVariantId, 'clinvarVariantTitle': data.clinvarVariantTitle}; // CHANGEME
+            newVariantInfo[fieldNum] = {
+                'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
+                'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
+                'carId': data.carId ? data.carId : null
+            };
             // Disable the 'Other description' textarea
             this.refs['VARothervariant' + fieldNum].resetValue();
             currVariantOption[parseInt(fieldNum)] = VAR_SPEC;
@@ -1416,14 +1421,24 @@ var IndividualVariantInfo = function() {
                             <div key={i} className="variant-panel">
                                 {this.state.variantInfo[i] ?
                                     <div>
-                                        <div className="row">
-                                            <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
-                                        </div>
-                                        <div className="row">
-                                            <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
-                                            <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
-                                        </div>
+                                        {this.state.variantInfo[i].clinvarVariantId ?
+                                            <div className="row">
+                                                <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
+                                                <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
+                                            </div>
+                                        : null}
+                                        {this.state.variantInfo[i].clinvarVariantTitle ?
+                                            <div className="row">
+                                                <span className="col-sm-5 control-label"><label>{<LabelClinVarVariantTitle />}</label></span>
+                                                <span className="col-sm-7 text-no-input clinvar-preferred-title">{this.state.variantInfo[i].clinvarVariantTitle}</span>
+                                            </div>
+                                        : null}
+                                        {this.state.variantInfo[i].carId ?
+                                            <div className="row">
+                                                <span className="col-sm-5 control-label"><label>CAR ID:</label></span>
+                                                <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].carId}</span>
+                                            </div>
+                                        : null}
                                         <div className="row variant-assessment">
                                             <span className="col-sm-5 control-label"><label></label></span>
                                             <span className="col-sm-7 text-no-input">
@@ -1445,16 +1460,16 @@ var IndividualVariantInfo = function() {
 
                                 <div className="row">
                                     <div className="form-group">
-                                        <span className="col-sm-5 control-label"><label>{!this.state.variantInfo[i] ? "Add Variant:" : "Clear Variant Selection:"}</label></span>
+                                        <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                         <span className="col-sm-7">
-                                            <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                            <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                 updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
                                             {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                             {!this.state.variantInfo[i] ?
-                                                <AddResourceId resourceType="car" labelVisible={false} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit CAR ID" : "Add CAR ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                    buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                     updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
                                             : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -60,9 +60,10 @@ var IndividualCuration = React.createClass({
             annotation: null, // Annotation object given in query string
             extraIndividualCount: 0, // Number of extra families to create
             extraIndividualNames: [], // Names of extra families to create
-            variantCount: 0, // Number of variants to display
+            variantCount: 1, // Number of variants to display
             variantOption: [VAR_NONE], // One variant panel, and nothing entered
             variantInfo: {}, // Extra holding info for variant display
+            variantRequired: false, // specifies whether or not variant information is required
             individualName: '', // Currently entered individual name
             addVariantDisabled: true, // True if Add Another Variant button enabled
             genotyping2Disabled: true, // True if genotyping method 2 dropdown disabled
@@ -85,11 +86,11 @@ var IndividualCuration = React.createClass({
         } else if (ref === 'SEGrecessiveZygosity') {
             let tempValue = this.refs[ref].getValue();
             if (tempValue === 'Heterozygous') {
-                this.setState({variantCount: 2});
+                this.setState({variantCount: 2, variantRequired: true});
             } else if (tempValue === 'Homozygous' || tempValue === 'Hemizygous') {
-                this.setState({variantCount: 1});
+                this.setState({variantCount: 1, variantRequired: true});
             } else {
-                this.setState({variantCount: 0});
+                this.setState({variantCount: 1, variantRequired: false});
             }
             /*
             //Only show option to add 2nd variant if user selects 'Heterozygous'
@@ -216,7 +217,8 @@ var IndividualCuration = React.createClass({
                 if (stateObj.individual.variants && stateObj.individual.variants.length && !(stateObj.individual.proband && stateObj.family)) {
                     var variants = stateObj.individual.variants;
                     // This individual has variants
-                    stateObj.variantCount = variants.length;
+                    stateObj.variantCount = variants.length ? variants.length : 1;
+                    stateObj.variantRequired = stateObj.individual.recessiveZygosity ? true : false;
                     stateObj.addVariantDisabled = false;
                     stateObj.variantInfo = {};
 
@@ -1486,7 +1488,7 @@ var IndividualVariantInfo = function() {
                                 {this.state.variantInfo[i] ?
                                     <div>
                                         <div className="row">
-                                            <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
+                                            <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
                                             <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
                                         </div>
                                         <div className="row">
@@ -1510,7 +1512,7 @@ var IndividualVariantInfo = function() {
                                 <Input type="text" ref={'VARclinvarid' + i} value={variant && variant.clinvarVariantId} handleChange={this.handleChange}
                                     error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
-                                <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                     buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} clearButtonClass="btn-inline-spacer"
                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                     updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
@@ -1558,13 +1560,13 @@ var IndividualVariantInfo = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:</span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 
 var LabelClinVarVariantTitle = React.createClass({
     render: function() {
-        return <span><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Preferred Title:</span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Preferred Title:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -322,8 +322,8 @@ var IndividualCuration = React.createClass({
             var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
             var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
             let SEGrecessiveZygosity = this.getFormValue('SEGrecessiveZygosity');
-            let variantId0 = this.getFormValue('VARclinvarid0'),
-                variantId1 = this.getFormValue('VARclinvarid1'),
+            let variantUuid0 = this.getFormValue('variantUuid0'),
+                variantUuid1 = this.getFormValue('variantUuid1'),
                 variantText0 = this.getFormValue('VARothervariant0'),
                 variantText1 = this.getFormValue('VARothervariant1');
 
@@ -362,7 +362,7 @@ var IndividualCuration = React.createClass({
             // Get variant uuid's if they were added via the modals
             for (var i = 0; i < this.state.variantCount; i++) {
                 // Grab the values from the variant form panel
-                var variantId = this.getFormValue('VARclinvarid' + i);
+                var variantId = this.getFormValue('variantUuid' + i);
 
                 // Build the search string depending on what the user entered
                 if (variantId) {
@@ -373,12 +373,12 @@ var IndividualCuration = React.createClass({
 
             // Check to see if the right number of variants exist
             if (SEGrecessiveZygosity === 'Heterozygous') {
-                if ((!variantId0 && !variantText0) || (!variantId1 && !variantText1)) {
+                if ((!variantUuid0 && !variantText0) || (!variantUuid1 && !variantText1)) {
                     formError = true;
                     this.setFormErrors('SEGrecessiveZygosity', 'For Heterozygous, two variants must be specified');
                 }
             } else if (SEGrecessiveZygosity === 'Hemizygous' || SEGrecessiveZygosity === 'Homozygous') {
-                if (!variantId0 && !variantText0) {
+                if (!variantUuid0 && !variantText0) {
                     formError = true;
                     this.setFormErrors('SEGrecessiveZygosity', `For ${SEGrecessiveZygosity}, one variant must be specified`);
                 }
@@ -792,7 +792,7 @@ var IndividualCuration = React.createClass({
                 addVariantDisabled = true;
             }
             // Update the form and display values with new data
-            this.refs['VARclinvarid' + fieldNum].setValue(data['uuid']);
+            this.refs['variantUuid' + fieldNum].setValue(data['uuid']);
             newVariantInfo[fieldNum] = {
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
@@ -803,7 +803,7 @@ var IndividualCuration = React.createClass({
             currVariantOption[parseInt(fieldNum)] = VAR_SPEC;
         } else {
             // Reset the form and display values
-            this.refs['VARclinvarid' + fieldNum].setValue('');
+            this.refs['variantUuid' + fieldNum].setValue('');
             delete newVariantInfo[fieldNum];
             // Reenable the 'Other description' textarea
             currVariantOption[parseInt(fieldNum)] = VAR_NONE;
@@ -1453,8 +1453,8 @@ var IndividualVariantInfo = function() {
                                         </div>
                                     </div>
                                 : null}
-                                <Input type="text" ref={'VARclinvarid' + i} value={variant && variant.uuid} handleChange={this.handleChange}
-                                    error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
+                                <Input type="text" ref={'variantUuid' + i} value={variant && variant.uuid} handleChange={this.handleChange}
+                                    error={this.getFormError('variantUuid' + i)} clearError={this.clrFormErrors.bind(null, 'variantUuid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <br />
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1507,18 +1507,20 @@ var IndividualVariantInfo = function() {
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <div className="row">
                                     <div className="form-group">
-                                    <span className="col-sm-5 control-label"><label>Add Variant</label></span>
-                                    <span className="col-sm-7">
-                                        <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRender={false} clearButtonClass="btn-inline-spacer"
-                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                            updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
-                                        <span> - or - </span>
-                                        <AddResourceId resourceType="car" labelVisible={false} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit CAR ID" : "Add CAR ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRender={false} clearButtonClass="btn-inline-spacer"
-                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                            updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
-                                    </span>
+                                        <span className="col-sm-5 control-label"><label>{!this.state.variantInfo[i] ? "Add Variant:" : "Clear Variant Selection:"}</label></span>
+                                        <span className="col-sm-7">
+                                            <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
+                                            {!this.state.variantInfo[i] ? <span> - or - </span> : null}
+                                            {!this.state.variantInfo[i] ?
+                                                <AddResourceId resourceType="car" labelVisible={false} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit CAR ID" : "Add CAR ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                    initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                    updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
+                                            : null}
+                                        </span>
                                     </div>
                                 </div>
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -847,11 +847,6 @@ var IndividualCuration = React.createClass({
         return newIndividual;
     },
 
-    // Add another variant section to the FamilyVariant panel
-    handleAddVariant: function() {
-        this.setState({variantCount: this.state.variantCount + 1, addVariantDisabled: true});
-    },
-
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
     updateClinvarVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
@@ -879,6 +874,7 @@ var IndividualCuration = React.createClass({
         }
         // Set state
         this.setState({variantInfo: newVariantInfo, variantOption: currVariantOption, addVariantDisabled: addVariantDisabled});
+        this.clrFormErrors('SEGrecessiveZygosity');
     },
 
     // Determine whether a Family is associated with a Group

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1406,7 +1406,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].grch38 ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label><LabelCARVariantTitle /></label></span>
-                                                <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
+                                                <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38} (GRCh38)</span>
                                             </div>
                                         : null}
                                         <div className="row variant-assessment">
@@ -1505,7 +1505,7 @@ var LabelCARVariant = React.createClass({
 
 var LabelCARVariantTitle = React.createClass({
     render: function() {
-        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
+        return <span><strong>Genomic HGVS Title:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1285,15 +1285,26 @@ var IndividualVariantInfo = function() {
                                 <p>Variant(s) for a proband associated with a Family can only be edited through the Family page: <a href={"/family-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&family=" + family.uuid}>Edit {family.label}</a></p>
                                 <h5>Variant {i + 1}</h5>
                                 <dl className="dl-horizontal">
-                                    <div>
-                                        <dt>ClinVar VariationID</dt>
-                                        <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} target="_blank">{variant.clinvarVariantId}</a></dd>
-                                    </div>
+                                    {variant.clinvarVariantId ?
+                                        <div>
+                                            <dt>ClinVar VariationID</dt>
+                                            <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                        </div>
+                                    : null}
 
-                                    <div>
-                                        <dt>ClinVar Preferred Title</dt>
-                                        <dd>{variant.clinvarVariantTitle}</dd>
-                                    </div>
+                                    {variant.clinvarVariantTitle ?
+                                        <div>
+                                            <dt>ClinVar Preferred Title</dt>
+                                            <dd>{variant.clinvarVariantTitle}</dd>
+                                        </div>
+                                    : null}
+
+                                    {variant.carId ?
+                                        <div>
+                                            <dt>CAR ID</dt>
+                                            <dd>{variant.carId}</dd>
+                                        </div>
+                                    : null}
 
                                     {variant.otherDescription && variant.otherDescription.length ?
                                         <div>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1842,7 +1842,6 @@ var LabelPanelTitleView = React.createClass({
 // Returns a promise once the Individual object is written.
 var makeStarterIndividual = module.exports.makeStarterIndividual = function(label, diseases, variants, zygosity, context) {
     var newIndividual = {};
-
     newIndividual.label = label;
     newIndividual.diagnosis = diseases;
     newIndividual.variants = variants;

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -84,6 +84,7 @@ var IndividualCuration = React.createClass({
         } else if (ref === 'individualname') {
             this.setState({individualName: this.refs[ref].getValue()});
         } else if (ref === 'SEGrecessiveZygosity') {
+            // set the variant count and variant required as necessary
             let tempValue = this.refs[ref].getValue();
             if (tempValue === 'Heterozygous') {
                 this.setState({variantCount: 2, variantRequired: true});
@@ -92,14 +93,6 @@ var IndividualCuration = React.createClass({
             } else {
                 this.setState({variantCount: 1, variantRequired: false});
             }
-            /*
-            //Only show option to add 2nd variant if user selects 'Heterozygous'
-            this.refs[ref].getValue() === 'Heterozygous' ? this.setState({recessiveZygosity: 'Heterozygous'}) : this.setState({recessiveZygosity: null}, () => {
-                if (this.state.variantCount > 1) {
-                    this.setState({variantCount: this.state.variantCount-1, addVariantDisabled: false});
-                }
-            });
-            */
         } else if (ref === 'proband' && this.refs[ref].getValue() === 'Yes') {
             this.setState({proband_selected: true});
         } else if (ref === 'proband') {

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1505,10 +1505,22 @@ var IndividualVariantInfo = function() {
                                 <Input type="text" ref={'VARclinvarid' + i} value={variant && variant.clinvarVariantId} handleChange={this.handleChange}
                                     error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
-                                <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} clearButtonClass="btn-inline-spacer"
-                                    initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                    updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
+                                <div className="row">
+                                    <div className="form-group">
+                                    <span className="col-sm-5 control-label"><label>Add Variant</label></span>
+                                    <span className="col-sm-7">
+                                        <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant variantRequired={this.state.variantRequired} />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRender={false} clearButtonClass="btn-inline-spacer"
+                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                            updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
+                                        <span> - or - </span>
+                                        <AddResourceId resourceType="car" labelVisible={false} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                            buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit CAR ID" : "Add CAR ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRender={false} clearButtonClass="btn-inline-spacer"
+                                            initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                            updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} buttonOnly={true} />
+                                    </span>
+                                    </div>
+                                </div>
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1505,7 +1505,7 @@ var IndividualVariantInfo = function() {
                                     error={this.getFormError('VARclinvarid' + i)} clearError={this.clrFormErrors.bind(null, 'VARclinvarid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <AddResourceId resourceType="clinvar" label={<LabelClinVarVariant />} labelVisible={!this.state.variantInfo[i]} parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol}
+                                    buttonText={this.state.variantOption[i] === VAR_SPEC ? "Edit ClinVar ID" : "Add ClinVar ID" } protocol={this.props.href_url.protocol} clearButtonRender={true} clearButtonClass="btn-inline-spacer"
                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                     updateParentForm={this.updateClinvarVariantId} disabled={this.state.variantOption[i] === VAR_OTHER} />
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -93,6 +93,16 @@ var IndividualCuration = React.createClass({
             } else {
                 this.setState({variantCount: 1, variantRequired: false});
             }
+        } else if (ref.indexOf('variantDesc') > -1) {
+            let variantIdx = ref.slice(-1);
+            let tempValue = this.refs[ref].getValue();
+            let tempVariantOption = this.state.variantOption;
+            if (tempValue) {
+                tempVariantOption[parseInt(variantIdx)] = VAR_OTHER;
+            } else {
+                tempVariantOption[parseInt(variantIdx)] = VAR_NONE;
+            }
+            this.setState({variantOption: tempVariantOption});
         } else if (ref === 'proband' && this.refs[ref].getValue() === 'Yes') {
             this.setState({proband_selected: true});
         } else if (ref === 'proband') {
@@ -324,8 +334,8 @@ var IndividualCuration = React.createClass({
             let SEGrecessiveZygosity = this.getFormValue('SEGrecessiveZygosity');
             let variantUuid0 = this.getFormValue('variantUuid0'),
                 variantUuid1 = this.getFormValue('variantUuid1'),
-                variantText0 = this.getFormValue('VARothervariant0'),
-                variantText1 = this.getFormValue('VARothervariant1');
+                variantText0 = this.getFormValue('variantDesc0'),
+                variantText1 = this.getFormValue('variantDesc1');
 
             // Check that all Orphanet IDs have the proper format (will check for existence later)
             if (this.state.proband_selected && (!orphaIds || !orphaIds.length || _(orphaIds).any(function(id) { return id === null; }))) {
@@ -494,7 +504,7 @@ var IndividualCuration = React.createClass({
                     if (!currIndividual || !(currIndividual.proband && family)) {
                         for (var i = 0; i < this.state.variantCount; i++) {
                             // Grab the values from the variant form panel
-                            var otherVariantText = this.getFormValue('VARothervariant' + i).trim();
+                            var otherVariantText = this.getFormValue('variantDesc' + i).trim();
 
                             // Build the search string depending on what the user entered
                             if (otherVariantText) {
@@ -799,7 +809,7 @@ var IndividualCuration = React.createClass({
                 'carId': data.carId ? data.carId : null
             };
             // Disable the 'Other description' textarea
-            this.refs['VARothervariant' + fieldNum].resetValue();
+            this.refs['variantDesc' + fieldNum].resetValue();
             currVariantOption[parseInt(fieldNum)] = VAR_SPEC;
         } else {
             // Reset the form and display values
@@ -1453,7 +1463,7 @@ var IndividualVariantInfo = function() {
                                         </div>
                                     </div>
                                 : null}
-                                <Input type="text" ref={'variantUuid' + i} value={variant && variant.uuid} handleChange={this.handleChange}
+                                <Input type="text" ref={'variantUuid' + i} value={variant && variant.uuid}
                                     error={this.getFormError('variantUuid' + i)} clearError={this.clrFormErrors.bind(null, 'variantUuid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <br />
@@ -1476,7 +1486,7 @@ var IndividualVariantInfo = function() {
                                         </span>
                                     </div>
                                 </div>
-                                <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
+                                <Input type="textarea" ref={'variantDesc' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}
                             </div>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -210,7 +210,7 @@ var IndividualCuration = React.createClass({
 
                     // Go through each variant to determine how its form fields should be disabled.
                     for (var i = 0; i < variants.length; i++) {
-                        if (variants[i].clinvarVariantId) {
+                        if (variants[i].clinvarVariantId || variants[i].carId) {
                             stateObj.variantInfo[i] = {
                                 'clinvarVariantId': variants[i].clinvarVariantId ? variants[i].clinvarVariantId : null,
                                 'clinvarVariantTitle': variants[i].clinvarVariantTitle ? variants[i].clinvarVariantTitle : null,
@@ -731,7 +731,6 @@ var IndividualCuration = React.createClass({
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
     updateVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
-        var currVariantOption = this.state.variantOption;
         var addVariantDisabled;
         if (data) {
             // Enable/Disable Add Variant button as needed
@@ -754,7 +753,7 @@ var IndividualCuration = React.createClass({
             delete newVariantInfo[fieldNum];
         }
         // Set state
-        this.setState({variantInfo: newVariantInfo, variantOption: currVariantOption, addVariantDisabled: addVariantDisabled});
+        this.setState({variantInfo: newVariantInfo, addVariantDisabled: addVariantDisabled});
         this.clrFormErrors('SEGrecessiveZygosity');
     },
 
@@ -1416,15 +1415,17 @@ var IndividualVariantInfo = function() {
                                     <div className="form-group">
                                         <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                         <span className="col-sm-7">
-                                            <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                                buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                                initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                                updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                            {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                                <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
+                                                    buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                    initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                    updateParentForm={this.updateVariantId} buttonOnly={true} />
+                                            : null}
                                             {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                            {!this.state.variantInfo[i] ?
+                                            {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
                                                 <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                     buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
-                                                    initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
+                                                    initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}
                                                     updateParentForm={this.updateVariantId} buttonOnly={true} />
                                             : null}
                                         </span>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -60,7 +60,7 @@ var IndividualCuration = React.createClass({
             annotation: null, // Annotation object given in query string
             extraIndividualCount: 0, // Number of extra families to create
             extraIndividualNames: [], // Names of extra families to create
-            variantCount: 1, // Number of variants to display
+            variantCount: 0, // Number of variants to display
             variantOption: [VAR_NONE], // One variant panel, and nothing entered
             variantInfo: {}, // Extra holding info for variant display
             individualName: '', // Currently entered individual name
@@ -83,13 +83,23 @@ var IndividualCuration = React.createClass({
         } else if (ref === 'individualname') {
             this.setState({individualName: this.refs[ref].getValue()});
         } else if (ref === 'SEGrecessiveZygosity') {
+            let tempValue = this.refs[ref].getValue();
+            if (tempValue === 'Heterozygous') {
+                this.setState({variantCount: 2});
+            } else if (tempValue === 'Homozygous' || tempValue === 'Hemizygous') {
+                this.setState({variantCount: 1});
+            } else {
+                this.setState({variantCount: 0});
+            }
+            /*
             //Only show option to add 2nd variant if user selects 'Heterozygous'
             this.refs[ref].getValue() === 'Heterozygous' ? this.setState({recessiveZygosity: 'Heterozygous'}) : this.setState({recessiveZygosity: null}, () => {
                 if (this.state.variantCount > 1) {
                     this.setState({variantCount: this.state.variantCount-1, addVariantDisabled: false});
                 }
             });
-        } else if (ref.substring(0, 3) === 'VAR') {
+            */
+        } else if (ref === 'variantId1' || ref === 'variantId2') {
             // Disable Add Another Variant if no variant fields have a value (variant fields all start with 'VAR')
             // First figure out the last variant panel’s ref suffix, then see if any values in that panel have changed
             var lastVariantSuffix = (this.state.variantCount - 1) + '';
@@ -326,7 +336,7 @@ var IndividualCuration = React.createClass({
     validateVariants: function() {
         var valid;
         var anyInvalid = false;
-
+        /*
         // Check Variant panel inputs for correct formats
         for (var i = 0; i < this.state.variantCount; i++) {
             // Check dbSNP ID for a valid format
@@ -349,7 +359,7 @@ var IndividualCuration = React.createClass({
                 }
             }
         }
-
+        */
         return !anyInvalid;
     },
 
@@ -1468,6 +1478,15 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
+                    <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
+                        value={individual && individual.recessiveZygosity ? individual.recessiveZygosity : 'none'} handleChange={this.handleChange}
+                        labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
+                        <option value="none">No Selection</option>
+                        <option disabled="disabled"></option>
+                        <option value="Homozygous">Homozygous</option>
+                        <option value="Hemizygous">Hemizygous</option>
+                        <option value="Heterozygous">Heterozygous</option>
+                    </Input>
                     {_.range(this.state.variantCount).map(i => {
                         var variant;
 
@@ -1511,29 +1530,9 @@ var IndividualVariantInfo = function() {
                                 <Input type="textarea" ref={'VARothervariant' + i} label={<LabelOtherVariant />} rows="5" value={variant && variant.otherDescription} handleChange={this.handleChange} inputDisabled={this.state.variantOption[i] === VAR_SPEC}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
                                 {curator.renderMutalyzerLink()}
-                                {this.state.variantInfo[i] && i === 0 ?
-                                    <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
-                                        value={individual && individual.recessiveZygosity ? individual.recessiveZygosity : 'none'} handleChange={this.handleChange}
-                                        labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
-                                        <option value="none">No Selection</option>
-                                        <option disabled="disabled"></option>
-                                        <option value="Homozygous">Homozygous</option>
-                                        <option value="Hemizygous">Hemizygous</option>
-                                        <option value="Heterozygous">Heterozygous</option>
-                                    </Input>
-                                : null}
                             </div>
                         );
                     })}
-                    {this.state.variantCount === 0 || (this.state.variantCount === 1 && this.state.recessiveZygosity === 'Heterozygous') ?
-                        <div className="row">
-                            <div className="col-sm-7 col-sm-offset-5 clearfix">
-                                <Input type="button" ref="addvariant" inputClassName="btn-default btn-last pull-right"
-                                    title={this.state.variantCount ? "Add 2nd variant associated with Proband" : "Add variant associated with Proband"}
-                                    clickHandler={this.handleAddVariant} inputDisabled={this.state.addVariantDisabled} />
-                            </div>
-                        </div>
-                    : null}
                     {Object.keys(this.state.variantInfo).length > 0 ?
                         <div  className="variant-panel">
                             <Input type="select" ref="individualBothVariantsInTrans" label={<span>If there are 2 variants described, are they both located in <i>trans</i> with respect to one another?</span>}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1415,14 +1415,14 @@ var IndividualVariantInfo = function() {
                                     <div className="form-group">
                                         <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
                                         <span className="col-sm-7">
-                                            {this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId ?
+                                            {!this.state.variantInfo[i] || (this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId) ?
                                                 <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                     buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                     updateParentForm={this.updateVariantId} buttonOnly={true} />
                                             : null}
                                             {!this.state.variantInfo[i] ? <span> - or - </span> : null}
-                                            {this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId ?
+                                            {!this.state.variantInfo[i] || (this.state.variantInfo[i] && !this.state.variantInfo[i].clinvarVariantId) ?
                                                 <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                     buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].carId} fieldNum={String(i)}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1400,8 +1400,6 @@ var IndividualVariantInfo = function() {
                                 <Input type="text" ref={'variantUuid' + i} value={variant && variant.uuid}
                                     error={this.getFormError('variantUuid' + i)} clearError={this.clrFormErrors.bind(null, 'variantUuid' + i)}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
-                                <br />
-
                                 <div className="row">
                                     <div className="form-group">
                                         <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -729,7 +729,7 @@ var IndividualCuration = React.createClass({
     },
 
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
-    updateClinvarVariantId: function(data, fieldNum) {
+    updateVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
         var currVariantOption = this.state.variantOption;
         var addVariantDisabled;
@@ -745,7 +745,8 @@ var IndividualCuration = React.createClass({
             newVariantInfo[fieldNum] = {
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
-                'carId': data.carId ? data.carId : null
+                'carId': data.carId ? data.carId : null,
+                'uuid': data.uuid
             };
         } else {
             // Reset the form and display values
@@ -1418,13 +1419,13 @@ var IndividualVariantInfo = function() {
                                             <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                 buttonText="Add ClinVar ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                 initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                                updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                                updateParentForm={this.updateVariantId} buttonOnly={true} />
                                             {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                             {!this.state.variantInfo[i] ?
                                                 <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
                                                     buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
-                                                    updateParentForm={this.updateClinvarVariantId} buttonOnly={true} />
+                                                    updateParentForm={this.updateVariantId} buttonOnly={true} />
                                             : null}
                                         </span>
                                     </div>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1281,15 +1281,15 @@ var IndividualVariantInfo = function() {
         <div className="row">
             {individual && individual.proband && family ?
                 <div>
+                    <p>Variant(s) for a proband associated with a Family can only be edited through the Family page: <a href={"/family-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&family=" + family.uuid}>Edit {family.label}</a></p>
                     {variants.map(function(variant, i) {
                         return (
                             <div key={i} className="variant-view-panel variant-view-panel-edit">
-                                <p>Variant(s) for a proband associated with a Family can only be edited through the Family page: <a href={"/family-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&family=" + family.uuid}>Edit {family.label}</a></p>
                                 <h5>Variant {i + 1}</h5>
                                 <dl className="dl-horizontal">
                                     {variant.clinvarVariantId ?
                                         <div>
-                                            <dt>ClinVar VariationID</dt>
+                                            <dt>ClinVar Variation ID</dt>
                                             <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} target="_blank">{variant.clinvarVariantId}</a></dd>
                                         </div>
                                     : null}
@@ -1303,8 +1303,15 @@ var IndividualVariantInfo = function() {
 
                                     {variant.carId ?
                                         <div>
-                                            <dt>CAR ID</dt>
+                                            <dt>ClinGen Allele Registry Variation ID</dt>
                                             <dd>{variant.carId}</dd>
+                                        </div>
+                                    : null}
+
+                                    {!variant.clinvarVariantTitle && variant.carId && variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                        <div>
+                                            <dt>Genomic HGVS Title (GRCh38)</dt>
+                                            <dd>{variant.hgvsNames.GRCh38}</dd>
                                         </div>
                                     : null}
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1303,15 +1303,15 @@ var IndividualVariantInfo = function() {
 
                                     {variant.carId ?
                                         <div>
-                                            <dt>ClinGen Allele Registry Variation ID</dt>
+                                            <dt>ClinGen Allele Registry ID</dt>
                                             <dd>{variant.carId}</dd>
                                         </div>
                                     : null}
 
                                     {!variant.clinvarVariantTitle && variant.carId && variant.hgvsNames && variant.hgvsNames.GRCh38 ?
                                         <div>
-                                            <dt>Genomic HGVS Title (GRCh38)</dt>
-                                            <dd>{variant.hgvsNames.GRCh38}</dd>
+                                            <dt>Genomic HGVS Title</dt>
+                                            <dd>{variant.hgvsNames.GRCh38} (GRCh38)</dd>
                                         </div>
                                     : null}
 
@@ -1499,7 +1499,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelCARVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -215,6 +215,7 @@ var IndividualCuration = React.createClass({
                                 'clinvarVariantId': variants[i].clinvarVariantId ? variants[i].clinvarVariantId : null,
                                 'clinvarVariantTitle': variants[i].clinvarVariantTitle ? variants[i].clinvarVariantTitle : null,
                                 'carId': variants[i].carId ? variants[i].carId : null,
+                                'grch38': variants[i].hgvsNames && variants[i].hgvsNames.GRCh38 ? variants[i].hgvsNames.GRCh38 : null,
                                 'uuid': variants[i].uuid
                             };
                         }
@@ -745,6 +746,7 @@ var IndividualCuration = React.createClass({
                 'clinvarVariantId': data.clinvarVariantId ? data.clinvarVariantId : null,
                 'clinvarVariantTitle': data.clinvarVariantTitle ? data.clinvarVariantTitle : null,
                 'carId': data.carId ? data.carId : null,
+                'grch38': data.hgvsNames && data.hgvsNames.GRCh38 ? data.hgvsNames.GRCh38 : null,
                 'uuid': data.uuid
             };
         } else {
@@ -1390,8 +1392,14 @@ var IndividualVariantInfo = function() {
                                         : null}
                                         {this.state.variantInfo[i].carId ?
                                             <div className="row">
-                                                <span className="col-sm-5 control-label"><label>CAR ID:</label></span>
-                                                <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].carId}</span>
+                                                <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
+                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                            </div>
+                                        : null}
+                                        {this.state.variantInfo[i].grch38 ?
+                                            <div className="row">
+                                                <span className="col-sm-5 control-label"><label><LabelCARVariantTitle /></label></span>
+                                                <span className="col-sm-7 text-no-input">{this.state.variantInfo[i].grch38}</span>
                                             </div>
                                         : null}
                                         <div className="row variant-assessment">
@@ -1472,13 +1480,25 @@ var IndividualVariantInfo = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> VariationID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
     }
 });
 
 var LabelClinVarVariantTitle = React.createClass({
     render: function() {
         return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Preferred Title:</strong></span>;
+    }
+});
+
+var LabelCARVariant = React.createClass({
+    render: function() {
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+    }
+});
+
+var LabelCARVariantTitle = React.createClass({
+    render: function() {
+        return <span><strong>Genomic HGVS Title (GRCh38):</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1423,7 +1423,7 @@ var IndividualVariantInfo = function() {
                                             {!this.state.variantInfo[i] ? <span> - or - </span> : null}
                                             {!this.state.variantInfo[i] ?
                                                 <AddResourceId resourceType="car" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
-                                                    buttonText="Add CAR ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
+                                                    buttonText="Add CA ID" protocol={this.props.href_url.protocol} clearButtonRender={true} editButtonRenderHide={true} clearButtonClass="btn-inline-spacer"
                                                     initialFormValue={this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId} fieldNum={String(i)}
                                                     updateParentForm={this.updateVariantId} buttonOnly={true} />
                                             : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1388,7 +1388,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].clinvarVariantId ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
-                                                <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
+                                                <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
                                             </div>
                                         : null}
                                         {this.state.variantInfo[i].clinvarVariantTitle ?
@@ -1400,7 +1400,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].carId ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
-                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
                                             </div>
                                         : null}
                                         {this.state.variantInfo[i].grch38 ?


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/20770449/9f864faa-b6fa-11e6-9aac-3d9378a09f67.png)

* Implemented ability to associate CAR Variants in the GCI's family, individual, and experimental pages (#957)
  * `submitForm` methods no longer ping the internal database to get a variant's UUID. The Add External Resource modal response handles this now
  * CAR IDs are displayed now whenever applicable with appropriate labels
* Added Clear option to GCI regarding variants (#1136)
* Added flag to control rendering of the Edit button for the Add External Resource modal module
* Removed old code and revised remaining code in the GCI's family, individual, and experimental pages regarding:
  * ClinVar-specific variant data
  * Free text
* Revised logic regarding adding of proband individual and variants via Family page
* Added link to edit proband individual from Family page (edit mode)

Testing:

1. Get to GCI
2. Curate Experimental and add different types of variants (ClinVar ID, CA ID, CA ID w/ no ClinVar data (CA501058)), testing Clear, Save (of form), Edit (of form)
3. Curate Individual and add different types of variants (ClinVar ID, CA ID, CA ID w/ no ClinVar data (CA501058)), testing Clear, Save (of form), Edit (of form)
4. Curate Family and add different types of variants (ClinVar ID, CA ID, CA ID w/ no ClinVar data (CA501058)), testing Clear, Save (of form), Edit (of form). Also check the form and function of the Individual page created by the Family form.

Note: Implementing CA ID support into the GCI has raised numerous downstream issues. These should be addressed in #1155.