### PR TITLE
Connects to #1239. Adding score panel header to evidence viewers.

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1905,8 +1905,8 @@ var CaseControlViewer = React.createClass({
 
                                 </dl>
                             </Panel>
-                            {evidenceScores.length > 1 ?
-                                <Panel panelClassName="panel-data">
+                            {evidenceScores.length > 1 || (evidenceScores.length === 1 && !userCaseControl) ?
+                                <Panel title="Case-Control - Other Curator Scores" panelClassName="panel-data">
                                     <ScoreViewer evidence={this.props.context} otherScores={true} session={this.props.session} />
                                 </Panel>
                             : null}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2476,7 +2476,7 @@ var ExperimentalViewer = React.createClass({
                                 <div>
                                     <dt>Interacting Gene(s)</dt>
                                     <dd>{experimental.proteinInteractions.interactingGenes && experimental.proteinInteractions.interactingGenes.map(function(gene, i) {
-                                        return <span key={gene.symbol}>{i > 0 ? ', ' : ''}<a href={external_url_map['HGNC'] + gene.hgncId} title={"HGNC entry for " + gene.symbol + " in new tab"} target="_blank">{gene.symbol}</a></span>;
+                                        return <span key={gene.symbol + '-' + i}>{i > 0 ? ', ' : ''}<a href={external_url_map['HGNC'] + gene.hgncId} title={"HGNC entry for " + gene.symbol + " in new tab"} target="_blank">{gene.symbol}</a></span>;
                                     })}</dd>
                                 </div>
 
@@ -2791,8 +2791,8 @@ var ExperimentalViewer = React.createClass({
                                 </dl>
                             </Panel>
                         : null}
-                        {evidenceScores.length > 1 ?
-                            <Panel panelClassName="panel-data">
+                        {evidenceScores.length > 1 || (evidenceScores.length === 1 && !userExperimental)?
+                            <Panel title="Experimental Data - Other Curator Scores" panelClassName="panel-data">
                                 <ScoreViewer evidence={experimental} otherScores={true} session={this.props.session} />
                             </Panel>
                         : null}

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1956,8 +1956,8 @@ var IndividualViewer = React.createClass({
 
                         {(associatedFamily && individual.proband) || (!associatedFamily && individual.proband) ?
                             <div>
-                                {evidenceScores.length > 1 ?
-                                    <Panel panelClassName="panel-data">
+                                {evidenceScores.length > 1 || (evidenceScores.length === 1 && !userIndividual) ?
+                                    <Panel title={<LabelPanelTitleView individual={individual} labelText="Other Curator Scores" />} panelClassName="panel-data">
                                         <ScoreViewer evidence={individual} otherScores={true} session={this.props.session} />
                                     </Panel>
                                 : null}

--- a/src/clincoded/static/components/score/viewer.js
+++ b/src/clincoded/static/components/score/viewer.js
@@ -69,7 +69,7 @@ var ScoreViewer = module.exports.ScoreViewer = React.createClass({
                 {scores.map((item, i) => {
                     return (
                         <div key={i} className="evidence-score-list-viewer">
-                            <h5>{item.submitted_by.title}</h5>
+                            <h5>Curator: {item.submitted_by.title}</h5>
                             <div>
                                 {item.scoreStatus && item.scoreStatus !== 'none' && this.props.evidence['@type'][0] !== 'caseControl' ?
                                     <dl className="dl-horizontal">


### PR DESCRIPTION
**Steps to test:**
1. Log into GCI as primary user and create a new GDM.
2. Add new evidence for Proband Individual, Case-Control, and Experimental. Score each of the evidence.
3. Log out and log in as a different user and **View/Score** each of the evidence in question in the GDM.
4. In each evidence, expect to see:
* Prior to scoring, the evidence's curator score is shown in the **"Other Curator Scores"** panel.
* There is a header in the **"Other Curator Scores"** panel.
* There is a "Curator: " prefix to the curator name in the **"Other Curator Scores"** panel.