### PR TITLE
Connects to #1123. Warning message in deletion modal.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2383,6 +2383,11 @@ var DeleteButtonModal = React.createClass({
         } else if (this.props.item['@type'][0] == 'family') {
             message = <p><strong>Warning</strong>: Deleting this Family will also delete any associated individuals (see any Individuals associated with the Family under its name, bolded below).</p>;
             tree = this.recurseItem(this.props.item, 0, 'display');
+        } else if (this.props.item['@type'][0] == 'individual') {
+            let individual = this.props.item;
+            if (individual.variants.length && individual.associatedFamilies.length) {
+                message = <p><strong>Warning</strong>: Deleting this individual will remove the association between its variants and the Family with which the Individual is associated.</p>;
+            }
         } else if (this.props.item['@type'][0] == 'caseControl') {
             itemLabel = this.props.item.label;
         }


### PR DESCRIPTION
**Technical notes:**
An extra warning message `Deleting this individual will remove the association between its variants and the Family with which the Individual is associated.` has been added to the individual deletion modal for the to-be-deleted item if he/she has both associated variant(s) and associated family.

**Steps to test:**
1. In GCI, add a family evidence and add 2 individuals to this family -- one with associated variant(s) and one without.
2. On the "Edit" form of the individual _with_ associated variant(s), click on the `Delete` button and expect to see the extra warning message appearing in the modal.
3. On the "Edit" form of the individual _without_ associated variant(s), click on the `Delete` button and expect to see NO extra warning message appearing in the modal.