### PR TITLE
Connects to #1129 bug new variant curation button

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -69,12 +69,14 @@ var EvaluationSummary = module.exports.EvaluationSummary = React.createClass({
             provisionalReason: nextProps.provisionalReason,
             provisionalInterpretation: nextProps.provisionalInterpretation
         }, () => {
-            if (!this.state.provisionalPathogenicity) {
-                this.refs['provisional-pathogenicity'].resetSelectedOption();
-                this.refs['provisional-reason'].resetValue();
-            } else {
-                this.refs['provisional-pathogenicity'].setValue(this.state.provisionalPathogenicity);
-                this.refs['provisional-reason'].setValue(this.state.provisionalReason);
+            if (this.state.interpretation && this.state.interpretation.evaluations && this.state.interpretation.evaluations.length) {
+                if (!this.state.provisionalPathogenicity) {
+                    this.refs['provisional-pathogenicity'].resetSelectedOption();
+                    this.refs['provisional-reason'].resetValue();
+                } else {
+                    this.refs['provisional-pathogenicity'].setValue(this.state.provisionalPathogenicity);
+                    this.refs['provisional-reason'].setValue(this.state.provisionalReason);
+                }
             }
         });
     },


### PR DESCRIPTION
Merging in existing fix to address the display of "Cannot read property 'resetSelectedOption' of undefined" on the select-variant page when moving from one variant evaluation to a new variant.

To test:

1. Click on "New Variant Curation"
2. Enter a new variant, and save it
3. Start Interpretation: "Interpretation +" on Evidence Only page
4. **Without evaluating any criteria** click "View Summary" 
5. Click "New Variant Curation" 

Normal "Search and Select Variant" page should be seen