### PR TITLE
Connects to #1198. Add helpdesk link.

### DIFF
--- a/src/clincoded/static/libs/bootstrap/navigation.js
+++ b/src/clincoded/static/libs/bootstrap/navigation.js
@@ -133,6 +133,9 @@ var NavItem = module.exports.NavItem = React.createClass({
         } else if (e.target === this.refs.menu_item_variant_curation) {
             this.setState({dropdownActive: false});
             window.open('/static/help/clingen-variant-curation-help.pdf');
+        } else if (e.target === this.refs.menu_item_contact_helpdesk) {
+            this.setState({dropdownActive: false});
+            location.href = 'mailto:clingen-helpdesk@lists.stanford.edu';
         } else {
             this.setState({dropdownActive: false});
         }
@@ -155,6 +158,7 @@ var NavItem = module.exports.NavItem = React.createClass({
                         <ul className="dropdown-menu">
                             <li><a href="#" ref="menu_item_gene_curation">Gene Curation</a></li>
                             <li><a href="#" ref="menu_item_variant_curation">Variant Curation</a></li>
+                            <li><a href="#" ref="menu_item_contact_helpdesk">Contact Helpdesk</a></li>
                         </ul>
                     : null}
                 </div>


### PR DESCRIPTION
**Steps to test:**
1. Click on the **"Help"** navbar button at top.
2. Then click on the **"Contact Helpdesk"** and expect to see the user's default mail client being launched with **"clingen-helpdesk@lists.stanford.edu"** in the **"To:"** field.