### PR TITLE
Connects to #1155. Expand CAR support in GCI

### DIFF
--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -83,8 +83,6 @@ var CurationCentral = React.createClass({
             }
 
             return gdm;
-        }).catch(function(e) {
-            console.log('GETGDM ERROR=: %o', e);
         });
     },
 

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -83,6 +83,8 @@ var CurationCentral = React.createClass({
             }
 
             return gdm;
+        }).catch(function(e) {
+            console.log('GETGDM ERROR=: %o', e);
         });
     },
 

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -95,7 +95,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
             var disease = this.props.gdm.disease;
             var mode = this.props.gdm.modeInheritance.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
             // Display selected MOI adjective if any. Otherwise, display selected MOI.
-            var modeInheritanceAdjective = this.props.gdm.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1];
+            var modeInheritanceAdjective = this.props.gdm.modeInheritanceAdjective ? this.props.gdm.modeInheritanceAdjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1] : null;
             var pmid = this.props.pmid;
             var i, j, k;
             // if provisional exist, show summary and classification, Edit link and Generate New Summary button.

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -809,7 +809,9 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session) {
         return (labelA < labelB) ? -1 : ((labelA > labelB ? 1 : 0));
     });
 
-    var variantTitle = variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.clinvarVariantId ? variant.clinvarVariantId : variant.otherDescription);
+    let clinvarRepresentation = variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.clinvarVariantId ? variant.clinvarVariantId : null);
+    let carRepresentation = variant.hgvsNames && variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.carId ? variant.carId : null);
+    let variantTitle = clinvarRepresentation ? clinvarRepresentation : carRepresentation;
 
     return (
         <div className="panel-evidence-group">

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -283,6 +283,15 @@ var searchProbandIndividual = function(individualList, variantList) {
     return false;
 };
 
+// function to get the preferred display title for variants. Current preferential order is clinvar variant title > clinvar variant ID
+// > grch38 hgvs term > CA ID
+var getVariantTitle = function(variant) {
+    let clinvarRepresentation = variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.clinvarVariantId ? variant.clinvarVariantId : null);
+    let carRepresentation = variant.hgvsNames && variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.carId ? variant.carId : null);
+    let variantTitle = clinvarRepresentation ? clinvarRepresentation : carRepresentation;
+
+    return variantTitle;
+};
 
 // Display the header of all variants involved with the current GDM.
 var VariantHeader = module.exports.VariantHeader = React.createClass({
@@ -306,8 +315,7 @@ var VariantHeader = module.exports.VariantHeader = React.createClass({
                         <p>Click a variant to View, Curate, or Edit it. The icon indicates curation by one or more curators.</p>
                         {Object.keys(collectedVariants).map(variantId => {
                             var variant = collectedVariants[variantId];
-                            var variantName = variant.clinvarVariantTitle ? variant.clinvarVariantTitle :
-                                (variant.clinvarVariantId ? variant.clinvarVariantId : variant.otherDescription);
+                            var variantName = getVariantTitle(variant);
                             var userPathogenicity = null;
 
                             // See if the variant has a pathogenicity curated in the current GDM
@@ -809,9 +817,7 @@ var renderVariant = function(variant, gdm, annotation, curatorMatch, session) {
         return (labelA < labelB) ? -1 : ((labelA > labelB ? 1 : 0));
     });
 
-    let clinvarRepresentation = variant.clinvarVariantTitle ? variant.clinvarVariantTitle : (variant.clinvarVariantId ? variant.clinvarVariantId : null);
-    let carRepresentation = variant.hgvsNames && variant.hgvsNames.GRCh38 ? variant.hgvsNames.GRCh38 : (variant.carId ? variant.carId : null);
-    let variantTitle = clinvarRepresentation ? clinvarRepresentation : carRepresentation;
+    let variantTitle = getVariantTitle(variant);
 
     return (
         <div className="panel-evidence-group">

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2660,7 +2660,7 @@ var ExperimentalViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2669,6 +2669,22 @@ var ExperimentalViewer = React.createClass({
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
                                                     <dd>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.carId ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinGen Allele Registry ID</dt>
+                                                    <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Genomic HGVS Title</dt>
+                                                    <dd>{variant.hgvsNames.GRCh38} (GRCh38)</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2103,8 +2103,8 @@ var FamilyViewer = React.createClass({
                                         {variant.clinvarVariantId ?
                                             <div>
                                                 <dl className="dl-horizontal">
-                                                    <dt>ClinVar VariationID</dt>
-                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dt>ClinVar Variation ID</dt>
+                                                    <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -2113,6 +2113,22 @@ var FamilyViewer = React.createClass({
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar Preferred Title</dt>
                                                     <dd>{variant.clinvarVariantTitle}</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.carId ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinGen Allele Registry ID</dt>
+                                                    <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Genomic HGVS Title</dt>
+                                                    <dd>{variant.hgvsNames.GRCh38} (GRCh38)</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1767,7 +1767,7 @@ var IndividualViewer = React.createClass({
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>ClinVar VariationID</dt>
-                                                    <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                                    <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
                                                 </dl>
                                             </div>
                                         : null }
@@ -1779,6 +1779,22 @@ var IndividualViewer = React.createClass({
                                                 </dl>
                                             </div>
                                         : null}
+                                        {variant.carId ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>ClinGen Allele Registry ID</dt>
+                                                    <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
+                                                </dl>
+                                            </div>
+                                        : null }
+                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                            <div>
+                                                <dl className="dl-horizontal">
+                                                    <dt>Genomic HGVS Title</dt>
+                                                    <dd>{variant.hgvsNames.GRCh38} (GRCh38)</dd>
+                                                </dl>
+                                            </div>
+                                        : null }
                                         {variant.otherDescription ?
                                             <div>
                                                 <dl className="dl-horizontal">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1290,7 +1290,7 @@ var IndividualVariantInfo = function() {
                                     {variant.clinvarVariantId ?
                                         <div>
                                             <dt>ClinVar Variation ID</dt>
-                                            <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                            <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
                                         </div>
                                     : null}
 
@@ -1304,7 +1304,7 @@ var IndividualVariantInfo = function() {
                                     {variant.carId ?
                                         <div>
                                             <dt>ClinGen Allele Registry ID</dt>
-                                            <dd>{variant.carId}</dd>
+                                            <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
                                         </div>
                                     : null}
 

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -343,7 +343,7 @@ var VariantCuration = React.createClass({
                                     <div className="row variant-association-header">
                                         <dl className="dl-horizontal">
                                             <dt>{gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; ClinGen Allele Registry ID</dt>
-                                            <dd><a href={`${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for variant ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
+                                            <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for variant ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
                                         </dl>
                                         <dl className="dl-horizontal">
                                             <dt>Genomic HGVS Term</dt>

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -327,30 +327,36 @@ var VariantCuration = React.createClass({
                         <VariantAssociationsHeader gdm={gdm} variant={variant} />
                         {variant ?
                             <h2>
-                                {variant.clinvarVariantId ?
-                                    <div className="row variant-association-header">
-                                        <dl className="dl-horizontal">
-                                            <dt>{gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; ClinVar Variation ID</dt>
-                                            <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
-                                        </dl>
-                                        <dl className="dl-horizontal">
-                                            <dt>ClinVar Preferred Title</dt>
-                                            <dd>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
-                                        </dl>
+                                <div className="row variant-association-header">
+                                    <div>
+                                        {gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null}
+                                        {variant.clinvarVariantId ?
+                                            <span>
+                                                <span className="term-name"> &#x2F;&#x2F; ClinVar Variation ID: </span>
+                                                <span className="term-value"><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></span>
+                                            </span>
+                                        : null}
+                                        {variant.carId ?
+                                            <span>
+                                                <span className="term-name"> &#x2F;&#x2F; ClinGen Allele Registry ID: </span>
+                                                <span className="term-value"><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for variant ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></span>
+                                            </span>
+                                        : null}
                                     </div>
-                                : null}
-                                {variant.carId && !variant.clinvarVariantId ?
-                                    <div className="row variant-association-header">
-                                        <dl className="dl-horizontal">
-                                            <dt>{gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; ClinGen Allele Registry ID</dt>
-                                            <dd><a href={`http:${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for variant ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
-                                        </dl>
-                                        <dl className="dl-horizontal">
-                                            <dt>Genomic HGVS Term</dt>
-                                            <dd>{variant.hgvsNames && variant.hgvsNames.GRCh38 ? `${variant.hgvsNames.GRCh38} (GRCh38)` : null}</dd>
-                                        </dl>
+                                    <div>
+                                        {variant.clinvarVariantTitle ?
+                                            <span>
+                                                <span className="term-name">ClinVar Preferred Title: </span>
+                                                <span className="term-value">{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</span>
+                                            </span>
+                                        :
+                                            <span>
+                                                <span className="term-name">Genomic HGVS Term: </span>
+                                                <span className="term-value">{variant.hgvsNames && variant.hgvsNames.GRCh38 ? `${variant.hgvsNames.GRCh38} (GRCh38)` : null}</span>
+                                            </span>
+                                        }
                                     </div>
-                                : null}
+                                </div>
                             </h2>
                         : null}
                     </div>

--- a/src/clincoded/static/components/variant_curation.js
+++ b/src/clincoded/static/components/variant_curation.js
@@ -326,28 +326,32 @@ var VariantCuration = React.createClass({
                         {curatorName ? <h2>{'Curator: ' + curatorName}</h2> : null}
                         <VariantAssociationsHeader gdm={gdm} variant={variant} />
                         {variant ?
-                            <h2>{variant.clinvarVariantId ?
-                                <div className="row variant-association-header">
-                                    <dl className="dl-horizontal">
-                                        <dt>{gdm && annotation ? <a href={'/curation-central/?gdm=' + gdm.uuid + '&pmid=' + annotation.article.pmid}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; VariationID</dt>
-                                        <dd><a href={external_url_map['ClinVarSearch'] + variant.clinvarVariantId} title={"ClinVar entry for variant " + variant.clinvarVariantId + " in new tab"} target="_blank">{variant.clinvarVariantId}</a></dd>
-                                    </dl>
-                                    <dl className="dl-horizontal">
-                                        <dt>ClinVar Preferred Title</dt>
-                                        <dd>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
-                                    </dl>
-                                </div>
-                            :
-                                <div className="row variant-association-header">
-                                    <dl className="dl-horizontal">
-                                        {gdm ? <a href={'/curation-central/?gdm=' + gdm.uuid + (gdm.annotations[0].article.pmid ? '&pmid=' + gdm.annotations[0].article.pmid : '')}><i className="icon icon-briefcase"></i></a> : null}
-                                    </dl>
-                                    <dl className="dl-horizontal">
-                                        <dt>Other Description</dt>
-                                        <dd>{variant.otherDescription ? variant.otherDescription : null}</dd>
-                                    </dl>
-                                </div>
-                            }</h2>
+                            <h2>
+                                {variant.clinvarVariantId ?
+                                    <div className="row variant-association-header">
+                                        <dl className="dl-horizontal">
+                                            <dt>{gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; ClinVar Variation ID</dt>
+                                            <dd><a href={`${external_url_map['ClinVarSearch']}${variant.clinvarVariantId}`} title={`ClinVar entry for variant ${variant.clinvarVariantId} in new tab`} target="_blank">{variant.clinvarVariantId}</a></dd>
+                                        </dl>
+                                        <dl className="dl-horizontal">
+                                            <dt>ClinVar Preferred Title</dt>
+                                            <dd>{variant.clinvarVariantTitle ? variant.clinvarVariantTitle : null}</dd>
+                                        </dl>
+                                    </div>
+                                : null}
+                                {variant.carId && !variant.clinvarVariantId ?
+                                    <div className="row variant-association-header">
+                                        <dl className="dl-horizontal">
+                                            <dt>{gdm && annotation ? <a href={`/curation-central/?gdm=${gdm.uuid}&pmid=${annotation.article.pmid}`}><i className="icon icon-briefcase"></i></a> : null} &#x2F;&#x2F; ClinGen Allele Registry ID</dt>
+                                            <dd><a href={`${external_url_map['CARallele']}${variant.carId}.html`} title={`ClinGen Allele Registry entry for variant ${variant.carId} in new tab`} target="_blank">{variant.carId}</a></dd>
+                                        </dl>
+                                        <dl className="dl-horizontal">
+                                            <dt>Genomic HGVS Term</dt>
+                                            <dd>{variant.hgvsNames && variant.hgvsNames.GRCh38 ? `${variant.hgvsNames.GRCh38} (GRCh38)` : null}</dd>
+                                        </dl>
+                                    </div>
+                                : null}
+                            </h2>
                         : null}
                     </div>
                     <div className="row group-curation-content">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -508,12 +508,11 @@
     .variant-association-header {
         padding-left: 15px;
 
-        dt {
-            font-weight: normal;
-            padding-right: 5px;
+        .term-name {
+            font-weight: 400;
         }
 
-        dd {
+        .term-value {
             word-break: break-all;
             word-wrap: break-word;
         }


### PR DESCRIPTION
Proper display of CAR variants in the following locations of the GCI:
* Gene-Disease-Record variants header
* Curation palette
* Curate variant page
* View pages for Family, Individual, and Experimental items w/ variant data

Also includes separate bugfix where old GDMs with no `modeInheritanceAdjective` variable would not load.

Testing:

1. Get to GCI
2. Add CAR variants (CA003323 - both ClinVar and CAR info, CA501068 - only CAR info) to Family, Individual, and Experimental curation pages
3. Confirm that the Variants properly display data in the above listed locations