### PR TITLE
Connects to #1249. CaseControl submit bug

### DIFF
--- a/src/clincoded/static/components/case_control_submit.js
+++ b/src/clincoded/static/components/case_control_submit.js
@@ -106,11 +106,10 @@ var CaseControlSubmit = module.exports.CaseControlSubmit = React.createClass({
         this.queryValues.annotationUuid = queryKeyValue('evidence', this.props.href);
 
         // Build the link to go back and edit the newly created group page
-        var editCaseControlLink = (gdm && caseControl && annotation) ? 
+        var editCaseControlLink = (gdm && caseControl && annotation) ?
                                     '/case-control-curation/?gdm=' + gdm.uuid +
-                                    '&evidence=' + annotation.uuid + 
+                                    '&evidence=' + annotation.uuid +
                                     '&casecontrol=' + caseControl.uuid +
-                                    '&evidencescore=' + caseControl.scores[0].uuid +
                                     '&casecohort=' + caseControl.caseCohort.uuid +
                                     '&controlcohort=' + caseControl.controlCohort.uuid
                                     : '';


### PR DESCRIPTION
This change should make the casecontrol submit page render and not display an error if a casecontrol object is created without a score.

Testing:

1. Create a CaseControl object with no score
2. Confirm that the save page renders properly and that there is no error in console
3. Confirm that the 'Edit' button on submit page takes you back to the casecontrol object, and all the info is there
4. Repeat steps 1~3 with a CaseControl object with a score