### PR TITLE
Connects to #1208. Connects to #1190. Fixed disabled Family-Segregation selection dropdown and Generate Summary button.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -210,7 +210,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                                 { summaryButton ?
                                                     ( summaryPage ?
                                                         <button type="button" className="btn btn-primary" disabled="disabled">
-                                                            Generate New Summary
+                                                            Generate Summary
                                                         </button>
                                                         :
                                                         <a className="btn btn-primary" role="button" href={'/provisional-curation/?gdm=' + gdm.uuid + '&calculate=yes'}>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -398,6 +398,8 @@ var FamilyCuration = React.createClass({
                     this.setState({orpha: false});
                 }
 
+                // Load the previously stored 'Published Calculated LOD score' if any
+                stateObj.publishedLodScore = stateObj.family.segregation.publishedLodScore ? stateObj.family.segregation.publishedLodScore : null;
                 // Calculate LOD from stored values, if applicable...
                 if (stateObj.lodLocked) {
                     this.calculateEstimatedLOD(
@@ -409,7 +411,6 @@ var FamilyCuration = React.createClass({
                 } else {
                     // ... otherwise, show the stored LOD score, if available
                     stateObj.estimatedLodScore = stateObj.family.segregation.estimatedLodScore ? stateObj.family.segregation.estimatedLodScore : null;
-                    stateObj.publishedLodScore = stateObj.family.segregation.publishedLodScore ? stateObj.family.segregation.publishedLodScore : null;
                 }
             }
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -711,6 +711,7 @@
 
     .button-box {
         width: 200px;
+        text-align: right;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
**Technical notes:**
The change made is to set the `publishedLodScore` state outside of the `if (stateObj.lodLocked)` eval in the `loadData` method, as the 'lodLocked' state value appears to be relevant to the `estimatedLodScore` text field.

**Steps to test:**
1. Create a new GDM and add a Family evidence.
2. In the **Family-Segregation** panel, select **Yes** from the **Published LOD score?** dropdown.
3. Enter a decimal number (e.g. 1.5) in the **Published Calculated LOD score** text input field.
4. Select either **Yes** or **No** from the **Include LOD score in final aggregate calculation?** dropdown.
5. Fill out other **required** fields and save the form page.
6. Return to the Family evidence form page and expect to see the **Include LOD score in final aggregate calculation?** dropdown being enabled in the **Family-Segregation** panel.
![image](https://cloud.githubusercontent.com/assets/6956310/21912432/beb099ec-d8da-11e6-9cd8-940293b9ed80.png)
7. Add a Proband individual evidence and score it. Then click on the **"Generate Summary"** button at the top. On the summary page, expect to see the disabled button to be **"Generate Summary"** instead of **"Generate New Summary"**.