### PR TITLE
Connects to #1258. Convert CA ID dbsnpids to string

### DIFF
--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -204,7 +204,7 @@ function parseCAR(json) {
         if (json.externalRecords.dbSNP && json.externalRecords.dbSNP.length > 0) {
             variant.dbSNPIds = [];
             json.externalRecords.dbSNP.map(function(dbSNPentry, i) {
-                variant.dbSNPIds.push(dbSNPentry.rs);
+                variant.dbSNPIds.push(dbSNPentry.rs.toString());
             });
         }
     }

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -52,6 +52,7 @@ Feature: Select Variant
         When I press the button "Save and View Evidence"
         And I wait for 10 seconds
         Then I should see "Evidence View"
+        Then I should see " rs566967979"
         When I press "Logout ClinGen Test Curator"
         And I wait for 10 seconds
         Then I should see "Access to these interfaces is currently restricted to ClinGen curators."

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -2,13 +2,13 @@
 Feature: Select Variant
 
     Scenario: VCI select-variant modal ClinVar functionality
+        When I visit "/select-variant/"
+        And I wait for 1 seconds
+        Then I should see "Search and Select Variant"
         When I press "Demo Login"
         And I wait for 10 seconds
         Then I should see "Logout ClinGen Test Curator"
-        When I visit "/select-variant/"
-        Then I should see "Search and Select Variant"
-        When I wait for 1 seconds
-        And I select "ClinVar Variation ID" from dropdown "form-control"
+        When I select "ClinVar Variation ID" from dropdown "form-control"
         And I wait for 1 seconds
         And I press "Add ClinVar ID"
         And I wait for an element with the css selector ".modal-open" to load
@@ -35,16 +35,25 @@ Feature: Select Variant
 
     Scenario: VCI select-variant modal CAR functionality
         When I visit "/select-variant/"
+        And I wait for 1 seconds
         Then I should see "Search and Select Variant"
-        When I wait for 1 seconds
-        And I select "ClinGen Allele Registry ID (CA ID)" from dropdown "form-control"
+        When I press "Demo Login"
+        And I wait for 10 seconds
+        Then I should see "Logout ClinGen Test Curator"
+        When I select "ClinGen Allele Registry ID (CA ID)" from dropdown "form-control"
         And I wait for 1 seconds
         And I press "Add CA ID"
         And I wait for an element with the css selector ".modal-open" to load
         Then I should see "Enter CA ID"
-        When I fill in the css element field "input.form-control" with "CA003323"
+        When I fill in the css element field "input.form-control" with "CA2738256"
         When I press "Retrieve from ClinGen Allele Registry"
         Then I should see an element with the css selector ".resource-metadata" within 30 seconds
-        Then I should see "BRCA1"
-        Then I should see "37644"
+        Then I should see "NC_000003.12:g.184957468G>A"
+        When I press the button "Save and View Evidence"
+        And I wait for 10 seconds
+        Then I should see "Evidence View"
+        When I press "Logout ClinGen Test Curator"
+        And I wait for 10 seconds
+        Then I should see "Access to these interfaces is currently restricted to ClinGen curators."
+
 


### PR DESCRIPTION
This patch is to convert the CAR's json response's dbsnpid value from an int to a str. This will allow CA IDs that have a dbsnpid but no ClinVar variant ID to be saved in our database.

Testing:

1. Attempt to add CA ID CA2738256 to VCI or GCI
2. Make sure it saves


edit: this is probably a temporary workaround... we may want to convert the field to an int in the database, convert pre-existing values to int, and update our parsers to add them as ints