### PR TITLE
Connects to #1255. Bug in caseControl score in summary.

### DIFF
--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -367,12 +367,9 @@ var ProvisionalCuration = React.createClass({
                     if (caseControl.scores && caseControl.scores.length) {
                         caseControl.scores.forEach(score => {
                             if (score.submitted_by.uuid === this.state.user) {
-                                if (score.scoreStatus === 'Score' && 'score' in score && score.score !== 'none') {
+                                if ('score' in score && score.score !== 'none') {
                                     scoreTableValues['caseControlCount'] += 1;
                                     scoreTableValues['caseControlPoints'] += parseFloat(score.score);
-                                } else if (score.scoreStatus === 'Contradicts') {
-                                    // set flag if a contradicting case-control evidence is found
-                                    contradictingEvidence.caseControl = true;
                                 }
                             }
                         });


### PR DESCRIPTION
Removed check for `scoreStatus` property in caseControl score object since the caseControl score object will only have the `score` property.

**Steps to test:**
1. Create a new GDM.
2. Add a caseControl evidence and score it.
3. Generate summary and expect to see the caseControl scoring data being shown on the summary page.