### PR TITLE
Connects to #1245. Orphaned evidenceScores

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1401,15 +1401,6 @@ var CaseControlViewer = React.createClass({
 
     scoreSubmit: function(e) {
         let caseControl = this.props.context;
-        /*,
-            evidenceScores = [];
-        let caseControlScores = caseControl && caseControl.scores ? caseControl.scores : [];
-        // Find any pre-existing score(s) and put their '@id' values into an array
-        if (caseControlScores.length) {
-            caseControlScores.forEach(score => {
-                evidenceScores.push(score['@id']);
-            });
-        }*/
         /*****************************************************/
         /* Evidence score data object                        */
         /*****************************************************/
@@ -1436,11 +1427,13 @@ var CaseControlViewer = React.createClass({
                     return Promise.resolve(newScoreObjectUuid);
                 }).then(newScoreObjectUuid => {
                     return this.getRestData('/casecontrol/' + caseControl.uuid, null, true).then(freshCaseControl => {
-                        let newCaseControl = curator.flatten(freshCaseControl);
-                        // Update individual's scores property
-                        if (!newCaseControl.scores) {
-                            newCaseControl.scores = [];
-                        }
+                        // flatten both context and fresh case-control
+                        let newCaseControl = curator.flatten(caseControl);
+                        let freshFlatCaseControl = curator.flatten(freshCaseControl);
+                        // take only the scores from the fresh case-control to not overwrite changes
+                        // in newCaseControl
+                        newCaseControl.scores = freshFlatCaseControl.scores ? freshFlatCaseControl.scores : [];
+                        // push new score uuid to newIndividual's scores list
                         newCaseControl.scores.push(newScoreObjectUuid);
 
                         return this.putRestData('/casecontrol/' + caseControl.uuid, newCaseControl).then(updatedCaseControlObj => {

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1400,7 +1400,8 @@ var CaseControlViewer = React.createClass({
     },
 
     scoreSubmit: function(e) {
-        let caseControl = this.props.context,
+        let caseControl = this.props.context;
+        /*,
             evidenceScores = [];
         let caseControlScores = caseControl && caseControl.scores ? caseControl.scores : [];
         // Find any pre-existing score(s) and put their '@id' values into an array
@@ -1408,7 +1409,7 @@ var CaseControlViewer = React.createClass({
             caseControlScores.forEach(score => {
                 evidenceScores.push(score['@id']);
             });
-        }
+        }*/
         /*****************************************************/
         /* Evidence score data object                        */
         /*****************************************************/
@@ -1428,18 +1429,24 @@ var CaseControlViewer = React.createClass({
                 });
             } else {
                 return this.postRestData('/evidencescore/', newUserScoreObj).then(newScoreObject => {
+                    let newScoreObjectUuid = null;
                     if (newScoreObject) {
-                        // Add new score @id to array
-                        evidenceScores.push(newScoreObject['@graph'][0]['@id']);
+                        newScoreObjectUuid = newScoreObject['@graph'][0]['@id'];
                     }
-                    return Promise.resolve(evidenceScores);
-                }).then(newScoresArray => {
-                    let newCaseControl = curator.flatten(caseControl);
-                    // Update individual's scores property
-                    newCaseControl['scores'] = newScoresArray;
-                    this.putRestData('/casecontrol/' + caseControl.uuid, newCaseControl).then(updatedCaseControlObj => {
-                        this.setState({submitBusy: false});
-                        return Promise.resolve(updatedCaseControlObj['@graph'][0]);
+                    return Promise.resolve(newScoreObjectUuid);
+                }).then(newScoreObjectUuid => {
+                    return this.getRestData('/casecontrol/' + caseControl.uuid, null, true).then(freshCaseControl => {
+                        let newCaseControl = curator.flatten(freshCaseControl);
+                        // Update individual's scores property
+                        if (!newCaseControl.scores) {
+                            newCaseControl.scores = [];
+                        }
+                        newCaseControl.scores.push(newScoreObjectUuid);
+
+                        return this.putRestData('/casecontrol/' + caseControl.uuid, newCaseControl).then(updatedCaseControlObj => {
+                            this.setState({submitBusy: false});
+                            return Promise.resolve(updatedCaseControlObj['@graph'][0]);
+                        });
                     });
                 }).then(data => {
                     this.handlePageRedirect();

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1781,6 +1781,13 @@ function flattenExperimental(experimental) {
         });
     }
 
+    // Flatten evidence scores
+    if (experimental.scores && experimental.scores.length) {
+        flat.scores = experimental.scores.map(function(score) {
+            return score['@id'];
+        });
+    }
+
     return flat;
 }
 

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -2272,17 +2272,12 @@ var ExperimentalViewer = React.createClass({
                     return this.getRestData('/experimental/' + experimental.uuid, null, true).then(freshExperimental => {
                         // flatten both context and fresh experimental
                         let newExperimental = curator.flatten(experimental);
-                        console.log('curr');
-                        console.log(newExperimental.scores);
                         let freshFlatExperimental = curator.flatten(freshExperimental);
-                        console.log('curr');
-                        console.log(freshFlatExperimental.scores);
                         // take only the scores from the fresh experimental to not overwrite changes
                         // in newExperimental
                         newExperimental.scores = freshFlatExperimental.scores ? freshFlatExperimental.scores : [];
                         // push new score uuid to newExperimental's scores list
                         newExperimental.scores.push(newScoreObjectUuid);
-                        console.log(newExperimental.scores);
 
                         return this.putRestData('/experimental/' + experimental.uuid, newExperimental).then(updatedExperimentalObj => {
                             this.setState({submitBusy: false});

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1624,17 +1624,6 @@ var IndividualViewer = React.createClass({
 
     scoreSubmit: function(e) {
         let individual = this.props.context;
-        /*,
-            evidenceScores = [];
-        /*
-        let individualScores = [individual && individual.scores ? individual.scores : [];
-        // Find any pre-existing score(s) and put their '@id' values into an array
-        if (individualScores.length) {
-            individualScores.forEach(score => {
-                evidenceScores.push(score['@id']);
-            });
-        }]
-        */
         /*****************************************************/
         /* Proband score status data object                  */
         /*****************************************************/

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1664,7 +1664,7 @@ var IndividualViewer = React.createClass({
                     }
                     return Promise.resolve(newScoreObjectUuid);
                 }).then(newScoreObjectUuid => {
-                    this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndivdiual => {
+                    return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndivdiual => {
                         let newIndividual = curator.flatten(individual);
                         // Update individual's scores property
                         if (!newIndividual.scores) {

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1653,8 +1653,8 @@ var IndividualViewer = React.createClass({
                     }
                     return Promise.resolve(newScoreObjectUuid);
                 }).then(newScoreObjectUuid => {
-                    return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndivdiual => {
-                        let newIndividual = curator.flatten(individual);
+                    return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndividual => {
+                        let newIndividual = curator.flatten(freshIndividual);
                         // Update individual's scores property
                         if (!newIndividual.scores) {
                             newIndividual.scores = [];

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1623,15 +1623,18 @@ var IndividualViewer = React.createClass({
     },
 
     scoreSubmit: function(e) {
-        let individual = this.props.context,
+        let individual = this.props.context;
+        /*,
             evidenceScores = [];
-        let individualScores = individual && individual.scores ? individual.scores : [];
+        /*
+        let individualScores = [individual && individual.scores ? individual.scores : [];
         // Find any pre-existing score(s) and put their '@id' values into an array
         if (individualScores.length) {
             individualScores.forEach(score => {
                 evidenceScores.push(score['@id']);
             });
-        }
+        }]
+        */
         /*****************************************************/
         /* Proband score status data object                  */
         /*****************************************************/
@@ -1655,18 +1658,24 @@ var IndividualViewer = React.createClass({
                 });
             } else {
                 return this.postRestData('/evidencescore/', newUserScoreObj).then(newScoreObject => {
+                    let newScoreObjectUuid = null;
                     if (newScoreObject) {
-                        // Add new score @id to array
-                        evidenceScores.push(newScoreObject['@graph'][0]['@id']);
+                        newScoreObjectUuid = newScoreObject['@graph'][0]['@id'];
                     }
-                    return Promise.resolve(evidenceScores);
-                }).then(newScoresArray => {
-                    let newIndividual = curator.flatten(individual);
-                    // Update individual's scores property
-                    newIndividual['scores'] = newScoresArray;
-                    this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {
-                        this.setState({submitBusy: false});
-                        return Promise.resolve(updatedIndividualObj['@graph'][0]);
+                    return Promise.resolve(newScoreObjectUuid);
+                }).then(newScoreObjectUuid => {
+                    this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndivdiual => {
+                        let newIndividual = curator.flatten(individual);
+                        // Update individual's scores property
+                        if (!newIndividual.scores) {
+                            newIndividual.scores = [];
+                        }
+                        newIndividual.scores.push(newScoreObjectUuid);
+
+                        return this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {
+                            this.setState({submitBusy: false});
+                            return Promise.resolve(updatedIndividualObj['@graph'][0]);
+                        });
                     });
                 }).then(data => {
                     this.handlePageRedirect();

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1654,11 +1654,13 @@ var IndividualViewer = React.createClass({
                     return Promise.resolve(newScoreObjectUuid);
                 }).then(newScoreObjectUuid => {
                     return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndividual => {
-                        let newIndividual = curator.flatten(freshIndividual);
-                        // Update individual's scores property
-                        if (!newIndividual.scores) {
-                            newIndividual.scores = [];
-                        }
+                        // flatten both context and fresh individual
+                        let newIndividual = curator.flatten(individual);
+                        let freshFlatIndividual = curator.flatten(freshIndividual);
+                        // take only the scores from the fresh individual to not overwrite changes
+                        // in newIndividual
+                        newIndividual.scores = freshFlatIndividual.scores ? freshFlatIndividual.scores : [];
+                        // push new score uuid to newIndividual's scores list
                         newIndividual.scores.push(newScoreObjectUuid);
 
                         return this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {


### PR DESCRIPTION
The changes in this PR revises the `scoreSubmit` methods in the `individual_curation` , `case_control_curation` , and `experimental_curation` pages so they get the freshest possible data for the evidence and use its scores list. Otherwise, a Save call of the Score using a stale version of the data may remove Scores added previously by other users.

Testing:

1. Create Proband individual and score it as User 1
2. Open the View/Score page for the Proband as User 1
3. As User 2, open the View/Score page for the same evidence on a different browser
4. Score the evidence as User 2
5. Without refreshing the page, Score the evidence as User 1 on the same browser window opened in step 2
6. Confirm that both User 1 and 2's Scores are present
7. Repeat steps 1~6 with a Case Control evidence
8. Repeat steps 1~6 with an Experimental evidence