### PR TITLE
Connects to #1251. Bug in changing scoreStatus to `No Selection`.

### DIFF
--- a/src/clincoded/static/components/score/experimental_score.js
+++ b/src/clincoded/static/components/score/experimental_score.js
@@ -108,7 +108,7 @@ var ScoreExperimental = module.exports.ScoreExperimental = React.createClass({
                             showScoreInput: false,
                             scoreStatus: scoreStatus ? scoreStatus : null
                         }, () => {
-                            this.refs.scoreStatus.setValue(scoreStatus);
+                            this.refs.scoreStatus.setValue(scoreStatus ? scoreStatus : 'none');
                             this.updateUserScoreObj();
                         });
                     }

--- a/src/clincoded/static/components/score/individual_score.js
+++ b/src/clincoded/static/components/score/individual_score.js
@@ -146,7 +146,7 @@ var ScoreIndividual = module.exports.ScoreIndividual = React.createClass({
                             showScoreInput: false,
                             scoreStatus: scoreStatus ? scoreStatus : null
                         }, () => {
-                            this.refs.scoreStatus.setValue(scoreStatus);
+                            this.refs.scoreStatus.setValue(scoreStatus ? scoreStatus : 'none');
                             this.updateUserScoreObj();
                         });
                     }


### PR DESCRIPTION
**Steps to test:**
1. Create a new GDM. 
2. Add a Proband Individual evidence and score it.
3. Upon completion, return to the Proband form page or go to its View/Edit page. Change the Score Status to "No Selection" and click on the "Save" button.
4. Return to the Proband form page or go to its View/Edit page, and expect to see the "No Selection" option being selected in the Score Status dropdown in the score panel.
5. Add an Experimental evidence and score it.
6. Upon completion, return to the Experimental form page or go to its View/Edit page. Change the Score Status to "No Selection" and click on the "Save" button.
7. Return to the Experimental form page or go to its View/Edit page, and expect to see the "No Selection" option being selected in the Score Status dropdown in the score panel.