### PR TITLE
Connects to #1199. Family proband save bugfix

### DIFF
--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -2017,7 +2017,9 @@ var updateProbandVariants = module.exports.updateProbandVariants = function(indi
     /* Update individual's recessiveZygosity property if:      */
     /* The passed argument is different from the strored value */
     /***********************************************************/
-    if (zygosity !== individual.recessiveZygosity) {
+    let tempZygosity = zygosity ? zygosity : null;
+    let tempIndivZygosity = individual.recessiveZygosity ? individual.recessiveZygosity : null;
+    if (tempZygosity !== tempIndivZygosity) {
         updateNeeded = true;
     }
 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -2036,7 +2036,11 @@ var updateProbandVariants = module.exports.updateProbandVariants = function(indi
             delete writerIndividual['recessiveZygosity'];
         }
         if (individual.scores && individual.scores.length) {
-            writerIndividual.scores = individual.scores;
+            let tempScores = [];
+            individual.scores.forEach(score => {
+                tempScores.push(score.uuid);
+            });
+            writerIndividual.scores = tempScores;
         }
 
         return context.putRestData('/individuals/' + individual.uuid, writerIndividual).then(data => {


### PR DESCRIPTION
Fixes bug where if a proband individual connected to a family had a score connected to it, any edits to the family would fail. This was caused by a combination of 1) an improper comparison between the zygosity value of the form and the zygosity of the individual leading to an unnecessary update of the individual object and 2) no flattening of the `scores` array of the individual, causing a `422` error upon a `PUT` attempt. Both issues have been corrected in this PR.

Testing:

1. Create Family w/ Proband Individual and 1 Variant.
2. Score the Individual
3. Go back to the Family and edit any non-individual field, and confirm that the object saves.
4. Go back to the Family and add a Variant to the Individual, but do not change anything else. Confirm that the object saves (this is to confirm that the Individual update is not only dependent on zygosity).
5. Go back to the Family and edit the Individual's zygosity, and confirm that the object saves.
6. Repeat Step 4 for further confirmation of proper zygosity checking and saving (these steps are to confirm that the Individual update triggers properly on zygosity change).