### PR TITLE
Connects to #1196. Schema changes to provisionalClassification object.

### DIFF
--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -52,17 +52,20 @@
                 "proband": {
                     "title": "Proband Individual Evidence",
                     "description": "Boolean value for Proband Individual Evidence",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 },
                 "caseControl": {
                     "title": "Case-Control Evidence",
                     "description": "Boolean value for Case-Control Evidence",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 },
                 "experimental": {
                     "title": "Experimental Evidence",
                     "description": "Boolean value for Experimental Evidence",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },

--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -38,6 +38,34 @@
             "type": "string",
             "default": ""
         },
+        "replicatedOverTime": {
+            "title": "Replication Over Time",
+            "description": "Boolean value for greater than 2 pubs with convincing evidence over time",
+            "type": "boolean",
+            "default": false
+        },
+        "contradictingEvidence": {
+            "title": "Contradictory Evidence",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "proband": {
+                    "title": "Proband Individual Evidence",
+                    "description": "Boolean value for Proband Individual Evidence",
+                    "type": "boolean"
+                },
+                "caseControl": {
+                    "title": "Case-Control Evidence",
+                    "description": "Boolean value for Case-Control Evidence",
+                    "type": "boolean"
+                },
+                "experimental": {
+                    "title": "Experimental Evidence",
+                    "description": "Boolean value for Experimental Evidence",
+                    "type": "boolean"
+                }
+            }
+        },
         "active": {
             "title": "Active",
             "description": "Boolean switch for usage",

--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -14,7 +14,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "totalScore": {
             "title": "Total Score",

--- a/src/clincoded/upgrade/provisionalClassification.py
+++ b/src/clincoded/upgrade/provisionalClassification.py
@@ -4,16 +4,11 @@ from contentbase.upgrader import upgrade_step
 @upgrade_step('provisionalClassification', '1', '2')
 def provisionalClassification_1_2(value, system):
     # https://github.com/ClinGen/clincoded/issues/1196
-    if 'alteredClassification' in value:
-        if value['alteredClassification'] == 'No Evidence':
-            value['alteredClassification'] = 'No selection'
-
-
-@upgrade_step('provisionalClassification', '2', '3')
-def provisionalClassification_2_3(value, system):
-    # https://github.com/ClinGen/clincoded/issues/1196
     if 'replicatedOverTime' not in value:
         value['replicatedOverTime'] = False
 
     if 'contradictingEvidence' not in value:
-    	value['contradictingEvidence'] = {}
+        value['contradictingEvidence'] = {}
+        value['contradictingEvidence']['proband'] = False
+        value['contradictingEvidence']['caseControl'] = False
+        value['contradictingEvidence']['experimental'] = False

--- a/src/clincoded/upgrade/provisionalClassification.py
+++ b/src/clincoded/upgrade/provisionalClassification.py
@@ -1,0 +1,19 @@
+from contentbase.upgrader import upgrade_step
+
+
+@upgrade_step('provisionalClassification', '1', '2')
+def provisionalClassification_1_2(value, system):
+    # https://github.com/ClinGen/clincoded/issues/1196
+    if 'alteredClassification' in value:
+        if value['alteredClassification'] == 'No Evidence':
+            value['alteredClassification'] = 'No selection'
+
+
+@upgrade_step('provisionalClassification', '2', '3')
+def provisionalClassification_2_3(value, system):
+    # https://github.com/ClinGen/clincoded/issues/1196
+    if 'replicatedOverTime' not in value:
+        value['replicatedOverTime'] = False
+
+    if 'contradictingEvidence' not in value:
+    	value['contradictingEvidence'] = {}


### PR DESCRIPTION
**Technical notes:**
An upgrade script has been created to add the new properties to existing provisionalClassification objects in the database.

**Steps to test:**
1. Log into instance https://1196-jz-provision-schema-d451a32-jzhen.demo.clinicalgenome.org and go to ^/provisional/.
2. Reveal any one of the existing provisional records and expect to see the following properties being added to the objects with their default values: `replicatedOverTime` and `contradictingEvidence`.
