### PR TITLE
Connects to #1195. Remove check for PM2 vs PS4

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -232,6 +232,8 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                 submittedCriteria.push(criterion);
             });
             // do hard-coded check for PM2 vs PS4
+            // UNCOMMENT BELOW TO RE-ENABLE PM2 vs PS4 CHECK - SEE #1195
+            /*
             if (interpretation.evaluations && interpretation.evaluations.length > 0) {
                 if (this.props.criteria.indexOf('PM2') > -1) {
                     if (criteriaEvalConflictValues.indexOf(this.refs['PM2-status'].getValue()) > -1) {
@@ -255,7 +257,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = Rea
                         }
                     }
                 }
-            }
+            }*/
             // check existing evaluations and map their UUIDs if they match the criteria in this form
             if (freshInterpretation.evaluations) {
                 freshInterpretation.evaluations.map(freshEvaluation => {


### PR DESCRIPTION
This PR comments out the bit of code that prohibits the user from assessing on both PM2 and PS4 as 'Met' and above.

![image](https://cloud.githubusercontent.com/assets/4326866/21820998/b3cba2de-d726-11e6-9155-1bd5e0e72789.png)
![image](https://cloud.githubusercontent.com/assets/4326866/21821005/bb6997f8-d726-11e6-83ed-a9841a2ce4ac.png)

Testing:

1. Enter interpretation mode in VCI
2. Assess 'Met' or above on PM2 under Population tab
3. Assess 'Met' or above on PS4 under Case/Segregation tab, and confirm that you are able to do this.