### PR TITLE
Connects to #1223. Connects to #1224.

### DIFF
--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -201,6 +201,7 @@ var CreateGeneDisease = React.createClass({
                                         return <option key={i} value={adjective}>{adjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</option>;
                                     })}
                                 </Input>
+                                <div><p className="alert alert-warning">Currently, the above options (gene, disease, mode of inheritance, or adjective) cannot be altered for a Gene:Disease record once the record has been created. This includes adding an adjective to a Gene:Disease:Mode of inheritance record that has already been created or editing an adjective associated with a record.</p></div>
                                 <Input type="submit" inputClassName="btn-default pull-right" id="submit" />
                             </div>
                         </Form>

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -195,7 +195,7 @@ var CreateGeneDisease = React.createClass({
                                 <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue="none"
                                     error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')} inputDisabled={adjectiveDisabled}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective">
-                                    <option value="none" disabled="disabled">Select</option>
+                                    <option value="none">Select</option>
                                     <option disabled="disabled"></option>
                                     {adjectives.map(function(adjective, i) {
                                         return <option key={i} value={adjective}>{adjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</option>;

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -612,7 +612,7 @@ var AssociateInheritance = React.createClass({
                          <Input type="select" ref="moiAdjective" label="Select an adjective" defaultValue='none' inputDisabled={adjectiveDisabled}
                             error={this.getFormError('moiAdjective')} clearError={this.clrFormErrors.bind(null, 'moiAdjective')}
                             labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="moiAdjective">
-                            <option value="none" disabled="disabled">Select</option>
+                            <option value="none">Select</option>
                             <option disabled="disabled"></option>
                             {adjectives.map(function(adjective, i) {
                                 return <option key={i} value={adjective}>{adjective.match(/^(.*?)(?: \(HP:[0-9]*?\)){0,1}$/)[1]}</option>;


### PR DESCRIPTION
**Steps to test #1223:**
1. In GCI, go to the "Create Gene-Disease Record" interface.
2. Expect to see the warning note beneath the dropdown menus.
![image](https://cloud.githubusercontent.com/assets/6956310/22043917/cba15160-dcc6-11e6-98fe-97d5f8affdb7.png)

**Steps to test #1224:**
1. In GCI, go to the "Create Gene-Disease Record" interface.
2. Select any MOI that return a list of adjectives in the dropdown menu beneath it (e.g. AD, AR, X-Linked).
3. In the adjective dropdown menu, select any available adjective and expect to be able to subsequently select the "Select" option which returns the "none" value _without_ switching to a different MOI to reset adjective dropdown menu option.
![image](https://cloud.githubusercontent.com/assets/6956310/22044330/fe814ca0-dcc8-11e6-87f1-7fa22c756c0d.png)
4. This minor change also applies to the MOI association modal in VCI.