### PR TITLE
Connects to #1159. Implement linkout css

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -488,7 +488,7 @@ function clinvarTxt(field, extra) {
             txt =
                 <span>
                     <p className="alert alert-info">
-                        <span>Enter a ClinVar VariationID. The VariationID can be found in the light blue box on a variant page (example: <a href={external_url_map['ClinVarSearch'] + '139214'} target="_blank">139214 <i className="icon icon-external-link"></i></a>).</span>
+                        <span>Enter a ClinVar VariationID. The VariationID can be found in the light blue box on a variant page (example: <a href={external_url_map['ClinVarSearch'] + '139214'} target="_blank">139214</a>).</span>
                     </p>
                 </span>;
             break;
@@ -571,7 +571,7 @@ function clinvarRenderResourceResult() {
                 <div className="row">
                     <div className="row">
                         <span className="col-xs-4 col-md-4 control-label"><label>ClinVar Variant ID</label></span>
-                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong></a></span>
                     </div>
                     {this.state.tempResource.hgvsNames ?
                         <div className="row">
@@ -651,7 +651,7 @@ function carTxt(field, extra) {
             txt =
                 <span>
                     <p className="alert alert-info">
-                        <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323 <i className="icon icon-external-link"></i></a>).</span>
+                        <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>
                     </p>
                 </span>;
             break;
@@ -731,12 +731,12 @@ function carRenderResourceResult() {
                 <div className="row">
                     <div className="row">
                         <span className="col-xs-4 col-md-4 control-label"><label>CA ID</label></span>
-                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong> <i className="icon icon-external-link"></i></a></span>
+                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong></a></span>
                     </div>
                     {this.state.tempResource.clinvarVariantId ?
                         <div className="row">
                             <span className="col-xs-4 col-md-4 control-label"><label>ClinVar Variant ID</label></span>
-                            <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong> <i className="icon icon-external-link"></i></a></span>
+                            <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong></a></span>
                         </div>
                     : null}
                     {this.state.tempResource.hgvsNames ?

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -652,7 +652,7 @@ function carTxt(field, extra) {
             txt =
                 <span>
                     <p className="alert alert-info">
-                        <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={external_url_map['CARallele'] + 'CA003323.html'} target="_blank">CA003323</a>).</span>
+                        <span>Enter a ClinGen Allele Registry ID (CA ID). The CA ID is returned when you register an allele with the ClinGen Allele Registry (example: <a href={`http:${external_url_map['CARallele']}CA003323.html`} target="_blank">CA003323</a>).</span>
                     </p>
                 </span>;
             break;
@@ -732,12 +732,12 @@ function carRenderResourceResult() {
                 <div className="row">
                     <div className="row">
                         <span className="col-xs-4 col-md-4 control-label"><label>CA ID</label></span>
-                        <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['CARallele'] + this.state.tempResource.carId + '.html'} target="_blank"><strong>{this.state.tempResource.carId}</strong></a></span>
+                        <span className="col-xs-8 col-md-8 text-no-input"><a href={`${this.props.protocol}${external_url_map['CARallele']}${this.state.tempResource.carId}.html`} target="_blank"><strong>{this.state.tempResource.carId}</strong></a></span>
                     </div>
                     {this.state.tempResource.clinvarVariantId ?
                         <div className="row">
                             <span className="col-xs-4 col-md-4 control-label"><label>ClinVar Variant ID</label></span>
-                            <span className="col-xs-8 col-md-8 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.tempResource.clinvarVariantId} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong></a></span>
+                            <span className="col-xs-8 col-md-8 text-no-input"><a href={`${external_url_map['ClinVarSearch']}${this.state.tempResource.clinvarVariantId}`} target="_blank"><strong>{this.state.tempResource.clinvarVariantId}</strong></a></span>
                         </div>
                     : null}
                     {this.state.tempResource.hgvsNames ?

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -246,7 +246,7 @@ var PmidSelectionList = React.createClass({
                                     <div className="pmid-selection-list-specs">
                                         <PmidSummary article={annotation.article} />
                                     </div>
-                                    <div className="pmid-selection-list-pmid"><a href={external_url_map['PubMed'] + annotation.article.pmid} target="_blank">PMID: {annotation.article.pmid} <i className="icon icon-external-link"></i></a></div>
+                                    <div className="pmid-selection-list-pmid"><a href={external_url_map['PubMed'] + annotation.article.pmid} target="_blank">PMID: {annotation.article.pmid}</a></div>
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -432,7 +432,7 @@ var PmidSummary = module.exports.PmidSummary = React.createClass({
                     {article.title + ' '}
                     {this.props.displayJournal ? <i>{article.journal + '. '}</i> : null}
                     <strong>{date[1]}</strong>{date[2]}
-                    {this.props.pmidLinkout ? <span>&nbsp;<a href={external_url_map['PubMed'] + article.pmid} title={"PubMed entry for PMID:" + article.pmid + " in new tab"} target="_blank">PMID: {article.pmid} <i className="icon icon-external-link"></i></a></span> : null}
+                    {this.props.pmidLinkout ? <span>&nbsp;<a href={external_url_map['PubMed'] + article.pmid} title={"PubMed entry for PMID:" + article.pmid + " in new tab"} target="_blank">PMID: {article.pmid}</a></span> : null}
                 </p>
             );
         } else {
@@ -2037,7 +2037,7 @@ var renderPhenotype = module.exports.renderPhenotype = function(objList, title, 
 var renderMutalyzerLink = module.exports.renderMutalyzerLink = function() {
     return (
         <p className="col-sm-7 col-sm-offset-5 mutalyzer-link">
-            (e.g. CA ID whenever possible; otherwise RCV, rs ID, or HGVS)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer <i className="icon icon-external-link"></i></a>
+            (e.g. CA ID whenever possible; otherwise RCV, rs ID, or HGVS)<br />For help in verifying, generating or converting to HGVS nomenclature, please visit <a href='https://mutalyzer.nl/' target='_blank'>Mutalyzer</a>
         </p>
     );
 };

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2050,7 +2050,7 @@ var ExperimentalDataVariant = function() {
                                     {this.state.variantInfo[i].clinvarVariantId ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
+                                            <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
                                         </div>
                                     : null}
                                     {this.state.variantInfo[i].clinvarVariantTitle ?
@@ -2062,7 +2062,7 @@ var ExperimentalDataVariant = function() {
                                     {this.state.variantInfo[i].carId ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelCARVariant />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
+                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                         </div>
                                     : null}
                                     {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1643,7 +1643,7 @@ var FamilyVariant = function() {
                                 {this.state.variantInfo[i].clinvarVariantId ?
                                     <div className="row variant-data-source">
                                         <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
-                                        <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
+                                        <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
                                     </div>
                                 : null}
                                 {this.state.variantInfo[i].clinvarVariantTitle ?
@@ -1655,7 +1655,7 @@ var FamilyVariant = function() {
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
                                         <span className="col-sm-5 control-label"><label><LabelCARVariant variantRequired={this.state.variantRequired} /></label></span>
-                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
+                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                     </div>
                                 : null}
                                 {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?
@@ -1668,13 +1668,13 @@ var FamilyVariant = function() {
                                     <span className="col-sm-5 control-label"><label></label></span>
                                     <span className="col-sm-7 text-no-input">
                                         <div className="alert alert-warning">Note: a variant's gene impact must be specified in order to score this proband.</div>
-                                        <a href={'/variant-curation/?all&gdm=' + gdmUuid + '&pmid=' + pmidUuid + '&variant=' + this.state.variantInfo[i].uuid + '&user=' + userUuid} target="_blank">Curate variant's gene impact <i className="icon icon-external-link"></i></a>
+                                        <a href={'/variant-curation/?all&gdm=' + gdmUuid + '&pmid=' + pmidUuid + '&variant=' + this.state.variantInfo[i].uuid + '&user=' + userUuid} target="_blank">Curate variant's gene impact</a>
                                     </span>
                                 </div>
                                 <div className="row variant-curation">
                                     <span className="col-sm-5 control-label"><label></label></span>
                                     <span className="col-sm-7 text-no-input">
-                                        <a href={'/variant-central/?variant=' + this.state.variantInfo[i].uuid} target="_blank">View variant evidence in Variant Curation Interface <i className="icon icon-external-link"></i></a>
+                                        <a href={'/variant-central/?variant=' + this.state.variantInfo[i].uuid} target="_blank">View variant evidence in Variant Curation Interface</a>
                                     </span>
                                 </div>
                             </div>
@@ -1735,7 +1735,7 @@ var LabelCARVariantTitle = React.createClass({
 
 var LabelOtherVariant = React.createClass({
     render: function() {
-        return <span>Other description when a ClinVar VariationID does not exist <span className="normal">(important: use CA ID registered with <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> whenever possible)</span>:</span>;
+        return <span>Other description when a ClinVar VariationID does not exist <span className="normal">(important: use CA ID registered with <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> whenever possible)</span>:</span>;
     }
 });
 

--- a/src/clincoded/static/components/home.js
+++ b/src/clincoded/static/components/home.js
@@ -43,7 +43,7 @@ var Home = module.exports.Home = React.createClass({
                                 <h1>ClinGen Curator Interfaces</h1>
                                 <h4>Variant Curation &#8226; Gene Curation</h4>
                                 <p className="lead">Access to these interfaces is currently restricted to ClinGen curators. If you are a ClinGen curator, you may request an account at <a href="mailto:clingen-helpdesk@lists.stanford.edu">clingen-helpdesk@lists.stanford.edu <i className="icon icon-envelope"></i></a>.</p>
-                                <p className="lead">ClinGen is a National Institutes of Health (NIH)-funded resource dedicated to building an authoritative central resource that defines the clinical relevance of genes and variants for use in precision medicine and research. One of the key goals of ClinGen is to implement an evidence-based consensus for curating genes and variants. For more information on the ClinGen resource, please visit the ClinGen portal at <a href="https://www.clinicalgenome.org" target="_blank">clinicalgenome.org <i className="icon icon-external-link"></i></a>.</p>
+                                <p className="lead">ClinGen is a National Institutes of Health (NIH)-funded resource dedicated to building an authoritative central resource that defines the clinical relevance of genes and variants for use in precision medicine and research. One of the key goals of ClinGen is to implement an evidence-based consensus for curating genes and variants. For more information on the ClinGen resource, please visit the ClinGen portal at <a href="https://www.clinicalgenome.org" target="_blank">clinicalgenome.org</a>.</p>
                             </div>
                         </div>
                     </div>
@@ -51,7 +51,7 @@ var Home = module.exports.Home = React.createClass({
                         {this.state.demoVersion ?
                             <div>Explore a demo version of the ClinGen interfaces by clicking on the "Demo Login" button located in the header above.</div>
                             :
-                            <div>Explore a demo version of the ClinGen interfaces at <a href="https://curation-test.clinicalgenome.org/">curation-test.clinicalgenome.org <i className="icon icon-external-link"></i></a></div>
+                            <div>Explore a demo version of the ClinGen interfaces at <a href="https://curation-test.clinicalgenome.org/">curation-test.clinicalgenome.org</a></div>
                         }
                     </div>
                     <div className="row">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1388,7 +1388,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].clinvarVariantId ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
-                                                <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId} <i className="icon icon-external-link"></i></a></span>
+                                                <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
                                             </div>
                                         : null}
                                         {this.state.variantInfo[i].clinvarVariantTitle ?
@@ -1400,7 +1400,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].carId ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
-                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId} <i className="icon icon-external-link"></i></a></span>
+                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                             </div>
                                         : null}
                                         {this.state.variantInfo[i].grch38 ?
@@ -1412,13 +1412,13 @@ var IndividualVariantInfo = function() {
                                         <div className="row variant-assessment">
                                             <span className="col-sm-5 control-label"><label></label></span>
                                             <span className="col-sm-7 text-no-input">
-                                                <a href={'/variant-curation/?all&gdm=' + gdmUuid + '&pmid=' + pmidUuid + '&variant=' + this.state.variantInfo[i].uuid + '&user=' + userUuid} target="_blank">Curate variant's gene impact <i className="icon icon-external-link"></i></a>
+                                                <a href={'/variant-curation/?all&gdm=' + gdmUuid + '&pmid=' + pmidUuid + '&variant=' + this.state.variantInfo[i].uuid + '&user=' + userUuid} target="_blank">Curate variant's gene impact</a>
                                             </span>
                                         </div>
                                         <div className="row variant-curation">
                                             <span className="col-sm-5 control-label"><label></label></span>
                                             <span className="col-sm-7 text-no-input">
-                                                <a href={'/variant-central/?variant=' + this.state.variantInfo[i].uuid} target="_blank">View variant evidence in Variant Curation Interface <i className="icon icon-external-link"></i></a>
+                                                <a href={'/variant-central/?variant=' + this.state.variantInfo[i].uuid} target="_blank">View variant evidence in Variant Curation Interface</a>
                                             </span>
                                         </div>
                                     </div>
@@ -1511,7 +1511,7 @@ var LabelCARVariantTitle = React.createClass({
 
 var LabelOtherVariant = React.createClass({
     render: function() {
-        return <span>Other description when a ClinVar VariationID does not exist <span className="normal">(important: use CA ID registered with <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> whenever possible)</span>:</span>;
+        return <span>Other description when a ClinVar VariationID does not exist <span className="normal">(important: use CA ID registered with <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> whenever possible)</span>:</span>;
     }
 });
 

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -93,12 +93,12 @@ var SelectVariant = React.createClass({
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />
                                         <ol className="instructions">
-                                            <li>Search <a href={external_url_map['ClinVar']} target="_blank">ClinVar <i className="icon icon-external-link"></i></a> for variant.</li>
+                                            <li>Search <a href={external_url_map['ClinVar']} target="_blank">ClinVar</a> for variant.</li>
                                             <li>If found in ClinVar, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                            <li>If not found in ClinVar, search the <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> with a valid HGVS term for that variant.
+                                            <li>If not found in ClinVar, search the <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> with a valid HGVS term for that variant.
                                             <ol type="a">
-                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
-                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry <i className="icon icon-external-link"></i></a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
+                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> returns a ClinVar ID, select “ClinVar VariationID” from the pull-down to enter it.</li>
+                                                <li>If <a href={external_url_map['CAR']} target="_blank">ClinGen Allele Registry</a> does not find a ClinVar ID, register the variant to return a CA ID and then select "ClinGen Allele Registry ID (CA ID)" from the pull-down and enter the CA ID.</li>
                                             </ol>
                                             </li>
                                         </ol>

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -572,7 +572,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                <dd className="col-lg-3"><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser <i className="icon icon-external-link"></i></a></dd>
+                                <dd className="col-lg-3"><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser</a></dd>
                             }
                             {(links_38 || links_37) ?
                                 <dd>Variation Viewer [
@@ -582,7 +582,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                <dd className="col-lg-4"><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer <i className="icon icon-external-link"></i></a></dd>
+                                <dd className="col-lg-4"><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer</a></dd>
                             }
                             {(links_38 || links_37) ?
                                 <dd>Ensembl Browser [
@@ -592,7 +592,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                     ]
                                 </dd>
                                 :
-                                <dd className="col-lg-3"><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser <i className="icon icon-external-link"></i></a></dd>
+                                <dd className="col-lg-3"><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser</a></dd>
                             }
                         </dl>
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -375,7 +375,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         return (
                             <dl className="inline-dl clearfix">
                                 <dt>Additional ClinVar variants found in the same codon: <span className="condon-variant-count">{codon.count-1}</span></dt>
-                                <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon <i className="icon icon-external-link"></i></a>)</dd>
+                                <dd>(<a href={external_url_map['ClinVar'] + '?term=' + codon.term + '+%5Bvariant+name%5D+and+' + codon.symbol} target="_blank">Search ClinVar for variants in this codon</a>)</dd>
                             </dl>
                         );
                     } else {
@@ -568,9 +568,9 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         <div className="panel panel-info datasource-splice">
                             <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
                             <div className="panel-body">
-                                <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">Analyze using MaxEntScan <i className="icon icon-external-link"></i></a>
-                                <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">Analyze using NNSPLICE <i className="icon icon-external-link"></i></a>
-                                <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">Analyze using HumanSplicingFinder <i className="icon icon-external-link"></i></a>
+                                <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">Analyze using MaxEntScan</a>
+                                <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">Analyze using NNSPLICE</a>
+                                <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">Analyze using HumanSplicingFinder</a>
                             </div>
                         </div>
                         {(this.props.data && this.state.interpretation) ?
@@ -675,9 +675,9 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                         <div className="panel panel-info datasource-splice">
                             <div className="panel-heading"><h3 className="panel-title">Splice Site Predictors</h3></div>
                             <div className="panel-body">
-                                <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">Analyze using MaxEntScan <i className="icon icon-external-link"></i></a>
-                                <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">Analyze using NNSPLICE <i className="icon icon-external-link"></i></a>
-                                <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">Analyze using HumanSplicingFinder <i className="icon icon-external-link"></i></a>
+                                <a href="http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html" target="_blank">Analyze using MaxEntScan</a>
+                                <a href="http://www.fruitfly.org/seq_tools/splice.html" target="_blank">Analyze using NNSPLICE</a>
+                                <a href="http://www.umd.be/HSF3/HSF.html" target="_blank">Analyze using HumanSplicingFinder</a>
                             </div>
                         </div>
                         {(this.props.data && this.state.interpretation) ?
@@ -717,7 +717,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        <dd className="col-lg-3"><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser <i className="icon icon-external-link"></i></a></dd>
+                                        <dd className="col-lg-3"><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser</a></dd>
                                     }
                                     {(links_38 || links_37) ?
                                         <dd>Variation Viewer [
@@ -727,7 +727,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        <dd className="col-lg-4"><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer <i className="icon icon-external-link"></i></a></dd>
+                                        <dd className="col-lg-4"><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer</a></dd>
                                     }
                                     {(links_38 || links_37) ?
                                         <dd>Ensembl Browser [
@@ -737,7 +737,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                                             ]
                                         </dd>
                                         :
-                                        <dd className="col-lg-3"><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser <i className="icon icon-external-link"></i></a></dd>
+                                        <dd className="col-lg-3"><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser</a></dd>
                                     }
                                 </dl>
                             </div>

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -144,7 +144,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                         <div className="panel-body">
                             {(myGeneInfo) ?
                                 <a href={external_url_map['ClinVar'] + '?term=' + myGeneInfo.symbol + '%5Bgene%5D'}
-                                    target="_blank">Search ClinVar for variants in this gene <i className="icon icon-external-link"></i></a>
+                                    target="_blank">Search ClinVar for variants in this gene</a>
                                 :
                                 <span>No other variants found in this gene at ClinVar.</span>
                             }
@@ -178,7 +178,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                                         {ensemblGeneId ?
                                             <a href={dbxref_prefix_map['ENSEMBL'] + ensemblGeneId + ';db=core'} target="_blank">{ensemblGeneId}</a>
                                             :
-                                            <a href="http://ensembl.org" target="_blank">Search Ensembl <i className="icon icon-external-link"></i></a>
+                                            <a href="http://ensembl.org" target="_blank">Search Ensembl</a>
                                         }
                                     </dd>
                                 </dl>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -624,7 +624,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             return (
                 <h3 className="panel-title">ExAC {variantExac}
                     <a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a>
-                    <a className="panel-subtitle pull-right" href={linkoutExac} target="_blank">See data in ExAC <i className="icon icon-external-link"></i></a>
+                    <a className="panel-subtitle pull-right" href={linkoutExac} target="_blank">See data in ExAC</a>
                 </h3>
             );
         } else {
@@ -644,7 +644,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             return (
                 <h3 className="panel-title">1000 Genomes: {variantTGenomes}
                     <a href="#credit-vep" className="credit-vep" title="VEP"><span>VEP</span></a>
-                    <a className="panel-subtitle pull-right" href={linkoutEnsembl} target="_blank">See data in Ensembl <i className="icon icon-external-link"></i></a>
+                    <a className="panel-subtitle pull-right" href={linkoutEnsembl} target="_blank">See data in Ensembl</a>
                 </h3>
             );
         } else {
@@ -664,7 +664,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             return (
                 <h3 className="panel-title">Exome Sequencing Project (ESP): {variantEsp}
                     <a href="#credit-myvariant" className="credit-myvariant" title="MyVariant.info"><span>MyVariant</span></a>
-                    <a className="panel-subtitle pull-right" href={linkoutEsp} target="_blank">See data in ESP <i className="icon icon-external-link"></i></a>
+                    <a className="panel-subtitle pull-right" href={linkoutEsp} target="_blank">See data in ESP</a>
                 </h3>
             );
         } else {

--- a/src/clincoded/static/components/variant_central/record_gene_disease.js
+++ b/src/clincoded/static/components/variant_central/record_gene_disease.js
@@ -90,7 +90,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            <dd><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser <i className="icon icon-external-link"></i></a></dd>
+                            <dd><a href={external_url_map['UCSCBrowserHome']} target="_blank">UCSC Browser</a></dd>
                         }
                         {(links_38 || links_37) ?
                             <dd>Variation Viewer [
@@ -100,7 +100,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            <dd><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer <i className="icon icon-external-link"></i></a></dd>
+                            <dd><a href={external_url_map['VariationViewerHome']} target="_blank">Variation Viewer</a></dd>
                         }
                         {(links_38 || links_37) ?
                             <dd>Ensembl Browser [
@@ -110,7 +110,7 @@ var CurationRecordGeneDisease = module.exports.CurationRecordGeneDisease = React
                                 ]
                             </dd>
                             :
-                            <dd><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser <i className="icon icon-external-link"></i></a></dd>
+                            <dd><a href={external_url_map['EnsemblBrowserHome']} target="_blank">Ensembl Browser</a></dd>
                         }
                     </dl>
                 </div>

--- a/src/clincoded/static/scss/clincoded/_base.scss
+++ b/src/clincoded/static/scss/clincoded/_base.scss
@@ -181,7 +181,8 @@ a[href^="http://"]:after,
 a[href^="https://"]:after,
 a.external-link:after {
     font-family: FontAwesome;
-    content: " \f08e";
+    content: "\a0\f08e";
+    font-weight: normal;
 }
 
 // Disable external-link icon for clinicalgenome.org and localhost links
@@ -190,6 +191,8 @@ a[href^="instance.clinicalgenome.org/"]:after,
 a[href^="demo.clinicalgenome.org/"]:after,
 a[href^="production.clinicalgenome.org/"]:after,
 a[href^="curation-test.clinicalgenome.org/"]:after,
-a[href^="curation.clinicalgenome.org/"]:after {
+a[href^="curation.clinicalgenome.org/"]:after,
+a.no-external-link:after {
     content: "";
+    padding-left: 0;
 }

--- a/src/clincoded/static/scss/clincoded/_base.scss
+++ b/src/clincoded/static/scss/clincoded/_base.scss
@@ -175,3 +175,21 @@ dl.dl-horizontal {
     text-align: center;
     line-height: 50px;
 }
+
+// Display external-link fontawesome icon after EVERY link (override later)
+a[href^="http://"]:after,
+a[href^="https://"]:after,
+a.external-link:after {
+    font-family: FontAwesome;
+    content: " \f08e";
+}
+
+// Disable external-link icon for clinicalgenome.org and localhost links
+a[href^="localhost"]:after,
+a[href^="instance.clinicalgenome.org/"]:after,
+a[href^="demo.clinicalgenome.org/"]:after,
+a[href^="production.clinicalgenome.org/"]:after,
+a[href^="curation-test.clinicalgenome.org/"]:after,
+a[href^="curation.clinicalgenome.org/"]:after {
+    content: "";
+}


### PR DESCRIPTION
Implements CSS rules so that external links automatically have the external-link font awesome icon attached to it. Removes previous manually added instances of the external-link icon from the code.

Links that do not include the external-link icons include ones pointing to `localhost` and `instance/demo/production/curation-test/curation.clinicalgenome.org`.

Testing:

1. Rebuild CSS
2. Use site and check to see if external-link icons exist where they should