### PR TITLE
Connects to #1206. Connects to #1207. Connects to #1209.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -192,8 +192,8 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                                             </div>
                                                             <div className="provisional-data-center">
                                                                 <span>
-                                                                    Calculated Score: {provisional.totalScore} ({provisional.autoClassification})<br />
-                                                                    Provisional Classification: {provisional.alteredClassification}
+                                                                    Calculated Score (Classification): {provisional.totalScore} ({provisional.autoClassification})<br />
+                                                                    Modified Provisional Classification: {provisional.alteredClassification === 'No Selection' ? 'None' : provisional.alteredClassification}
                                                                     { summaryPage ?
                                                                         null
                                                                         :

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -192,7 +192,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                                             </div>
                                                             <div className="provisional-data-center">
                                                                 <span>
-                                                                    Total Score: {provisional.totalScore} ({provisional.autoClassification})<br />
+                                                                    Calculated Score: {provisional.totalScore} ({provisional.autoClassification})<br />
                                                                     Provisional Classification: {provisional.alteredClassification}
                                                                     { summaryPage ?
                                                                         null

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -604,7 +604,7 @@ var ExperimentalCuration = React.createClass({
         // Make sure there is an explanation for the score selected differently from the default score
         let newUserScoreObj = Object.keys(this.state.userScoreObj).length ? this.state.userScoreObj : {};
         if (Object.keys(newUserScoreObj).length) {
-            if(newUserScoreObj.score && !newUserScoreObj.scoreExplanation) {
+            if(newUserScoreObj.hasOwnProperty('score') && newUserScoreObj.score !== false && !newUserScoreObj.scoreExplanation) {
                 this.setState({formError: true});
                 return false;
             }
@@ -2254,7 +2254,7 @@ var ExperimentalViewer = React.createClass({
         let newUserScoreObj = Object.keys(this.state.userScoreObj).length ? this.state.userScoreObj : {};
 
         if (Object.keys(newUserScoreObj).length) {
-            if(newUserScoreObj.score && !newUserScoreObj.scoreExplanation) {
+            if(newUserScoreObj.hasOwnProperty('score') && newUserScoreObj.score !== false && !newUserScoreObj.scoreExplanation) {
                 this.setState({formError: true});
                 return false;
             }

--- a/src/clincoded/static/components/score/constants/score_maps.js
+++ b/src/clincoded/static/components/score/constants/score_maps.js
@@ -43,48 +43,48 @@ const SCORE_MAPS = {
     },
     FUNCTION_BIOCHEMICAL_FUNCTION: {
         DEFAULT_SCORE: 0.5,
-        SCORE_RANGE: [0.5, 1, 1.5, 2],
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
         MAX_SCORE: 2
     },
     FUNCTION_PROTEIN_INTERACTIONS: {
         DEFAULT_SCORE: 0.5,
-        SCORE_RANGE: [0.5, 1, 1.5, 2],
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
         MAX_SCORE: 2
     },
     FUNCTION_EXPRESSION: {
         DEFAULT_SCORE: 0.5,
-        SCORE_RANGE: [0.5, 1, 1.5, 2],
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
         MAX_SCORE: 2
     },
     FUNCTIONAL_ALTERATION_PATIENT_CELLS: {
         DEFAULT_SCORE: 1,
-        SCORE_RANGE: [1, 1.5, 2],
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
         MAX_SCORE: 2
     },
     FUNCTIONAL_ALTERATION_ENGINEERED_EQUIVALENT: {
         DEFAULT_SCORE: 0.5,
-        SCORE_RANGE: [0.5, 1],
+        SCORE_RANGE: [0, 0.5, 1],
         MAX_SCORE: 2
     },
     MODEL_SYSTEMS_ANIMAL_MODEL: {
         DEFAULT_SCORE: 2,
-        SCORE_RANGE: [2, 2.5, 3, 3.5, 4],
-        MAX_SCORE: 2
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
+        MAX_SCORE: 4
     },
     MODEL_SYSTEMS_ENGINEERED_EQUIVALENT: {
         DEFAULT_SCORE: 1,
-        SCORE_RANGE: [0.5, 1, 1.5, 2],
-        MAX_SCORE: 2
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
+        MAX_SCORE: 4
     },
     RESCUE_PATIENT_CELLS: {
         DEFAULT_SCORE: 2,
-        SCORE_RANGE: [2, 2.5, 3, 3.5, 4],
-        MAX_SCORE: 2
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4],
+        MAX_SCORE: 4
     },
     RESCUE_ENGINEERED_EQUIVALENT: {
         DEFAULT_SCORE: 1,
-        SCORE_RANGE: [0.5, 1, 1.5, 2],
-        MAX_SCORE: 2
+        SCORE_RANGE: [0, 0.5, 1, 1.5, 2],
+        MAX_SCORE: 4
     }
 };
 

--- a/src/clincoded/static/components/score/experimental_score.js
+++ b/src/clincoded/static/components/score/experimental_score.js
@@ -87,7 +87,7 @@ var ScoreExperimental = module.exports.ScoreExperimental = React.createClass({
                             this.refs.scoreStatus.setValue(scoreStatus);
                             // If the score form fields are allowed, then proceed with the following
                             let defaultScore = loggedInUserScore.calculatedScore,
-                                modifiedScore = loggedInUserScore.score.toString(),
+                                modifiedScore = loggedInUserScore.hasOwnProperty('score') ? loggedInUserScore.score.toString() : null,
                                 scoreExplanation = loggedInUserScore.scoreExplanation,
                                 calcScoreRange = [];
                             this.setState({defaultScore: !isNaN(parseFloat(defaultScore)) ? defaultScore : null});

--- a/src/clincoded/static/components/score/individual_score.js
+++ b/src/clincoded/static/components/score/individual_score.js
@@ -307,7 +307,7 @@ var ScoreIndividual = module.exports.ScoreIndividual = React.createClass({
             }
         }
 
-        if (score && score !== 'none') {
+        if (!isNaN(parseFloat(score))) {
             newUserScoreObj['score'] = parseFloat(score);
         } else {
             if ('score' in newUserScoreObj) {


### PR DESCRIPTION
**Known issues:**
Changes made for #1206 can not be verified in the GCI interface until they are merged with the PR for #1184.

**Changes made for #1206:**
1. The "Total Score:" text label for the GCI provision summary in the header has been changed to "Calculated Score (Classification):".
2. The "Provisional Classification:" text label for the GCI provision summary in the header has been changed to "Modified Provisional Classification:".
3. The displayed value for "Modified Provisional Classification:" will show "None" (instead of "No Selection") if the curator did not select an option in the modified classification dropdown menu.

**Steps to test #1207:**
1. Create a new GDM and add an Experimental evidence.
2. By selecting different evidence types, expect to see the different default scores as well as their score ranges in the dropdown menu matching the following specifications:
![screen shot 2017-01-11 at 11 42 13 am](https://cloud.githubusercontent.com/assets/11320314/21863608/07b3a582-d7f3-11e6-8df2-7207bd250b3e.png)

**Steps to test #1209:**
1. Either edit the Experimental evidence created previously or create a new one.
2. Score the evidence but do NOT select a custom score (leave the selected option at "No Selection" ) in the dropdown menu.
3. Save the form page and expect to be redirected back to Curation-Central.
4. Click on the "Edit" link of the Experimental evidence in question. On the subsequent form page, expect to see the previously saved default score being shown and the custom score dropdown menu being enabled.
![image](https://cloud.githubusercontent.com/assets/6956310/21882955/a1042dc4-d861-11e6-8152-7b3a3d1912d5.png)
