### PR TITLE
Connects to #1177. LOD dropdown/value fixes

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -289,6 +289,9 @@ var FamilyCuration = React.createClass({
                 estimatedLodScore = Math.log(1 / (Math.pow(0.25, numAffected - 1) * Math.pow(0.75, numUnaffected))) / Math.log(10);
             }
         }
+        if (isNaN(estimatedLodScore)) {
+            estimatedLodScore = null;
+        }
         if (lodCalcMode === 'AD' || lodCalcMode === 'AR') {
             if (estimatedLodScore) {
                 estimatedLodScore = parseFloat(estimatedLodScore.toFixed(2));

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1601,7 +1601,8 @@ var FamilySegregation = function() {
             : null}
             <Input type="select" ref="SEGincludeLodScoreInAggregateCalculation" label="Include LOD score in final aggregate calculation?"
                 defaultValue="none" value={curator.booleanToDropdown(segregation.includeLodScoreInAggregateCalculation)} handleChange={this.handleChange}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputDisabled={(this.state.lodPublished === 'Yes' && !this.state.publishedLodScore) || (this.state.lodPublished === 'No' && !this.state.estimatedLodScore)}>
+                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
+                inputDisabled={(this.state.lodPublished === null) || (this.state.lodPublished === 'Yes' && !this.state.publishedLodScore) || (this.state.lodPublished === 'No' && !this.state.estimatedLodScore)}>
                 <option value="none">No Selection</option>
                 <option disabled="disabled"></option>
                 <option value="Yes">Yes</option>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -185,6 +185,11 @@ var FamilyCuration = React.createClass({
                     this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
                 }
             }
+            if (ref === 'SEGlodPublished') {
+                if (this.refs[ref].getValue() === 'none') {
+                    this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
+                }
+            }
 
             // Update Estimated LOD if it should be automatically calculated
             if (this.state.lodLocked && (ref === 'SEGnumberOfAffectedWithGenotype'

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -133,12 +133,20 @@ var FamilyCuration = React.createClass({
                 this.setState({individualRequired: false});
             }
         } else if (ref === 'SEGlodPublished') {
-            if (this.refs[ref].getValue() === 'Yes') {
+            let lodPublished = this.refs[ref].getValue();
+            if (lodPublished === 'Yes') {
                 this.setState({lodPublished: 'Yes'});
-            } else if (this.refs[ref].getValue() === 'No') {
-                this.setState({lodPublished: 'No'});
+                if (!this.state.publishedLodScore) {
+                    this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
+                }
+            } else if (lodPublished === 'No') {
+                this.setState({lodPublished: 'No', publishedLodScore: null});
+                if (!this.state.estimatedLodScore) {
+                    this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
+                }
             } else {
-                this.setState({lodPublished: null});
+                this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
+                this.setState({lodPublished: null, publishedLodScore: null});
             }
         } else if (ref === 'zygosityHomozygous') {
             if (this.refs[ref].toggleValue()) {
@@ -182,11 +190,6 @@ var FamilyCuration = React.createClass({
                 let publishedLodScore = this.refs[ref].getValue();
                 this.setState({publishedLodScore: publishedLodScore});
                 if (publishedLodScore == '') {
-                    this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
-                }
-            }
-            if (ref === 'SEGlodPublished') {
-                if (this.refs[ref].getValue() === 'none') {
                     this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
                 }
             }


### PR DESCRIPTION
Bunch of fixes to the LOD-related dropdown logic in the Family Curation page of the GCI.

After discussing with @selinad it was decided that the 'For Recessive Only' field will NOT be locked when in a GDM that is not Autosomal Recessive to retain flexibility for users.

I've confirmed that changing the 'For Recessive Only' field for an Autosomal Dominant GDM does NOT affect the calculated LOD score, and that changing the '# Segregation' field for an Autosomal Recessive GDM does NOT affect the calculated LOD score, both in code and UI.

Testing:

1. Enter GDM w/ Autosomal Dominant MOI, Family Curation. Test many permutations of interaction to ensure that the LOD Score and Include LOD Score in Final Calculation fields reset properly. Examples:
   - Enter Published LOD Score and select Include LOD Score dropdown. Switch to Calculated LOD score that does not have enough information. Ensure that Include LOD Score dropdown resets and becomes blocked. Switch back to Published LOD Score. Ensure that Published LOD Score field is empty and LOD Score dropdown is still reset and locked.
   - Switch from Published LOD Score and selected Include LOD Score dropdown to Calculated LOD score that has enough information. Ensure that the Include LOD Score dropdown does NOT reset.
   - Enter/calculate LOD Score then reset Published/Estimated LOD Score dropdown. Ensure that the Include LOD Score dropdown resets. Switch back to Published/Estimated and ensure that the Include LOD Score dropdown is still reset and locked, UNLESS the Estimated LOD Score has enough information, at which point it should just switch to being unlocked but still reset.
2. Repeat step 1, but w/ GDM w/ Autosomal Recessive MOI.
3. Repeat step 1, but w/ GDM w/ a NON Autosomal Recessive OR Autosomal Dominant MOI.