### PR TITLE
Connects to #1228. Family-Proband Variants-Scores connection

### DIFF
--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -2073,6 +2073,7 @@ var updateProbandVariants = module.exports.updateProbandVariants = function(indi
         }
 
         return context.putRestData('/individuals/' + individual.uuid, writerIndividual).then(data => {
+            // update any evidenceScore objects, if any
             return Promise.all(updatedScores);
         });
     }

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -2046,10 +2046,15 @@ var updateProbandVariants = module.exports.updateProbandVariants = function(indi
     }
 
     if (updateNeeded) {
+        console.log('update needed');
         var writerIndividual = curator.flatten(individual);
+        console.log(variants);
         // manage variants variable in individual object
-        if (!variants) {
+        if (!variants || (variants && variants.length === 0)) {
+            console.log('no variants');
             delete writerIndividual['variants'];
+            // clear any scores, too, if the variants are cleared
+            delete writerIndividual['scores'];
         } else {
             writerIndividual.variants = variants;
         }


### PR DESCRIPTION
This fixes an issue where, if a user scores a Proband connected to a Family, and then removes the variants from the Family (connected to, and required to score a Proband), the Proband's Score still exists by:

1. If the Family's Variant count is 0, it deletes the `evidenceScore` key from the associated Proband Individual, removing all Scores on that Proband Individual
2. Looping through and setting the Proband Individuals' Scores to have a `status` of `deleted` so we do not have orphan'ed `evidenceScore` objects in the database

Testing:

1. Get to GCI and create Family w/ 2 variants + Proband
2. Score Proband
3. Get another person/account to score Proband
4. Remove 1 variant from Family and save. Confirm that the 2 scores are still there
5. Remove last variant from Family and save. Confirm that the 2 scores are gone
6. Add variant to Family and save. Confirm that the 2 scores are still gone
7. Score Proband with original user (just to check that this still works properly)
8. Score Proband with second user (just to check that this still works properly)

Dev testing:

8. Keep track of UUIDs of `evidenceScore` objects after scoring... check that their `status` is set to `deleted` after the Family was modified to have 0 variants

Edit:

The matter of locking the original evidence creator's ability to modify an evidence once another user has Scored an evidence will be addressed in #1237. It was deemed that it would most likely be an issue for this release.