### PR TITLE
Connects to #1221. Connects to #1227. LOD related changes

### DIFF
--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1571,7 +1571,7 @@ var FamilySegregation = function() {
                 value={segregation.numberOfUnaffectedWithoutBiallelicGenotype} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfUnaffectedWithoutBiallelicGenotype')}
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfUnaffectedWithoutBiallelicGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
             <Input type="number" yesInteger={true} ref="SEGnumberOfSegregationsForThisFamily"
-                label={<span>Number of segregations reported for this Family:<br/>(required for calculating an estimated LOD score for Dominant and X-linked inheritances)</span>}
+                label={<span>Number of segregations reported for this Family:<br/>(required for calculating an estimated LOD score for Dominant or X-linked inheritance)</span>}
                 value={segregation.numberOfSegregationsForThisFamily} handleChange={this.handleChange}
                 error={this.getFormError('SEGnumberOfSegregationsForThisFamily')} clearError={this.clrFormErrors.bind(null, 'SEGnumberOfSegregationsForThisFamily')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1562,7 +1562,7 @@ var FamilySegregation = function() {
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfAffectedWithGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" required />
             <Input type="number" yesInteger={true} ref="SEGnumberOfUnaffectedWithoutBiallelicGenotype"
                 label={<span>For Recessive inheritance only:<br/>Number of UNAFFECTED individuals <i>WITHOUT</i> the biallelic genotype? (required for Recessive inheritance)</span>}
-                value={segregation.numberOfUnaffectedWithoutBiallelicGenotype} minVal={2} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfUnaffectedWithoutBiallelicGenotype')}
+                value={segregation.numberOfUnaffectedWithoutBiallelicGenotype} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfUnaffectedWithoutBiallelicGenotype')}
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfUnaffectedWithoutBiallelicGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
             <Input type="number" yesInteger={true} ref="SEGnumberOfSegregationsForThisFamily"
                 label={<span>Number of segregations reported for this Family:<br/>(required for calculating an estimated LOD score for Dominant and X-linked inheritances)</span>}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1565,7 +1565,7 @@ var FamilySegregation = function() {
                 value={segregation.numberOfUnaffectedWithoutBiallelicGenotype} minVal={2} handleChange={this.handleChange} error={this.getFormError('SEGnumberOfUnaffectedWithoutBiallelicGenotype')}
                 clearError={this.clrFormErrors.bind(null, 'SEGnumberOfUnaffectedWithoutBiallelicGenotype')} labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
             <Input type="number" yesInteger={true} ref="SEGnumberOfSegregationsForThisFamily"
-                label={<span>Number of segregations reported for this Family:<br/>(required for calculating an estimated LOD score for Dominant inheritance)</span>}
+                label={<span>Number of segregations reported for this Family:<br/>(required for calculating an estimated LOD score for Dominant and X-linked inheritances)</span>}
                 value={segregation.numberOfSegregationsForThisFamily} handleChange={this.handleChange}
                 error={this.getFormError('SEGnumberOfSegregationsForThisFamily')} clearError={this.clrFormErrors.bind(null, 'SEGnumberOfSegregationsForThisFamily')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -283,8 +283,8 @@ var FamilyCuration = React.createClass({
     // Calculate estimated LOD for Autosomal dominant and Autosomal recessive GDMs
     calculateEstimatedLOD: function(lodCalcMode, numAffected=0, numUnaffected=0, numSegregation=0) {
         let estimatedLodScore = null;
-        if (lodCalcMode === 'AD') {
-            // LOD scoring if GDM is Autosomal dominant
+        if (lodCalcMode === 'ADX') {
+            // LOD scoring if GDM is Autosomal dominant or X-Linked
             if (numSegregation !== '') {
                 numSegregation = parseInt(numSegregation);
                 estimatedLodScore = Math.log(1 / Math.pow(0.5, numSegregation)) / Math.log(10);
@@ -300,7 +300,7 @@ var FamilyCuration = React.createClass({
         if (isNaN(estimatedLodScore)) {
             estimatedLodScore = null;
         }
-        if (lodCalcMode === 'AD' || lodCalcMode === 'AR') {
+        if (lodCalcMode === 'ADX' || lodCalcMode === 'AR') {
             if (estimatedLodScore) {
                 estimatedLodScore = parseFloat(estimatedLodScore.toFixed(2));
             }
@@ -371,9 +371,9 @@ var FamilyCuration = React.createClass({
 
             // Update the LOD locked and calculation modes
             if (stateObj.gdm && stateObj.gdm.modeInheritance) {
-                if (stateObj.gdm.modeInheritance.indexOf('Autosomal dominant') > -1) {
+                if (stateObj.gdm.modeInheritance.indexOf('Autosomal dominant') > -1 || stateObj.gdm.modeInheritance.indexOf('X-linked inheritance') > -1) {
                     stateObj.lodLocked = true;
-                    stateObj.lodCalcMode = 'AD';
+                    stateObj.lodCalcMode = 'ADX';
                 } else if (stateObj.gdm.modeInheritance.indexOf('Autosomal recessive') > -1) {
                     stateObj.lodLocked = true;
                     stateObj.lodCalcMode = 'AR';


### PR DESCRIPTION
#### Connects to #1221:

* Remove `minVal` limit on # Unaffected individuals fields on Family curation page.

Testing:

1. Get to GCI and navigate to Family curation page
2. Attempt to add a Family w/ # of Unaffected individuals being `1`
3. Ensure that the Family can be saved

![image](https://cloud.githubusercontent.com/assets/4326866/22039615/d6df3a68-dcb4-11e6-97ad-9c014121e869.png)

#### Connects to #1227:

* Make it so that GDMs with MOI of X-Linked inheritance uses the same automatic LOD formula as Autosomal Dominant inheritance

Testing:

1. Get to GCI w/ GDM with X-Linked inheritance MOI and navigate to Family curation page
2. Add `14` to `Number of segregations reported for this Family` field
3. Select `No` for `Published LOD score` field
4. Ensure that the `Estimated LOD score` field value is `4.21`
5. Change the `14` to `15` and ensure that the `Estimated LOD score` updates to `4.52`
6. Set to Include LOD score in Calculations and save the Family
7. Click to Generate a summary and ensure that the Segregations fields are `1`, `6.5 (4.52*)`, and `6.5`
