### PR TITLE
Connects to #1217. Fixed LOD score bug.

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -134,11 +134,17 @@ var FamilyCuration = React.createClass({
             }
         } else if (ref === 'SEGlodPublished') {
             let lodPublished = this.refs[ref].getValue();
+            // Find out whether there is pre-existing score in db
+            let publishedLodScore;
+            if (this.state.family && this.state.family.segregation && this.state.family.segregation.publishedLodScore) {
+                publishedLodScore = this.state.family.segregation.publishedLodScore;
+            }
             if (lodPublished === 'Yes') {
-                this.setState({lodPublished: 'Yes'});
-                if (!this.state.publishedLodScore) {
-                    this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
-                }
+                this.setState({lodPublished: 'Yes', publishedLodScore: publishedLodScore ? publishedLodScore : null}, () => {
+                    if (!this.state.publishedLodScore) {
+                        this.refs['SEGincludeLodScoreInAggregateCalculation'].resetValue();
+                    }
+                });
             } else if (lodPublished === 'No') {
                 this.setState({lodPublished: 'No', publishedLodScore: null});
                 if (!this.state.estimatedLodScore) {


### PR DESCRIPTION
**Steps to test:**
1. Create a new GDM and add a Family evidence.
2. Fill out the **required** fields on the form page.
3. Specifically in the **Family-Segregation** panel, select **Yes** from the `Published LOD score?` dropdown.
4. Enter a "1.2" score in the `Published Calculated LOD score` text input.
5. Select **Yes** from the `Include LOD score in final aggregate calculation?` dropdown.
6. After saving the form page, return to it and edit the LOD score specifically.
7. Select **No** or **No Selection** from `Published LOD score?` dropdown, and then select **Yes** again. Expect to see the `Include LOD score in final aggregate calculation?` dropdown being enabled and the previously saved score being shown.