### PR TITLE
Connects to #1240. scoreStatus `default` property removal.

### DIFF
--- a/src/clincoded/schemas/evidenceScore.json
+++ b/src/clincoded/schemas/evidenceScore.json
@@ -20,7 +20,6 @@
         "scoreStatus": {
             "title": "Score Status",
             "description": "Score, Review or Contradicts",
-            "default": "Score",
             "type": "string"
         },
         "calculatedScore": {


### PR DESCRIPTION
Removed the 'default' value property of the 'scoreStatus' object in the schema.