### PR TITLE
Connects to #1262. Fix proband counting bug on provisional page

### DIFF
--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -308,19 +308,16 @@ var ProvisionalCuration = React.createClass({
         /*****************************************************/
         /* Find all proband individuals that had been scored */
         /*****************************************************/
-        let probandTotal = []; // Total proband combined
-        let probandFamily = []; // Total probands associated with families from all annotations
-        let probandIndividual = []; // Total proband individuals from all annotations
-
+        let probandTotal = []; // all probands
         var proband_variants = [];
         let tempFamilyScraperValues = {};
-        let individualMatched = [];
         let caseControlTotal = [];
 
         // scan gdm
         let annotations = gdm.annotations && gdm.annotations.length ? gdm.annotations : [];
         annotations.forEach(annotation => {
             let groups, families, individuals, experimentals;
+            let individualMatched = [];
 
             // loop through groups
             groups = annotation.groups && annotation.groups.length ? annotation.groups : [];
@@ -344,9 +341,9 @@ var ProvisionalCuration = React.createClass({
             scoreTableValues['segregationPoints'] = tempFamilyScraperValues['segregationPoints'];
             individualMatched = tempFamilyScraperValues['individualMatched'];
 
-            // push all matched individuals from families and families of groups to probandFamily
+            // push all matched individuals from families and families of groups to probandTotal
             individualMatched.forEach(item => {
-                probandFamily.push(item);
+                probandTotal.push(item);
             });
 
             // loop through individuals
@@ -354,9 +351,9 @@ var ProvisionalCuration = React.createClass({
                 // get proband individuals
                 individualMatched = [];
                 individualMatched = this.individualScraper(annotation.individuals, individualMatched);
-                // push all matched individuals to probandIndividual
+                // push all matched individuals to probandTotal
                 individualMatched.forEach(item => {
-                    probandIndividual.push(item);
+                    probandTotal.push(item);
                 });
             }
 
@@ -445,8 +442,6 @@ var ProvisionalCuration = React.createClass({
             });
         });
 
-        // combine all probands
-        probandTotal = probandFamily.concat(probandIndividual);
         // scan probands
         probandTotal.forEach(proband => {
             proband.scores.forEach(score => {


### PR DESCRIPTION
This fixes a bug where proband individuals might be counted multiple time during final score calculation in the GCI.

Testing:

1. Create proband individual
2. Create proband individual within Family (for test)
3. Create proband individual within Group (for test)
4. Confirm that scoring is correct on provisional page
5. Add a pubmed annotation w/ no evidence
6. Confirm that scoring is still correct