### PR TITLE
Connects to #1150. Interpretation list

### DIFF
--- a/src/clincoded/schemas/gdm.json
+++ b/src/clincoded/schemas/gdm.json
@@ -171,6 +171,10 @@
             "title": "Creator",
             "type": "string"
         },
+        "submitted_by.first_name": {
+            "title": "Creator",
+            "type": "string"
+        },
         "submitted_by.email": {
             "title": "Creator email",
             "type": "string"

--- a/src/clincoded/schemas/group.json
+++ b/src/clincoded/schemas/group.json
@@ -366,10 +366,6 @@
         "submitted_by.title": {
             "title": "Submitted by",
             "type": "string"
-        },
-        "date_created": {
-            "title": "Creation Date",
-            "type": "string"
         }
     }
 }

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -180,6 +180,10 @@
             "title": "# Provisional",
             "type": "number"
         },
+        "evaluations": {
+            "title": "Evaluations",
+            "type": "string"
+        },
         "submitted_by.last_name": {
             "title": "Creator Last Name",
             "type": "string"

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -180,6 +180,14 @@
             "title": "# Provisional",
             "type": "number"
         },
+        "submitted_by.last_name": {
+            "title": "Creator Last Name",
+            "type": "string"
+        },
+        "submitted_by.first_name": {
+            "title": "Creator First Name",
+            "type": "string"
+        },
         "submitted_by.title": {
             "title": "Creator",
             "type": "string"

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -128,13 +128,29 @@
         }
     },
     "columns": {
-        "variant.variant_identifier": {
-            "title": "Variant ID",
+        "uuid": {
+            "title": "Interpretation UUID",
             "type": "string"
         },
-        "variant.source": {
-            "title": "Variant Source",
+        "variant.uuid": {
+            "title": "Variant UUID",
             "type": "string"
+        },
+        "variant.clinvarVariantId": {
+            "title": "Variant ClinVar ID",
+            "type": "string"
+        },
+        "variant.clinvarVariantTitle": {
+            "title": "Variant ClinVar Title",
+            "type": "string"
+        },
+        "variant.carId": {
+            "title": "Variant CA ID",
+            "type": "string"
+        },
+        "variant.hgvsNames": {
+            "title": "Variant HGVS Names",
+            "type": "object"
         },
         "interpretation_status": {
             "title": "Interpretation Status",
@@ -144,8 +160,16 @@
             "title": "Genes",
             "type": "string"
         },
-        "interpretation_disease": {
-            "title": "Disease",
+        "disease.orphaNumber": {
+            "title": "Disease Orphanet Number",
+            "type": "string"
+        },
+        "disease.term": {
+            "title": "Disease Orphanet Term",
+            "type": "string"
+        },
+        "modeInheritance": {
+            "title": "Mode of Inheritance",
             "type": "string"
         },
         "evaluation_count": {

--- a/src/clincoded/schemas/interpretation.json
+++ b/src/clincoded/schemas/interpretation.json
@@ -195,6 +195,10 @@
         "submitted_by.title": {
             "title": "Creator",
             "type": "string"
+        },
+        "date_created": {
+            "title": "Creation Date",
+            "type": "string"
         }
     }
 }

--- a/src/clincoded/static/components/dashboard.js
+++ b/src/clincoded/static/components/dashboard.js
@@ -147,6 +147,7 @@ var Dashboard = React.createClass({
                                         <i className="icon icon-question-circle"></i>
                                     </a>
                                 </li>
+                                <li><a href="/interpretations/">View list of all Variant Interpretations</a></li>
                                 <li><a href="/create-gene-disease/">Create Gene-Disease Record</a></li>
                                 <li><a href="/gdm/">View list of all Gene-Disease Records</a></li>
                             </ul>

--- a/src/clincoded/static/components/gdm.js
+++ b/src/clincoded/static/components/gdm.js
@@ -11,7 +11,7 @@ var Input = form.Input;
 var truncateString = globals.truncateString;
 
 
-// Map GDM statuses from 
+// Map GDM statuses from
 var statusMappings = {
 //  Status from GDM                         CSS class                Short name for screen display
     'Created':                             {cssClass: 'created',     shortName: 'Created'},
@@ -57,7 +57,7 @@ var GdmCollection = module.exports.GdmCollection = React.createClass({
             case 'last':
                 var aAnnotation = curator.findLatestAnnotation(a);
                 var bAnnotation = curator.findLatestAnnotation(b);
-                diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? -1 : 1);
+                diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? 1 : -1);
                 break;
             case 'creator':
                 var aLower = a.submitted_by.last_name.toLowerCase();
@@ -170,7 +170,7 @@ var GdmCollection = module.exports.GdmCollection = React.createClass({
                                     </div>
 
                                     <div className="table-cell-gdm">
-                                        <div>{gdm.submitted_by.title}</div>
+                                        <div>{gdm.submitted_by.last_name}, {gdm.submitted_by.first_name}</div>
                                     </div>
 
                                     <div className="table-cell-gdm">
@@ -198,7 +198,7 @@ var GdmStatusLegend = React.createClass({
                 <div className="gdm-status-legend">
                     {Object.keys(statusMappings).map(function(status, i) {
                         var iconClass = 'icon gdm-status-icon-' + statusMappings[status].cssClass;
-                        
+
                         return (
                             <div className={"col-sm-2 gdm-status-item" + (i === 0 ? ' col-sm-offset-1' : '')} key={i}>
                                 <span className={iconClass}></span>

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -457,7 +457,9 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                             let orphanetId = interpretation.disease && interpretation.disease.orphaNumber ? interpretation.disease.orphaNumber : null;
                             let diseaseTerm = interpretation.disease && interpretation.disease.term ? interpretation.disease.term : null;
                             let modeInheritance = interpretation.modeInheritance ? interpretation.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
+                            console.log(interpretation.date_created);
                             let createdTime = moment(interpretation.date_created);
+                            console.log(createdTime);
                             let latestEvaluation = interpretation && this.findLatestEvaluations(interpretation);
                             let latestTime = latestEvaluation ? moment(latestEvaluation.date_created) : '';
                             let statusString = statusMappings[interpretation.interpretation_status].cssClass; // Convert status string to CSS class

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -292,11 +292,6 @@ var InterpretationModifyHistory = React.createClass({
 globals.history_views.register(InterpretationModifyHistory, 'interpretation', 'modify');
 
 
-
-
-
-
-
 // Map Interpretation statuses from
 var statusMappings = {
 //  Status from Interpretation        CSS class                Short name for screen display
@@ -344,8 +339,8 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                 diff = (a.modeInheritance ? a.modeInheritance : "") > (b.modeInheritance ? b.modeInheritance : "") ? 1 : -1;
                 break;
             case 'last':
-                var aAnnotation = curator.findLatestAnnotation(a);
-                var bAnnotation = curator.findLatestAnnotation(b);
+                var aAnnotation = this.findLatestEvaluations(a);
+                var bAnnotation = this.findLatestEvaluations(b);
                 diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? -1 : 1);
                 break;
             case 'creator':
@@ -366,6 +361,23 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
     searchChange: function(ref, e) {
         var searchVal = this.refs[ref].getValue().toLowerCase();
         this.setState({searchTerm: searchVal});
+    },
+
+    findLatestEvaluations: function(interpretation) {
+        var evaluations = interpretation && interpretation.evaluations;
+        var latestEvaluation = null;
+        var latestTime = 0;
+        if (evaluations && evaluations.length) {
+            evaluations.forEach(function(evaluation) {
+                // Get Unix timestamp version of annotation's time and compare against the saved version.
+                var time = moment(evaluation.date_created).format('x');
+                if (latestTime < time) {
+                    latestEvaluation = evaluation;
+                    latestTime = time;
+                }
+            });
+        }
+        return latestEvaluation;
     },
 
     render: function () {
@@ -436,12 +448,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                                 Created<span className={sortIconClass.created}></span>
                             </div>
                         </div>
-                        {filteredInterpretations.sort(this.sortCol).map(function(interpretation) {
-                            console.log(interpretation);
-                            //var annotationOwners = curator.getAnnotationOwners(gdm);
-                            //var latestAnnotation = gdm && curator.findLatestAnnotation(gdm);
-                            //var mode = gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
-                            //var term = truncateString(gdm.disease.term, 30);
+                        {filteredInterpretations.sort(this.sortCol).map(interpretation => {
                             let variantUuid = interpretation.variant.uuid;
                             let clinvarVariantId = interpretation.variant.clinvarVariantId ? interpretation.variant.clinvarVariantId : null;
                             let clinvarVariantTitle = interpretation.variant.clinvarVariantTitle ? interpretation.variant.clinvarVariantTitle : null;
@@ -451,8 +458,8 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                             let diseaseTerm = interpretation.disease && interpretation.disease.term ? interpretation.disease.term : null;
                             let modeInheritance = interpretation.modeInheritance ? interpretation.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
                             let createdTime = moment(interpretation.date_created);
-                            //var latestTime = latestAnnotation ? moment(latestAnnotation.date_created) : '';
-                            //var participants = annotationOwners.map(function(owner) { return owner.title; }).join(', ');
+                            let latestEvaluation = interpretation && this.findLatestEvaluations(interpretation);
+                            let latestTime = latestEvaluation ? moment(latestEvaluation.date_created) : '';
                             let statusString = statusMappings[interpretation.interpretation_status].cssClass; // Convert status string to CSS class
                             let iconClass = 'icon gdm-status-icon-' + statusString;
 
@@ -480,12 +487,12 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                                     </div>
 
                                     <div className="table-cell-gdm">
-                                        {/*latestTime ?
+                                        {latestTime ?
                                             <div>
                                                 <div>{latestTime.format("YYYY MMM DD")}</div>
                                                 <div>{latestTime.format("h:mm a")}</div>
                                             </div>
-                                        : null*/}
+                                        : null}
                                     </div>
 
                                     <div className="table-cell-gdm">

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -341,7 +341,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
             case 'last':
                 var aAnnotation = this.findLatestEvaluations(a);
                 var bAnnotation = this.findLatestEvaluations(b);
-                diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? -1 : 1);
+                diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? 1 : -1);
                 break;
             case 'creator':
                 var aLower = a.submitted_by.last_name.toLowerCase();

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -317,8 +317,8 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
         this.setState({sortCol: sortCol, reversed: reversed});
     },
 
-    // Call-back for the JS sorting function. Expects GDMs to compare in a and b. Depending on the column currently selected
-    // for sorting, this function sorts on the relevant parts of the GDM.
+    // Call-back for the JS sorting function. Expects Interpretationss to compare in a and b. Depending on the column currently selected
+    // for sorting, this function sorts on the relevant parts of the Interpretation.
     sortCol: function(a, b) {
         var diff;
 
@@ -369,7 +369,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
         var latestTime = 0;
         if (evaluations && evaluations.length) {
             evaluations.forEach(function(evaluation) {
-                // Get Unix timestamp version of annotation's time and compare against the saved version.
+                // Get Unix timestamp version of evaluations's time and compare against the saved version.
                 var time = moment(evaluation.date_created).format('x');
                 if (latestTime < time) {
                     latestEvaluation = evaluation;
@@ -516,7 +516,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
 globals.content_views.register(InterpretationCollection, 'interpretation_collection');
 
 
-// Render the GDM status legend
+// Render the Interpretation status legend
 var InterpretationStatusLegend = React.createClass({
     render: function() {
         return (

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -367,7 +367,10 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
         var interpretations = context['@graph'];
         var searchTerm = this.state.searchTerm;
         var filteredInterpretations;
-        var sortIconClass = {status: 'tcell-sort', variant: 'tcell-sort', last: 'tcell-sort', creator: 'tcell-sort', created: 'tcell-sort'};
+        var sortIconClass = {
+            status: 'tcell-sort', variant: 'tcell-sort', disease: 'tcell-sort', moi: 'tcell-sort',
+            last: 'tcell-sort', creator: 'tcell-sort', created: 'tcell-sort'
+        };
         sortIconClass[this.state.sortCol] = this.state.reversed ? 'tcell-desc' : 'tcell-asc';
 
         // Filter Interpretations
@@ -407,12 +410,15 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                             <div className="table-cell-gdm-status tcell-sortable" onClick={this.sortDir.bind(null, 'status')}>
                                 <span className="icon gdm-status-icon-header"></span><span className={sortIconClass.status}></span>
                             </div>
-                            <div className="table-cell-gdm-main tcell-sortable" onClick={this.sortDir.bind(null, 'gdm')}>
+                            <div className="table-cell-gdm-main tcell-sortable" onClick={this.sortDir.bind(null, 'variant')}>
                                 <div>Variant Preferred Title<span className={sortIconClass.variant}></span></div>
                                 <div>Variant ID(s)</div>
                             </div>
-                            <div className="table-cell-gdm">
-                                Participants
+                            <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'disease')}>
+                                Disease<span className={sortIconClass.disease}></span>
+                            </div>
+                            <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'moi')}>
+                                Mode of Inheritance<span className={sortIconClass.moi}></span>
                             </div>
                             <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'last')}>
                                 Last Edited<span className={sortIconClass.last}></span>
@@ -437,6 +443,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                             let grch38 = interpretation.variant.hgvsNames && interpretation.variant.hgvsNames.GRCh38 ? interpretation.variant.hgvsNames.GRCh38 : null;
                             let orphanetId = interpretation.disease && interpretation.disease.orphaNumber ? interpretation.disease.orphaNumber : null;
                             let diseaseTerm = interpretation.disease && interpretation.disease.term ? interpretation.disease.term : null;
+                            let modeInheritance = interpretation.modeInheritance ? interpretation.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
                             let createdTime = moment(interpretation.date_created);
                             //var latestTime = latestAnnotation ? moment(latestAnnotation.date_created) : '';
                             //var participants = annotationOwners.map(function(owner) { return owner.title; }).join(', ');
@@ -450,11 +457,20 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                                     </div>
 
                                     <div className="table-cell-gdm-main">
-                                        <div>{clinvarVariantId} – {clinvarVariantTitle}</div>
+                                        <div>{clinvarVariantTitle ? clinvarVariantTitle : grch38}</div>
+                                        <div>
+                                            {clinvarVariantId ? <span>ClinVar Variation ID: <strong>{clinvarVariantId}</strong></span> : null}
+                                            {clinvarVariantId && carId ? " // " : null}
+                                            {carId ? <span>ClinGen Allele Registry ID: <strong>{carId}</strong></span> : null}
+                                        </div>
                                     </div>
 
                                     <div className="table-cell-gdm">
-                                        {/*participants*/}
+                                        {diseaseTerm ? <span>{diseaseTerm} (ORPHA{orphanetId})</span> : null}
+                                    </div>
+
+                                    <div className="table-cell-gdm">
+                                        {modeInheritance ? modeInheritance : null}
                                     </div>
 
                                     <div className="table-cell-gdm">

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -330,12 +330,18 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
         switch (this.state.sortCol) {
             case 'status':
                 var statuses = Object.keys(statusMappings);
-                var statusIndexA = statuses.indexOf(a.gdm_status);
-                var statusIndexB = statuses.indexOf(b.gdm_status);
+                var statusIndexA = statuses.indexOf(a.interpretation_status);
+                var statusIndexB = statuses.indexOf(b.interpretation_status);
                 diff = statusIndexA - statusIndexB;
                 break;
-            case 'gdm':
-                diff = a.gene.symbol > b.gene.symbol ? 1 : -1;
+            case 'variant':
+                diff = (a.variant.clinvarVariantId ? a.variant.clinvarVariantId : a.variant.carId) > (b.variant.clinvarVariantId ? b.variant.clinvarVariantId : b.variant.carId) ? 1 : -1;
+                break;
+            case 'disease':
+                diff = (a.disease && a.disease.orphaNumber ? a.disease.orphaNumber : "") > (b.disease && b.disease.orphaNumber ? b.disease.orphaNumber : "") ? 1 : -1;
+                break;
+            case 'moi':
+                diff = (a.modeInheritance ? a.modeInheritance : "") > (b.modeInheritance ? b.modeInheritance : "") ? 1 : -1;
                 break;
             case 'last':
                 var aAnnotation = curator.findLatestAnnotation(a);

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -333,7 +333,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                 diff = (a.variant.clinvarVariantId ? a.variant.clinvarVariantId : a.variant.carId) > (b.variant.clinvarVariantId ? b.variant.clinvarVariantId : b.variant.carId) ? 1 : -1;
                 break;
             case 'disease':
-                diff = (a.disease && a.disease.orphaNumber ? a.disease.orphaNumber : "") > (b.disease && b.disease.orphaNumber ? b.disease.orphaNumber : "") ? 1 : -1;
+                diff = (a.disease && a.disease.term ? a.disease.term : "") > (b.disease && b.disease.term ? b.disease.term : "") ? 1 : -1;
                 break;
             case 'moi':
                 diff = (a.modeInheritance ? a.modeInheritance : "") > (b.modeInheritance ? b.modeInheritance : "") ? 1 : -1;

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -7,9 +7,11 @@ var form = require('../../libs/bootstrap/form');
 var Form = form.Form;
 var Input = form.Input;
 var FormMixin = form.FormMixin;
+var curator = require('../curator');
 
 var queryKeyValue = globals.queryKeyValue;
 var editQueryValue = globals.editQueryValue;
+var truncateString = globals.truncateString;
 
 // Import individual tab components
 var CurationInterpretationCriteria = require('./interpretation/criteria').CurationInterpretationCriteria;
@@ -288,3 +290,221 @@ var InterpretationModifyHistory = React.createClass({
 });
 
 globals.history_views.register(InterpretationModifyHistory, 'interpretation', 'modify');
+
+
+
+
+
+
+
+// Map Interpretation statuses from
+var statusMappings = {
+//  Status from Interpretation        CSS class                Short name for screen display
+    'In Progress':                    {cssClass: 'in-progress', shortName: 'In Progress'},
+    'Provisional':                    {cssClass: 'provisional', shortName: 'Provisional'}
+};
+
+var InterpretationCollection = module.exports.InterpretationCollection = React.createClass({
+    mixins: [FormMixin],
+
+    getInitialState: function() {
+        return {
+            sortCol: 'variant',
+            reversed: false,
+            searchTerm: ''
+        };
+    },
+
+    // Handle clicks in the table header for sorting
+    sortDir: function(colName) {
+        var reversed = colName === this.state.sortCol ? !this.state.reversed : false;
+        var sortCol = colName;
+        this.setState({sortCol: sortCol, reversed: reversed});
+    },
+
+    // Call-back for the JS sorting function. Expects GDMs to compare in a and b. Depending on the column currently selected
+    // for sorting, this function sorts on the relevant parts of the GDM.
+    sortCol: function(a, b) {
+        var diff;
+
+        switch (this.state.sortCol) {
+            case 'status':
+                var statuses = Object.keys(statusMappings);
+                var statusIndexA = statuses.indexOf(a.gdm_status);
+                var statusIndexB = statuses.indexOf(b.gdm_status);
+                diff = statusIndexA - statusIndexB;
+                break;
+            case 'gdm':
+                diff = a.gene.symbol > b.gene.symbol ? 1 : -1;
+                break;
+            case 'last':
+                var aAnnotation = curator.findLatestAnnotation(a);
+                var bAnnotation = curator.findLatestAnnotation(b);
+                diff = aAnnotation && bAnnotation ? Date.parse(aAnnotation.date_created) - Date.parse(bAnnotation.date_created) : (aAnnotation ? -1 : 1);
+                break;
+            case 'creator':
+                var aLower = a.submitted_by.last_name.toLowerCase();
+                var bLower = b.submitted_by.last_name.toLowerCase();
+                diff = aLower > bLower ? 1 : (aLower === bLower ? 0 : -1);
+                break;
+            case 'created':
+                diff = Date.parse(a.date_created) - Date.parse(b.date_created);
+                break;
+            default:
+                diff = 0;
+                break;
+        }
+        return this.state.reversed ? -diff : diff;
+    },
+
+    searchChange: function(ref, e) {
+        var searchVal = this.refs[ref].getValue().toLowerCase();
+        this.setState({searchTerm: searchVal});
+    },
+
+    render: function () {
+        var context = this.props.context;
+        var interpretations = context['@graph'];
+        var searchTerm = this.state.searchTerm;
+        var filteredInterpretations;
+        var sortIconClass = {status: 'tcell-sort', variant: 'tcell-sort', last: 'tcell-sort', creator: 'tcell-sort', created: 'tcell-sort'};
+        sortIconClass[this.state.sortCol] = this.state.reversed ? 'tcell-desc' : 'tcell-asc';
+
+        // Filter Interpretations
+        if (searchTerm) {
+            filteredInterpretations = interpretations.filter(function(interpretation) {
+                return (
+                    (interpretation.variant.clinvarVariantId && interpretation.variant.clinvarVariantId.toLowerCase().indexOf(searchTerm) !== -1) ||
+                    (interpretation.variant.clinvarVariantTitle && interpretation.variant.clinvarVariantTitle.toLowerCase().indexOf(searchTerm) !== -1) ||
+                    (interpretation.variant.carId && interpretation.variant.carId.toLowerCase().indexOf(searchTerm) !== -1) ||
+                    (interpretation.variant.hvgsNames && interpretation.variant.hgvsNames.GRCh38 && interpretation.variant.hgvsNames.GRCh38.toLowerCase().indexOf(searchTerm) !== -1) ||
+                    (interpretation.disease && interpretation.disease.orphaNumber && interpretation.disease.orphaNumber.indexOf(searchTerm) !== -1) ||
+                    (interpretation.disease && interpretation.disease.term && interpretation.disease.term.toLowerCase().indexOf(searchTerm) !== -1)
+                );
+            });
+        } else {
+            filteredInterpretations = interpretations;
+        }
+
+        return (
+            <div className="container">
+                <div className="row gdm-header">
+                    <div className="col-sm-12 col-md-8">
+                        <h1>All Interpretations</h1>
+                    </div>
+                    <div className="col-md-1"></div>
+                    <div className="col-sm-12 col-md-3">
+                        <Form formClassName="form-std gdm-filter-form">
+                            <Input type="text" ref="q" placeholder="Filter by Variant or Disease" handleChange={this.searchChange}
+                                labelClassName="control-label" groupClassName="form-group" />
+                        </Form>
+                    </div>
+                </div>
+                <InterpretationStatusLegend />
+                <div className="table-responsive">
+                    <div className="table-gdm">
+                        <div className="table-header-gdm">
+                            <div className="table-cell-gdm-status tcell-sortable" onClick={this.sortDir.bind(null, 'status')}>
+                                <span className="icon gdm-status-icon-header"></span><span className={sortIconClass.status}></span>
+                            </div>
+                            <div className="table-cell-gdm-main tcell-sortable" onClick={this.sortDir.bind(null, 'gdm')}>
+                                <div>Variant Preferred Title<span className={sortIconClass.variant}></span></div>
+                                <div>Variant ID(s)</div>
+                            </div>
+                            <div className="table-cell-gdm">
+                                Participants
+                            </div>
+                            <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'last')}>
+                                Last Edited<span className={sortIconClass.last}></span>
+                            </div>
+                            <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'creator')}>
+                                Creator<span className={sortIconClass.creator}></span>
+                            </div>
+                            <div className="table-cell-gdm tcell-sortable" onClick={this.sortDir.bind(null, 'created')}>
+                                Created<span className={sortIconClass.created}></span>
+                            </div>
+                        </div>
+                        {filteredInterpretations.sort(this.sortCol).map(function(interpretation) {
+                            console.log(interpretation);
+                            //var annotationOwners = curator.getAnnotationOwners(gdm);
+                            //var latestAnnotation = gdm && curator.findLatestAnnotation(gdm);
+                            //var mode = gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
+                            //var term = truncateString(gdm.disease.term, 30);
+                            let variantUuid = interpretation.variant.uuid;
+                            let clinvarVariantId = interpretation.variant.clinvarVariantId ? interpretation.variant.clinvarVariantId : null;
+                            let clinvarVariantTitle = interpretation.variant.clinvarVariantTitle ? interpretation.variant.clinvarVariantTitle : null;
+                            let carId = interpretation.variant.carId ? interpretation.variant.carId : null;
+                            let grch38 = interpretation.variant.hgvsNames && interpretation.variant.hgvsNames.GRCh38 ? interpretation.variant.hgvsNames.GRCh38 : null;
+                            let orphanetId = interpretation.disease && interpretation.disease.orphaNumber ? interpretation.disease.orphaNumber : null;
+                            let diseaseTerm = interpretation.disease && interpretation.disease.term ? interpretation.disease.term : null;
+                            let createdTime = moment(interpretation.date_created);
+                            //var latestTime = latestAnnotation ? moment(latestAnnotation.date_created) : '';
+                            //var participants = annotationOwners.map(function(owner) { return owner.title; }).join(', ');
+                            let statusString = statusMappings[interpretation.interpretation_status].cssClass; // Convert status string to CSS class
+                            let iconClass = 'icon gdm-status-icon-' + statusString;
+
+                            return (
+                                <a className="table-row-gdm" href={'/variant-central/?variant=' + variantUuid} key={interpretation.uuid}>
+                                    <div className="table-cell-gdm-status">
+                                        <span className={iconClass} title={interpretation.interpretation_status}></span>
+                                    </div>
+
+                                    <div className="table-cell-gdm-main">
+                                        <div>{clinvarVariantId} – {clinvarVariantTitle}</div>
+                                    </div>
+
+                                    <div className="table-cell-gdm">
+                                        {/*participants*/}
+                                    </div>
+
+                                    <div className="table-cell-gdm">
+                                        {/*latestTime ?
+                                            <div>
+                                                <div>{latestTime.format("YYYY MMM DD")}</div>
+                                                <div>{latestTime.format("h:mm a")}</div>
+                                            </div>
+                                        : null*/}
+                                    </div>
+
+                                    <div className="table-cell-gdm">
+                                        <div>{interpretation.submitted_by.title}</div>
+                                    </div>
+
+                                    <div className="table-cell-gdm">
+                                        <div>{createdTime.format("YYYY MMM DD")}</div>
+                                        <div>{createdTime.format("h:mm a")}</div>
+                                    </div>
+                                </a>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+});
+
+globals.content_views.register(InterpretationCollection, 'interpretation_collection');
+
+
+// Render the GDM status legend
+var InterpretationStatusLegend = React.createClass({
+    render: function() {
+        return (
+            <div className="row">
+                <div className="gdm-status-legend">
+                    {Object.keys(statusMappings).map(function(status, i) {
+                        var iconClass = 'icon gdm-status-icon-' + statusMappings[status].cssClass;
+
+                        return (
+                            <div className={"col-sm-2 gdm-status-item" + (i === 0 ? ' col-sm-offset-1' : '')} key={i}>
+                                <span className={iconClass}></span>
+                                <span className="gdm-status-text">{statusMappings[status].shortName}</span>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        );
+    }
+});

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -457,9 +457,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                             let orphanetId = interpretation.disease && interpretation.disease.orphaNumber ? interpretation.disease.orphaNumber : null;
                             let diseaseTerm = interpretation.disease && interpretation.disease.term ? interpretation.disease.term : null;
                             let modeInheritance = interpretation.modeInheritance ? interpretation.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
-                            console.log(interpretation.date_created);
                             let createdTime = moment(interpretation.date_created);
-                            console.log(createdTime);
                             let latestEvaluation = interpretation && this.findLatestEvaluations(interpretation);
                             let latestTime = latestEvaluation ? moment(latestEvaluation.date_created) : '';
                             let statusString = statusMappings[interpretation.interpretation_status].cssClass; // Convert status string to CSS class

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -496,7 +496,7 @@ var InterpretationCollection = module.exports.InterpretationCollection = React.c
                                     </div>
 
                                     <div className="table-cell-gdm">
-                                        <div>{interpretation.submitted_by.title}</div>
+                                        <div>{interpretation.submitted_by.last_name}, {interpretation.submitted_by.first_name}</div>
                                     </div>
 
                                     <div className="table-cell-gdm">

--- a/src/clincoded/tests/features/generics.feature
+++ b/src/clincoded/tests/features/generics.feature
@@ -14,5 +14,15 @@ Feature: Generics
         Then I should see "J. Michael Cherry"
         When I visit "/search/"
         Then I should see "Showing"
+        When I visit "/gdm/"
+        Then I should see "AGTR2"
+        When I fill in "q" with "CD3E"
+        Then I should not see "AGTR2"
+        And I should see "Severe combined"
+        When I visit "/interpretations/"
+        Then I should see "NM_000111"
+        When I fill in "q" with "79452"
+        Then I should not see "May 10"
+        And I should see "Milroy disease"
 
 # couldn't get Collections loop to work properly...


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/20984700/3a6503ba-bc76-11e6-98e3-458288dbcb55.png)

Adds master interpretation list, much like the master GDM list. Adds link to the master interpretation list to Dashboard. Minor changes to master GDM list for consistency in sorting and display. Changes to JSON schema files is to add additional return fields, not actual schema changes. 'Last Edit' column value is only available/dependent on Evaluations in Interpretation.

Testing:

1. Go to Dashboard
2. Click on 'View all interpretations' link
3. Confirm that columns sort properly and that the filtering works fine
4. Confirm that clicking on interpretation row takes you to that variant in VCI