### PR TITLE
Connects to #1141. Reworked zygosity workflow

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -672,6 +672,22 @@ function carValidateForm() {
         valid = false;
         this.setFormErrors('resourceId', 'Invalid CA ID');
     }
+
+    // valid if parent object is family, individual or experimental and input isn't already associated with it
+    if (valid && this.props.parentObj && this.props.parentObj['@type'] && this.props.parentObj['@type'][0] == 'variantList') {
+        // loop through received variantlist and make sure that the variant is not already associated
+        for (var i in this.props.parentObj.variantList) {
+            // but don't check against the field it's editing against, in case it is an edit
+            if (i != this.props.fieldNum && this.props.parentObj.variantList.hasOwnProperty(i)) {
+                if (this.props.parentObj.variantList[i].carId == formInput) {
+                    valid = false;
+                    this.setFormErrors('resourceId', 'This variant has already been associated with this piece of ' + this.props.parentObj['@type'][1] + ' evidence.');
+                    this.setState({submitBusy: false});
+                    break;
+                }
+            }
+        }
+    }
     return valid;
 }
 function carQueryResource() {

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2680,7 +2680,7 @@ var ExperimentalViewer = React.createClass({
                                                 </dl>
                                             </div>
                                         : null }
-                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                        {!variant.clinvarVariantTitle && (variant.hgvsNames && variant.hgvsNames.GRCh38) ?
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>Genomic HGVS Title</dt>

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1273,7 +1273,7 @@ var ExperimentalNameType = function() {
     var experimental = this.state.experimental;
 
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             {!this.state.experimentalType || this.state.experimentalType == 'none' ?
                 <div className="col-sm-7 col-sm-offset-5">
                     <p>Select which experiment type you would like to curate:</p>
@@ -1353,7 +1353,7 @@ var TypeBiochemicalFunction = function() {
         biochemicalFunction.evidenceForFunctionInPaper = biochemicalFunction.evidenceForFunctionInPaper ? biochemicalFunction.evidenceForFunctionInPaper : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <p className="col-sm-7 col-sm-offset-5">Search <a href={external_url_map['GO_Slim']} target="_blank" title="Open GO_Slim in a new tab">GO_Slim</a> for a GO ID (e.g. biological_process = GO:0008150)</p>
             <Input type="text" ref="identifiedFunction" label={<LabelIdentifiedFunction />}
                 error={this.getFormError('identifiedFunction')} clearError={this.clrFormErrors.bind(null, 'identifiedFunction')}
@@ -1506,7 +1506,7 @@ var TypeProteinInteractions = function() {
         proteinInteractions.evidenceInPaper = proteinInteractions.evidenceInPaper ? proteinInteractions.evidenceInPaper : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <Input type="text" ref="interactingGenes" label={<LabelInteractingGenes />}
                 error={this.getFormError('interactingGenes')} clearError={this.clrFormErrors.bind(null, 'interactingGenes')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input"
@@ -1573,7 +1573,7 @@ var TypeExpression = function() {
         expression.organOfTissue = expression.organOfTissue ? expression.organOfTissue : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <p className="col-sm-7 col-sm-offset-5">Search <a href={external_url_map['Uberon']} target="_blank" title="Open Uberon in a new tab">Uberon</a> for an organ type (e.g. heart = UBERON_0015228)</p>
             <Input type="text" ref="organOfTissue" label={<LabelUberonId />}
                 error={this.getFormError('organOfTissue')} clearError={this.clrFormErrors.bind(null, 'organOfTissue')}
@@ -1669,7 +1669,7 @@ var TypeFunctionalAlteration = function() {
         functionalAlteration.evidenceInPaper = functionalAlteration.evidenceInPaper ? functionalAlteration.evidenceInPaper : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <Input type="select" ref="cellMutationOrEngineeredEquivalent" label="Patient cells with candidate mutation or engineered equivalent?:"
                 error={this.getFormError('cellMutationOrEngineeredEquivalent')} clearError={this.clrFormErrors.bind(null, 'cellMutationOrEngineeredEquivalent')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
@@ -1756,7 +1756,7 @@ var TypeModelSystems = function() {
         modelSystems.evidenceInPaper = modelSystems.evidenceInPaper ? modelSystems.evidenceInPaper : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <Input type="select" ref="animalOrCellCulture" label="Non-human animal or cell-culture model?:"
                 error={this.getFormError('animalOrCellCulture')} clearError={this.clrFormErrors.bind(null, 'animalOrCellCulture')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
@@ -1887,7 +1887,7 @@ var TypeRescue = function() {
         rescue.evidenceInPaper = rescue.evidenceInPaper ? rescue.evidenceInPaper : null;
     }
     return (
-        <div className="row experimental-data-form">
+        <div className="row form-row-helper">
             <Input type="select" ref="patientCellOrEngineeredEquivalent" label="Patient cells with or engineered equivalent?:"
                 error={this.getFormError('patientCellOrEngineeredEquivalent')} clearError={this.clrFormErrors.bind(null, 'patientCellOrEngineeredEquivalent')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2062,7 +2062,7 @@ var ExperimentalDataVariant = function() {
                                     {this.state.variantInfo[i].carId ?
                                         <div className="row">
                                             <span className="col-sm-5 control-label"><label>{<LabelCARVariant />}</label></span>
-                                            <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                            <span className="col-sm-7 text-no-input"><a href={`https:${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                         </div>
                                     : null}
                                     {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1583,7 +1583,7 @@ var FamilyVariant = function() {
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
-            <p className="col-sm-7 col-sm-offset-5">
+            <p className="col-sm-7 col-sm-offset-5 input-note-below">
                 Note: if homozygous, enter only 1 variant below
             </p>
             <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -96,7 +96,6 @@ var FamilyCuration = React.createClass({
             variantInfo: {}, // Extra holding info for variant display
             probandIndividual: null, //Proband individual if the family being edited has one
             familyName: '', // Currently entered family name
-            addVariantDisabled: false, // True if Add Another Variant button enabled
             individualRequired: null, // Boolean for set up requirement of proband
             variantRequired: null, // boolean for set up requirement of variant if proband individual data entered
             genotyping2Disabled: true, // True if genotyping method 2 dropdown disabled
@@ -333,7 +332,6 @@ var FamilyCuration = React.createClass({
                         // We have variants
                         stateObj.variantCount = segregation.variants.length;
                         stateObj.variantRequired = stateObj.probandIndividual.recessiveZygosity ? true : false;
-                        stateObj.addVariantDisabled = false;
                         stateObj.variantInfo = {};
                         // For each incoming variant, set the form value
                         for (var i = 0; i < segregation.variants.length; i++) {
@@ -1024,14 +1022,7 @@ var FamilyCuration = React.createClass({
     updateVariantId: function(data, fieldNum) {
         let newVariantInfo = _.clone(this.state.variantInfo);
         let variantCount = this.state.variantCount;
-        let addVariantDisabled;
         if (data) {
-            // Enable/Disable Add Variant button as needed
-            if (fieldNum == 0) {
-                addVariantDisabled = false;
-            } else {
-                addVariantDisabled = true;
-            }
             // Update the form and display values with new data
             this.refs['variantUuid' + fieldNum].setValue(data.uuid);
             newVariantInfo[fieldNum] = {
@@ -1073,7 +1064,7 @@ var FamilyCuration = React.createClass({
         }
 
         // Set state
-        this.setState({variantInfo: newVariantInfo, addVariantDisabled: addVariantDisabled, variantCount: variantCount});
+        this.setState({variantInfo: newVariantInfo, variantCount: variantCount});
         this.clrFormErrors('individualorphanetid');
         this.clrFormErrors('SEGrecessiveZygosity');
     },

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -137,7 +137,6 @@ var FamilyCuration = React.createClass({
                 this.setState({lodPublished: null});
             }
         } else if (ref === 'zygosityHomozygous') {
-            console.log('clicked');
             if (this.refs[ref].toggleValue()) {
                 this.setState({recessiveZygosity: 'Homozygous'});
                 this.refs['zygosityHemizygous'].resetValue();

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -514,13 +514,6 @@ var FamilyCuration = React.createClass({
                 }
             }
 
-            if (this.state.individualRequired) {
-                if (!variantId0) {
-                    formError = true;
-                    this.setFormErrors('individualorphanetid', 'You must specify a variant if you are defining a proband individual');
-                }
-            }
-
             if (!formError) {
                 // Build search string from given ORPHA IDs, empty string if no Orphanet id entered.
                 var searchStr;

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1583,6 +1583,7 @@ var FamilyVariant = function() {
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
+            <p className="alert alert-info">Note: if homozygous, enter only 1 variant below</p>
             <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                 error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -503,7 +503,7 @@ var FamilyCuration = React.createClass({
             }
 
             // Get variant uuid's if they were added via the modals
-            for (var i = 0; i < this.state.variantCount; i++) {
+            for (var i = 0; i < MAX_VARIANTS; i++) {
                 // Grab the values from the variant form panel
                 var variantId = this.getFormValue('variantUuid' + i);
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -97,7 +97,6 @@ var FamilyCuration = React.createClass({
             probandIndividual: null, //Proband individual if the family being edited has one
             familyName: '', // Currently entered family name
             individualRequired: null, // Boolean for set up requirement of proband
-            variantRequired: null, // boolean for set up requirement of variant if proband individual data entered
             genotyping2Disabled: true, // True if genotyping method 2 dropdown disabled
             segregationFilled: false, // True if at least one segregation field has a value
             submitBusy: false, // True while form is submitting
@@ -125,9 +124,9 @@ var FamilyCuration = React.createClass({
             let individualName = this.refs['individualname'].getValue();
             let individualOrphanetId = this.refs['individualorphanetid'].getValue();
             if (individualName || individualOrphanetId) {
-                this.setState({individualRequired: true, variantRequired: true});
+                this.setState({individualRequired: true});
             } else if (!individualName && !individualOrphanetId) {
-                this.setState({individualRequired: false, variantRequired: false});
+                this.setState({individualRequired: false});
             }
         } else if (ref === 'SEGlodPublished') {
             if (this.refs[ref].getValue() === 'Yes') {
@@ -188,7 +187,7 @@ var FamilyCuration = React.createClass({
         var hpoIds = '';
         var hpoFreeText = '';
         if (fromTarget == 'group') {
-            this.setState({individualRequired: true, variantRequired: true});
+            this.setState({individualRequired: true});
             if (this.state.group) {
                 // We have a group, so get the disease array from it.
                 associatedGroups = [this.state.group];
@@ -233,7 +232,7 @@ var FamilyCuration = React.createClass({
                 }
             }
         } else if (fromTarget == 'family') {
-            this.setState({individualRequired: true, variantRequired: true});
+            this.setState({individualRequired: true});
             orphanetVal = this.refs['orphanetid'].getValue();
             this.refs['individualorphanetid'].setValue(orphanetVal);
             var errors = this.state.formErrors;
@@ -328,7 +327,6 @@ var FamilyCuration = React.createClass({
                     if (segregation.variants && segregation.variants.length) {
                         // We have variants
                         stateObj.variantCount = segregation.variants.length;
-                        stateObj.variantRequired = stateObj.probandIndividual.recessiveZygosity ? true : false;
                         stateObj.variantInfo = {};
                         // For each incoming variant, set the form value
                         for (var i = 0; i < segregation.variants.length; i++) {
@@ -517,7 +515,7 @@ var FamilyCuration = React.createClass({
                 }
             }
 
-            if (this.state.individualRequired || this.state.variantRequired) {
+            if (this.state.individualRequired) {
                 if (!variantId0) {
                     formError = true;
                     this.setFormErrors('individualorphanetid', 'You must specify a variant if you are defining a proband individual');
@@ -1034,16 +1032,16 @@ var FamilyCuration = React.createClass({
         // If not entered at all, proband individua is not required and must be no error messages at individual fields.
         if (noVariantData && this.refs['individualname']) {
             if (this.refs['individualname'].getValue() || this.refs['individualorphanetid'].getValue()) {
-                this.setState({individualRequired: true, variantRequired: true});
+                this.setState({individualRequired: true});
             } else {
-                this.setState({individualRequired: false, variantRequired: false});
+                this.setState({individualRequired: false});
             }
             var errors = this.state.formErrors;
             errors['individualname'] = '';
             errors['individualorphanetid'] = '';
             this.setState({formErrors: errors});
         } else {
-            this.setState({individualRequired: true, variantRequired: true});
+            this.setState({individualRequired: true});
         }
 
         // Set state
@@ -1611,7 +1609,7 @@ var FamilyVariant = function() {
                             <div className="variant-resources">
                                 {this.state.variantInfo[i].clinvarVariantId ?
                                     <div className="row variant-data-source">
-                                        <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant variantRequired={this.state.variantRequired} />}</label></span>
+                                        <span className="col-sm-5 control-label"><label>{<LabelClinVarVariant />}</label></span>
                                         <span className="col-sm-7 text-no-input"><a href={external_url_map['ClinVarSearch'] + this.state.variantInfo[i].clinvarVariantId} target="_blank">{this.state.variantInfo[i].clinvarVariantId}</a></span>
                                     </div>
                                 : null}
@@ -1623,7 +1621,7 @@ var FamilyVariant = function() {
                                 : null}
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
-                                        <span className="col-sm-5 control-label"><label><LabelCARVariant variantRequired={this.state.variantRequired} /></label></span>
+                                        <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
                                         <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                     </div>
                                 : null}
@@ -1653,7 +1651,7 @@ var FamilyVariant = function() {
                             labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                         <div className="row">
                             <div className="form-group">
-                                <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
+                                <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:</label> : <label>Clear Variant Selection:</label>}</span>
                                 <span className="col-sm-7">
                                     {!this.state.variantInfo[i] || (this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId) ?
                                         <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Family'], 'variantList': this.state.variantInfo}}
@@ -1680,7 +1678,7 @@ var FamilyVariant = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:</strong></span>;
     }
 });
 
@@ -1692,7 +1690,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelCARVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1578,14 +1578,11 @@ var FamilyVariant = function() {
             :
                 <p>The proband associated with this Family can be edited here: <a href={"/individual-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&individual=" + probandIndividual.uuid}>Edit {probandIndividual.label}</a></p>
             }
-            <Input type="checkbox" ref="zygosityHomozygous" label="Check here if homozygous:"
+            <Input type="checkbox" ref="zygosityHomozygous" label={<span>Check here if homozygous:<br /><i className="non-bold-font">(Note: if homozygous, enter only 1 variant below)</i></span>}
                 error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
-            <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                Note: if homozygous, enter only 1 variant below
-            </p>
             <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                 error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2084,7 +2084,7 @@ var FamilyViewer = React.createClass({
                                                 </dl>
                                             </div>
                                         : null }
-                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                        {!variant.clinvarVariantTitle && (variant.hgvsNames && variant.hgvsNames.GRCh38) ?
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>Genomic HGVS Title</dt>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1583,7 +1583,9 @@ var FamilyVariant = function() {
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
-            <p className="alert alert-info">Note: if homozygous, enter only 1 variant below</p>
+            <p className="col-sm-7 col-sm-offset-5">
+                Note: if homozygous, enter only 1 variant below
+            </p>
             <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                 error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1561,7 +1561,7 @@ var FamilyVariant = function() {
     let userUuid = this.state.gdm && this.state.gdm.submitted_by.uuid ? this.state.gdm.submitted_by.uuid : null;
 
     return (
-        <div className="row">
+        <div className="row form-row-helper">
             {!family || !family.segregation || !family.segregation.variants || family.segregation.variants.length === 0 ?
                 <div className="row">
                     <p className="col-sm-7 col-sm-offset-5">
@@ -1606,12 +1606,12 @@ var FamilyVariant = function() {
             }
             <Input type="checkbox" ref="zygosityHomozygous" label="If this is a recessive condition, check here if homozygous:"
                 error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
-                value={probandIndividual && probandIndividual.recessiveZygosity ? probandIndividual.recessiveZygosity : 'none'} handleChange={this.handleChange}
+                handleChange={this.handleChange} defaultChecked="false" checked="false"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
             <Input type="checkbox" ref="zygosityHemizygous" label="Check here if the inheritance pattern is hemizygous:"
                 error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
-                value={probandIndividual && probandIndividual.recessiveZygosity ? probandIndividual.recessiveZygosity : 'none'} handleChange={this.handleChange}
+                handleChange={this.handleChange} defaultChecked="false" checked="false"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
             {_.range(MAX_VARIANTS).map(i => {

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1578,12 +1578,12 @@ var FamilyVariant = function() {
             :
                 <p>The proband associated with this Family can be edited here: <a href={"/individual-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&individual=" + probandIndividual.uuid}>Edit {probandIndividual.label}</a></p>
             }
-            <Input type="checkbox" ref="zygosityHomozygous" label="Check here if the inheritance pattern is homozygous:"
+            <Input type="checkbox" ref="zygosityHomozygous" label="Check here if homozygous:"
                 error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
             </Input>
-            <Input type="checkbox" ref="zygosityHemizygous" label="Check here if the inheritance pattern is hemizygous:"
+            <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                 error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1885,7 +1885,7 @@ var FamilyViewer = React.createClass({
         //    }
         //}
 
-        var variants = segregation ? ((segregation.variants && segregation.variants.length) ? segregation.variants : [{}]) : [{}];
+        var variants = segregation ? ((segregation.variants && segregation.variants.length) ? segregation.variants : []) : [];
         var user = this.props.session && this.props.session.user_properties;
         var userFamily = user && family && family.submitted_by ? user.uuid === family.submitted_by.uuid : false;
         var familyUserAssessed = false; // TRUE if logged-in user doesn't own the family, but the family's owner assessed its segregation

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1578,7 +1578,7 @@ var FamilyVariant = function() {
             :
                 <p>The proband associated with this Family can be edited here: <a href={"/individual-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&individual=" + probandIndividual.uuid}>Edit {probandIndividual.label}</a></p>
             }
-            <Input type="checkbox" ref="zygosityHomozygous" label="If this is a recessive condition, check here if homozygous:"
+            <Input type="checkbox" ref="zygosityHomozygous" label="Check here if the inheritance pattern is homozygous:"
                 error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                 handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2055,6 +2055,22 @@ var FamilyViewer = React.createClass({
                         : null}
 
                         <Panel title="Family - Variant(s) Segregating with Proband" panelClassName="panel-data">
+                            {family.individualIncluded && family.individualIncluded.length ?
+                                <div>
+                                    {family.individualIncluded.map(function(ind, index) {
+                                        return (
+                                            <div key={index}>
+                                                {ind.proband && ind.recessiveZygosity ?
+                                                    <dl className="dl-horizontal">
+                                                        <dt>If Recessive, select variant zygosity</dt>
+                                                        <dd>{ind.recessiveZygosity}</dd>
+                                                    </dl>
+                                                : null}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            : null }
                             {variants.map(function(variant, i) {
                                 return (
                                     <div className="variant-view-panel" key={variant.uuid ? variant.uuid : i}>
@@ -2097,22 +2113,6 @@ var FamilyViewer = React.createClass({
                                                     <dt>Other description</dt>
                                                     <dd>{variant.otherDescription}</dd>
                                                 </dl>
-                                            </div>
-                                        : null }
-                                        {family.individualIncluded && family.individualIncluded.length && i === 0 ?
-                                            <div>
-                                                {family.individualIncluded.map(function(ind, index) {
-                                                    return (
-                                                        <div key={index}>
-                                                            {ind.proband && ind.recessiveZygosity ?
-                                                                <dl className="dl-horizontal">
-                                                                    <dt>If Recessive, select variant zygosity</dt>
-                                                                    <dd>{ind.recessiveZygosity}</dd>
-                                                                </dl>
-                                                            : null}
-                                                        </div>
-                                                    );
-                                                })}
                                             </div>
                                         : null }
                                     </div>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1614,7 +1614,7 @@ var FamilyVariant = function() {
                                 {this.state.variantInfo[i].carId ?
                                     <div className="row">
                                         <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
-                                        <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                        <span className="col-sm-7 text-no-input"><a href={`https:${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                     </div>
                                 : null}
                                 {!this.state.variantInfo[i].clinvarVariantTitle && this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2060,12 +2060,10 @@ var FamilyViewer = React.createClass({
                                     {family.individualIncluded.map(function(ind, index) {
                                         return (
                                             <div key={index}>
-                                                {ind.proband && ind.recessiveZygosity ?
-                                                    <dl className="dl-horizontal">
-                                                        <dt>If Recessive, select variant zygosity</dt>
-                                                        <dd>{ind.recessiveZygosity}</dd>
-                                                    </dl>
-                                                : null}
+                                                <dl className="dl-horizontal">
+                                                    <dt>Zygosity</dt>
+                                                    <dd>{ind.proband && ind.recessiveZygosity ? ind.recessiveZygosity : "None selected"}</dd>
+                                                </dl>
                                             </div>
                                         );
                                     })}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1354,6 +1354,7 @@ var IndividualVariantInfo = function() {
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     </Input>
+                    <p className="alert alert-info">Note: if homozygous, enter only 1 variant below</p>
                     <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                         error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -346,7 +346,7 @@ var IndividualCuration = React.createClass({
             }
 
             // Get variant uuid's if they were added via the modals
-            for (var i = 0; i < this.state.variantCount; i++) {
+            for (var i = 0; i < MAX_VARIANTS; i++) {
                 // Grab the values from the variant form panel
                 var variantId = this.getFormValue('variantUuid' + i);
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1263,7 +1263,7 @@ var IndividualVariantInfo = function() {
     let userUuid = gdm && gdm.submitted_by.uuid ? gdm.submitted_by.uuid : null;
 
     return (
-        <div className="row">
+        <div className="row form-row-helper">
             {individual && individual.proband && family ?
                 <div>
                     <p>Variant(s) for a proband associated with a Family can only be edited through the Family page: <a href={"/family-curation/?editsc&gdm=" + gdm.uuid + "&evidence=" + annotation.uuid + "&family=" + family.uuid}>Edit {family.label}</a></p>
@@ -1354,7 +1354,7 @@ var IndividualVariantInfo = function() {
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     </Input>
-                    <p className="col-sm-7 col-sm-offset-5">
+                    <p className="col-sm-7 col-sm-offset-5 input-note-below">
                         Note: if homozygous, enter only 1 variant below
                     </p>
                     <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -31,8 +31,7 @@ var external_url_map = globals.external_url_map;
 var DeleteButton = curator.DeleteButton;
 var AddResourceId = add_external_resource.AddResourceId;
 
-// Will be great to convert to 'const' when available
-var MAX_VARIANTS = 2;
+const MAX_VARIANTS = 2;
 
 var IndividualCuration = React.createClass({
     mixins: [FormMixin, RestMixin, CurationMixin, CuratorHistory],
@@ -54,15 +53,13 @@ var IndividualCuration = React.createClass({
             annotation: null, // Annotation object given in query string
             extraIndividualCount: 0, // Number of extra families to create
             extraIndividualNames: [], // Names of extra families to create
-            variantCount: 1, // Number of variants to display
+            variantCount: 0, // Number of variants loaded
             variantInfo: {}, // Extra holding info for variant display
-            variantRequired: false, // specifies whether or not variant information is required
             individualName: '', // Currently entered individual name
-            addVariantDisabled: true, // True if Add Another Variant button enabled
             genotyping2Disabled: true, // True if genotyping method 2 dropdown disabled
             proband: null, // If we have an associated family that has a proband, this points at it
             submitBusy: false, // True while form is submitting
-            recessiveZygosity: null, // Determines whether to allow user to add 2nd variant
+            recessiveZygosity: null, // Indicates which zygosity checkbox should be checked, if any
             evidenceScoreUuid: null
         };
     },
@@ -76,15 +73,19 @@ var IndividualCuration = React.createClass({
             this.setState({genotyping2Disabled: this.refs[ref].getValue() === 'none'});
         } else if (ref === 'individualname') {
             this.setState({individualName: this.refs[ref].getValue()});
-        } else if (ref === 'SEGrecessiveZygosity') {
-            // set the variant count and variant required as necessary
-            let tempValue = this.refs[ref].getValue();
-            if (tempValue === 'Heterozygous') {
-                this.setState({variantCount: 2, variantRequired: true});
-            } else if (tempValue === 'Homozygous' || tempValue === 'Hemizygous') {
-                this.setState({variantCount: 1, variantRequired: true});
+        } else if (ref === 'zygosityHomozygous') {
+            if (this.refs[ref].toggleValue()) {
+                this.setState({recessiveZygosity: 'Homozygous'});
+                this.refs['zygosityHemizygous'].resetValue();
             } else {
-                this.setState({variantCount: 1, variantRequired: false});
+                this.setState({recessiveZygosity: null});
+            }
+        } else if (ref === 'zygosityHemizygous') {
+            if (this.refs[ref].toggleValue()) {
+                this.setState({recessiveZygosity: 'Hemizygous'});
+                this.refs['zygosityHomozygous'].resetValue();
+            } else {
+                this.setState({recessiveZygosity: null});
             }
         } else if (ref === 'proband' && this.refs[ref].getValue() === 'Yes') {
             this.setState({proband_selected: true});
@@ -199,13 +200,13 @@ var IndividualCuration = React.createClass({
             if (stateObj.individual) {
                 stateObj.genotyping2Disabled = !(stateObj.individual.method && stateObj.individual.method.genotypingMethods && stateObj.individual.method.genotypingMethods.length);
 
+                stateObj.recessiveZygosity = stateObj.individual.recessiveZygosity ? stateObj.individual.recessiveZygosity : null;
+
                 // If this individual has variants and isn't the proband in a family, handle the variant panels.
                 if (stateObj.individual.variants && stateObj.individual.variants.length && !(stateObj.individual.proband && stateObj.family)) {
                     var variants = stateObj.individual.variants;
                     // This individual has variants
-                    stateObj.variantCount = variants.length ? variants.length : 1;
-                    stateObj.variantRequired = stateObj.individual.recessiveZygosity ? true : false;
-                    stateObj.addVariantDisabled = false;
+                    stateObj.variantCount = variants.length ? variants.length : 0;
                     stateObj.variantInfo = {};
 
                     // Go through each variant to determine how its form fields should be disabled.
@@ -308,7 +309,7 @@ var IndividualCuration = React.createClass({
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
             var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
             var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
-            let SEGrecessiveZygosity = this.getFormValue('SEGrecessiveZygosity');
+            let recessiveZygosity = this.state.recessiveZygosity;
             let variantUuid0 = this.getFormValue('variantUuid0'),
                 variantUuid1 = this.getFormValue('variantUuid1');
 
@@ -353,19 +354,6 @@ var IndividualCuration = React.createClass({
                 if (variantId) {
                     // Make a search string for these terms
                     individualVariants.push('/variants/' + variantId);
-                }
-            }
-
-            // Check to see if the right number of variants exist
-            if (SEGrecessiveZygosity === 'Heterozygous') {
-                if (!variantUuid0 || !variantUuid1) {
-                    formError = true;
-                    this.setFormErrors('SEGrecessiveZygosity', 'For Heterozygous, two variants must be specified');
-                }
-            } else if (SEGrecessiveZygosity === 'Hemizygous' || SEGrecessiveZygosity === 'Homozygous') {
-                if (!variantUuid0) {
-                    formError = true;
-                    this.setFormErrors('SEGrecessiveZygosity', `For ${SEGrecessiveZygosity}, one variant must be specified`);
                 }
             }
 
@@ -689,7 +677,7 @@ var IndividualCuration = React.createClass({
         /* with a family and 1 or more variants          */
         /*************************************************/
         if (individualVariants) {
-            value = this.getFormValue('SEGrecessiveZygosity');
+            value = this.state.recessiveZygosity;
             if (value && value !== 'none') {
                 newIndividual.recessiveZygosity = value;
             } else {
@@ -732,14 +720,8 @@ var IndividualCuration = React.createClass({
     // Update the ClinVar Variant ID fields upon interaction with the Add Resource modal
     updateVariantId: function(data, fieldNum) {
         var newVariantInfo = _.clone(this.state.variantInfo);
-        var addVariantDisabled;
+        let variantCount = this.state.variantCount;
         if (data) {
-            // Enable/Disable Add Variant button as needed
-            if (fieldNum == 0) {
-                addVariantDisabled = false;
-            } else {
-                addVariantDisabled = true;
-            }
             // Update the form and display values with new data
             this.refs['variantUuid' + fieldNum].setValue(data['uuid']);
             newVariantInfo[fieldNum] = {
@@ -749,14 +731,17 @@ var IndividualCuration = React.createClass({
                 'grch38': data.hgvsNames && data.hgvsNames.GRCh38 ? data.hgvsNames.GRCh38 : null,
                 'uuid': data.uuid
             };
+            variantCount += 1;  // We have one more variant to show
         } else {
             // Reset the form and display values
             this.refs['variantUuid' + fieldNum].setValue('');
             delete newVariantInfo[fieldNum];
+            variantCount -= 1;  // we have one less variant to show
         }
         // Set state
-        this.setState({variantInfo: newVariantInfo, addVariantDisabled: addVariantDisabled});
-        this.clrFormErrors('SEGrecessiveZygosity');
+        this.setState({variantInfo: newVariantInfo, variantCount: variantCount});
+        this.clrFormErrors('zygosityHemizygous');
+        this.clrFormErrors('zygosityHomozygous');
     },
 
     // Determine whether a Family is associated with a Group
@@ -1364,17 +1349,17 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
-                    <Input type="select" ref="SEGrecessiveZygosity" label="If Recessive, select variant zygosity:" defaultValue="none"
-                        error={this.getFormError('SEGrecessiveZygosity')} clearError={this.clrFormErrors.bind(null, 'SEGrecessiveZygosity')}
-                        value={individual && individual.recessiveZygosity ? individual.recessiveZygosity : 'none'} handleChange={this.handleChange}
+                    <Input type="checkbox" ref="zygosityHomozygous" label="If this is a recessive condition, check here if homozygous:"
+                        error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
+                        handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
-                        <option value="none">No Selection</option>
-                        <option disabled="disabled"></option>
-                        <option value="Homozygous">Homozygous</option>
-                        <option value="Hemizygous">Hemizygous</option>
-                        <option value="Heterozygous">Heterozygous</option>
                     </Input>
-                    {_.range(this.state.variantCount).map(i => {
+                    <Input type="checkbox" ref="zygosityHemizygous" label="Check here if the inheritance pattern is hemizygous:"
+                        error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
+                        handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}
+                        labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
+                    </Input>
+                    {_.range(MAX_VARIANTS).map(i => {
                         var variant;
 
                         if (variants && variants.length) {
@@ -1428,7 +1413,7 @@ var IndividualVariantInfo = function() {
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="hidden" />
                                 <div className="row">
                                     <div className="form-group">
-                                        <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:{this.state.variantRequired ? ' *' : null}</label> : <label>Clear Variant Selection:</label>}</span>
+                                        <span className="col-sm-5 control-label">{!this.state.variantInfo[i] ? <label>Add Variant:</label> : <label>Clear Variant Selection:</label>}</span>
                                         <span className="col-sm-7">
                                             {!this.state.variantInfo[i] || (this.state.variantInfo[i] && this.state.variantInfo[i].clinvarVariantId) ?
                                                 <AddResourceId resourceType="clinvar" parentObj={{'@type': ['variantList', 'Individual'], 'variantList': this.state.variantInfo}}
@@ -1487,7 +1472,7 @@ var IndividualVariantInfo = function() {
 
 var LabelClinVarVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['ClinVar']} target="_blank" title="ClinVar home page at NCBI in a new tab">ClinVar</a> Variation ID:</strong></span>;
     }
 });
 
@@ -1499,7 +1484,7 @@ var LabelClinVarVariantTitle = React.createClass({
 
 var LabelCARVariant = React.createClass({
     render: function() {
-        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:{this.props.variantRequired ? ' *' : null}</strong></span>;
+        return <span><strong><a href={external_url_map['CAR']} target="_blank" title="ClinGen Allele Registry in a new tab">ClinGen Allele Registry</a> ID:</strong></span>;
     }
 });
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1385,7 +1385,7 @@ var IndividualVariantInfo = function() {
                                         {this.state.variantInfo[i].carId ?
                                             <div className="row">
                                                 <span className="col-sm-5 control-label"><label><LabelCARVariant /></label></span>
-                                                <span className="col-sm-7 text-no-input"><a href={`${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
+                                                <span className="col-sm-7 text-no-input"><a href={`https:${external_url_map['CARallele']}${this.state.variantInfo[i].carId}.html`} target="_blank">{this.state.variantInfo[i].carId}</a></span>
                                             </div>
                                         : null}
                                         {this.state.variantInfo[i].grch38 ?

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1349,7 +1349,7 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
-                    <Input type="checkbox" ref="zygosityHomozygous" label="If this is a recessive condition, check here if homozygous:"
+                    <Input type="checkbox" ref="zygosityHomozygous" label="Check here if the inheritance pattern is homozygous:"
                         error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1349,12 +1349,12 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
-                    <Input type="checkbox" ref="zygosityHomozygous" label="Check here if the inheritance pattern is homozygous:"
+                    <Input type="checkbox" ref="zygosityHomozygous" label="Check here if homozygous:"
                         error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     </Input>
-                    <Input type="checkbox" ref="zygosityHemizygous" label="Check here if the inheritance pattern is hemizygous:"
+                    <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                         error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1564,7 +1564,7 @@ var IndividualViewer = React.createClass({
     render: function() {
         var individual = this.props.context;
         var method = individual.method;
-        var variants = (individual.variants && individual.variants.length) ? individual.variants : [{}];
+        var variants = (individual.variants && individual.variants.length) ? individual.variants : [];
         var i = 0;
         var groupRenders = [];
         var probandLabel = (individual && individual.proband ? <i className="icon icon-proband"></i> : null);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1349,14 +1349,11 @@ var IndividualVariantInfo = function() {
                 </div>
             :
                 <div>
-                    <Input type="checkbox" ref="zygosityHomozygous" label="Check here if homozygous:"
+                    <Input type="checkbox" ref="zygosityHomozygous" label={<span>Check here if homozygous:<br /><i className="non-bold-font">(Note: if homozygous, enter only 1 variant below)</i></span>}
                         error={this.getFormError('zygosityHomozygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHomozygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     </Input>
-                    <p className="col-sm-7 col-sm-offset-5 input-note-below">
-                        Note: if homozygous, enter only 1 variant below
-                    </p>
                     <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                         error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1773,7 +1773,7 @@ var IndividualViewer = React.createClass({
                                                 </dl>
                                             </div>
                                         : null }
-                                        {variant.hgvsNames && variant.hgvsNames.GRCh38 ?
+                                        {!variant.clinvarVariantTitle && (variant.hgvsNames && variant.hgvsNames.GRCh38) ?
                                             <div>
                                                 <dl className="dl-horizontal">
                                                     <dt>Genomic HGVS Title</dt>

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1744,14 +1744,12 @@ var IndividualViewer = React.createClass({
                         </Panel>
 
                         <Panel title={<LabelPanelTitleView individual={individual} variant />} panelClassName="panel-data">
-                            {individual && individual.recessiveZygosity ?
-                                <div>
-                                    <dl className="dl-horizontal">
-                                        <dt>If Recessive, select variant zygosity</dt>
-                                        <dd>{individual.recessiveZygosity}</dd>
-                                    </dl>
-                                </div>
-                            : null }
+                            <div>
+                                <dl className="dl-horizontal">
+                                    <dt>Zygosity</dt>
+                                    <dd>{individual && individual.recessiveZygosity ? individual.recessiveZygosity : "None selected"}</dd>
+                                </dl>
+                            </div>
                             {variants.map(function(variant, i) {
                                 return (
                                     <div key={i} className="variant-view-panel">

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1744,6 +1744,14 @@ var IndividualViewer = React.createClass({
                         </Panel>
 
                         <Panel title={<LabelPanelTitleView individual={individual} variant />} panelClassName="panel-data">
+                            {individual && individual.recessiveZygosity ?
+                                <div>
+                                    <dl className="dl-horizontal">
+                                        <dt>If Recessive, select variant zygosity</dt>
+                                        <dd>{individual.recessiveZygosity}</dd>
+                                    </dl>
+                                </div>
+                            : null }
                             {variants.map(function(variant, i) {
                                 return (
                                     <div key={i} className="variant-view-panel">
@@ -1785,14 +1793,6 @@ var IndividualViewer = React.createClass({
                                                 <dl className="dl-horizontal">
                                                     <dt>Other description</dt>
                                                     <dd>{variant.otherDescription}</dd>
-                                                </dl>
-                                            </div>
-                                        : null }
-                                        {individual && individual.recessiveZygosity && i === 0 ?
-                                            <div>
-                                                <dl className="dl-horizontal">
-                                                    <dt>If Recessive, select variant zygosity</dt>
-                                                    <dd>{individual.recessiveZygosity}</dd>
                                                 </dl>
                                             </div>
                                         : null }

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1354,7 +1354,9 @@ var IndividualVariantInfo = function() {
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Homozygous'}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group">
                     </Input>
-                    <p className="alert alert-info">Note: if homozygous, enter only 1 variant below</p>
+                    <p className="col-sm-7 col-sm-offset-5">
+                        Note: if homozygous, enter only 1 variant below
+                    </p>
                     <Input type="checkbox" ref="zygosityHemizygous" label="Check here if hemizygous:"
                         error={this.getFormError('zygosityHemizygous')} clearError={this.clrFormErrors.bind(null, 'zygosityHemizygous')}
                         handleChange={this.handleChange} defaultChecked="false" checked={this.state.recessiveZygosity == 'Hemizygous'}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -612,7 +612,7 @@
     }
 }
 
-.experimental-data-form {
+.form-row-helper {
     input[type=checkbox] {
         margin-top: 11px;
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4326866/21154442/3da9ee26-c123-11e6-8207-3288ee9d0e37.png)

Reworked the family and individual curation pages of the VCI to support the new zygosity workflow. Users are now asked to check a checkbox depending on zygosity, and are always given 2 variants to add regardless of their zygosity selection. Variants are never required, also regardless of their zygosity selection.

Usage of variables in family and individual curation pages were changed to support this change. The handlers for the zygosity checkboxes were done so that the old data scheme can be used.

Testing:

1. Get to GCI
2. Do family and individual curation with zero, one, or two variants, and different selections of the zygosity checkboxes. Confirm that the variants display properly in the View and Edit pages.
3. Edit the variants and zygosities. Confirm again that the variants display properly in the View and Edit pages.

Note that a bug does exist where an individual proband will not be created via the Family curation page if a variant is not added despite all other relevant fields being filled out. This will be addressed in a separate ticket downstream.