### PR TITLE
Patch: bump elasticsearch version to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - eggs
     - .npm
 addons:
-  # apt_packages:
-  # - graphviz
   apt:
     sources:
       - elasticsearch-1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ cache:
     - eggs
     - .npm
 addons:
-  apt_packages:
-  - graphviz
+  # apt_packages:
+  # - graphviz
+  apt:
+    sources:
+      - elasticsearch-1.7
+    packages:
+      - elasticsearch
+      - graphviz
 env:
   global:
     - secure: "TJYx9N1ZqFPTt5IBhc7GRQNEr5d7HlhRzXv8UnWCT1OSW4j1AHhXJ2Uql4tIUx0frwrSySCOMx+PFtg0vvf0iYOAR4jNl+/cgLV/6JgtnuGiKG3Pwyu7r3ED0I2v0ZV2jSVGAd0VW5/l4Wq7ZFRaPb6YQHKQ6HIhM+4CXaITT3Gg5+Q/ELCMTuxYqG0kFmRAuu+qsJYOFrbxvGuELhlRuYsSGKJj95YuJO2ImHLbbhwyERUPsVtZPk3om10TAT3o+nNqfy+CZNTmi7jusYcdOO/OJ8CDD/CM9bBnr65TQZix6ThTDT0wsGDYQiIgopWiu+reAkDAvI1zkOZcFHket7On1lC6eBATSTg1NZOV+aaSTJsyZzGH8qjGgOhsnIqTwrQ5/IphzzuORnpP2L1x0njYTssAM7F4xeCmlrLohzEsp2GLVacZE13kwZc1HLcldxM8deTtksoQxEZxFa6m4awOuBZqDTyAYUaf8BKv1YBGeNUxuUBe0e7o9AyS8cuOBfDaZ0/8I2hMgW2oXK6r+Gj8oZCaY1eY02b+E2LOZIiRiHxSjwMmi9TgySuQDWCjnv7Mqi3cWFiMshXNdPwASe0uRG1vskNwXJR9iBumvHPWcKUtb+LAGfSGAHfTnmWex3xcsDfLC6lgmxp/ZWWcUNJ1I38TIaoR0LLeU+k+DSg="

--- a/versions.cfg
+++ b/versions.cfg
@@ -75,7 +75,7 @@ boto = 2.38.0
 
 # Required by:
 # encoded==0.1
-elasticsearch = 1.4.0
+elasticsearch = 1.7.0
 
 # Required by:
 # encoded==0.1


### PR DESCRIPTION
This is related to #551 (which will cover a more robust change to 1.7->2.*->5.*). Elasticsearch was already version bumped to 1.7. on cloud configs, but these are also necessary.
 - Update travis `.travis.yml` config
 - Update `versions.cfg`file

To test:
 -  Go to a travis test. e.g. https://travis-ci.org/ClinGen/clincoded/jobs/192687595
![image](https://cloud.githubusercontent.com/assets/1878194/22023702/17a3dbe6-dc7c-11e6-8d2e-cd1728b77c75.png)

 - Locally, run `bin/buildout -c buildout-dev.cfg;`
 -  the `bin/commands` folder files should show elasticsearch-1.7.0 in the path for elasticsearch
![image](https://cloud.githubusercontent.com/assets/1878194/22023819/a6211514-dc7c-11e6-841c-86fd7a6ec533.png)

 - All tests should pass
https://kd-elasticsearch-1-7-1d9fb54-karen.demo.clinicalgenome.org/dashboard/