### PR TITLE
Connects to #1167. Support ability to create proband individual w/ no variant

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -473,7 +473,7 @@ var FamilyCuration = React.createClass({
             }
 
             // Check that all individual’s Orphanet IDs have the proper format (will check for existence later)
-            if (this.state.variantCount > 0 && !this.state.probandIndividual && this.state.individualRequired) {
+            if (this.state.individualRequired) {
                 if (!indOrphaIds || !indOrphaIds.length || _(indOrphaIds).any(function(id) { return id === null; })) {
                     // Individual’s ORPHA list is bad
                     formError = true;
@@ -550,7 +550,7 @@ var FamilyCuration = React.createClass({
                     throw e;
                 }).then(diseases => {
                     // Check for individual orphanet IDs if we have variants and no existing proband
-                    if (this.state.variantCount && !this.state.probandIndividual && this.state.individualRequired) {
+                    if (!this.state.probandIndividual && this.state.individualRequired) {
                         var searchStr = '/search/?type=orphaPhenotype&' + indOrphaIds.map(function(id) { return 'orphaNumber=' + id; }).join('&');
 
                         // Verify given Orpha ID exists in DB
@@ -658,7 +658,7 @@ var FamilyCuration = React.createClass({
 
                     // Creating or editing a family, and the form has at least one variant. Create the starter individual and return a promise
                     // from its creation. Also remember we have new variants.
-                    if (this.state.variantCount && !this.state.probandIndividual && this.state.individualRequired) {
+                    if (!this.state.probandIndividual && this.state.individualRequired) {
                         initvar = true;
                         label = this.getFormValue('individualname');
                         diseases = individualDiseases['@graph'].map(function(disease) { return disease['@id']; });

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -462,8 +462,6 @@ var FamilyCuration = React.createClass({
             var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
             var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
             let recessiveZygosity = this.state.recessiveZygosity;
-            let variantId0 = this.getFormValue('variantUuid0'),
-                variantId1 = this.getFormValue('variantUuid1');
 
             // Check that all Orphanet IDs have the proper format (will check for existence later)
             if (orphaIds && orphaIds.length && _(orphaIds).any(function(id) { return id === null; })) {
@@ -473,7 +471,7 @@ var FamilyCuration = React.createClass({
             }
 
             // Check that all individual’s Orphanet IDs have the proper format (will check for existence later)
-            if (this.state.individualRequired) {
+            if (this.state.individualRequired && !this.state.probandIndividual) {
                 if (!indOrphaIds || !indOrphaIds.length || _(indOrphaIds).any(function(id) { return id === null; })) {
                     // Individual’s ORPHA list is bad
                     formError = true;


### PR DESCRIPTION
Downstream fix for issues caused by #1141.

Adds in the ability for the user to create proband individuals via the family curation page even if they have no variant data input. In #1141 the user could 'Submit' the form and it would save fine, but an Individual would not be created due to lack of variants, causing issues in the submit page, as well as acting as unexpected behavior. The changes here remove and/or replace checks for variants during individual creation.

Testing:

1. Get to the GCI's Family Curation page
2. Create Family w/ Proband Individual with no Variants (Add Individual name and orphanet; zygosity is optional)
3. Confirm that the Proband Individual is created properly
4. Add Variants for just-created family and confirm that they are saved properly to both Family and Individual
5. Create Family w/ Proband Individual with Variants
6. Edit this family and remove all variants from it, then confirm that no variants are properly saved to both Family and Invidiual