### PR TITLE
Connects to #1124. Remove trans and de novo questions for non-proband individuals.

### DIFF
--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1450,7 +1450,7 @@ var IndividualVariantInfo = function() {
                             </div>
                         );
                     })}
-                    {Object.keys(this.state.variantInfo).length > 0 ?
+                    {Object.keys(this.state.variantInfo).length > 0 && this.state.proband_selected ?
                         <div  className="variant-panel">
                             <Input type="select" ref="individualBothVariantsInTrans" label={<span>If there are 2 variants described, are they both located in <i>trans</i> with respect to one another?</span>}
                                 defaultValue="none" value={individual && individual.bothVariantsInTrans ? individual.bothVariantsInTrans : 'none'}
@@ -1886,7 +1886,7 @@ var IndividualViewer = React.createClass({
                                     </div>
                                 );
                             })}
-                            {variants && variants.length ?
+                            {variants && variants.length && individual.proband ?
                                 <div className="variant-view-panel family-associated">
                                     <div>
                                         <dl className="dl-horizontal">


### PR DESCRIPTION
**Technical notes:**
For a non-proband individuals (associated with a family or not), we do not need to ask them the questions about trans and de novo.

**Steps to test:**
1. Login and create a new GDM.
2. Given the newly created GDM, create a new Family evidence and add a proband individual to the family with one or more variants. Now go into the Individual page and expect to see the 3 questions (trans, de novo, maternity) being shown.
3. Save this Family evidence with proband associated. Now add a non-proband individual to this family with one or more variants. Now go into the Individual page and expect to see the 3 questions (trans, de novo, maternity) NOT being shown.
4. Now create a new Individual evidence and set it to be a proband. Then add a variant and expect to see the 3 questions (trans, de novo, maternity) being shown. Now try setting the individual to a non-proband. Expect to see the 3 questions (trans, de novo, maternity) NOT being shown.
5. Return to the Curation-Central page and click on the "View/Score" links of various evidence in the curation palette. Expect to see the 3 questions (trans, de novo, maternity) being shown or not depending on whether the individual is a proband or not.