### PR TITLE
Connects to #1280. Gene-centric tab bug in VCI.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -61,15 +61,21 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                 nonTcga = myGeneInfo.exac.nontcga;
             return (
                 <tbody>
-                    <tr>
-                        <td>All ExAC</td><td>{this.parseFloatShort(allExac.p_li)}</td><td>{this.parseFloatShort(allExac.p_rec)}</td><td>{this.parseFloatShort(allExac.p_null)}</td>
-                    </tr>
-                    <tr>
-                        <td>Non-psych</td><td>{this.parseFloatShort(nonPsych.p_li)}</td><td>{this.parseFloatShort(nonPsych.p_rec)}</td><td>{this.parseFloatShort(nonPsych.p_null)}</td>
-                    </tr>
-                    <tr>
-                        <td>Non-TCGA</td><td>{this.parseFloatShort(nonTcga.p_li)}</td><td>{this.parseFloatShort(nonTcga.p_rec)}</td><td>{this.parseFloatShort(nonTcga.p_null)}</td>
-                    </tr>
+                    {allExac ?
+                        <tr>
+                            <td>All ExAC</td><td>{this.parseFloatShort(allExac.p_li)}</td><td>{this.parseFloatShort(allExac.p_rec)}</td><td>{this.parseFloatShort(allExac.p_null)}</td>
+                        </tr>
+                    : null}
+                    {nonPsych ?
+                        <tr>
+                            <td>Non-psych</td><td>{this.parseFloatShort(nonPsych.p_li)}</td><td>{this.parseFloatShort(nonPsych.p_rec)}</td><td>{this.parseFloatShort(nonPsych.p_null)}</td>
+                        </tr>
+                    : null}
+                    {nonTcga ?
+                        <tr>
+                            <td>Non-TCGA</td><td>{this.parseFloatShort(nonTcga.p_li)}</td><td>{this.parseFloatShort(nonTcga.p_rec)}</td><td>{this.parseFloatShort(nonTcga.p_null)}</td>
+                        </tr>
+                    : null}
                 </tbody>
             );
         }


### PR DESCRIPTION
**Technical note:**
Added `if-else` condition to the rendering of the 'ExAC Constraint Scores' table rows on the 'Gene-Centric' tab based on the presence of the expected gene data provided in the mygene.info API call.

**Steps to test:**
1. Login and proceed to VCI.
2. Select a variant using CA ID `CA323244`.
3. Upon loading the **Basic Info** tab successfully, click on the **Gene-centric** tab.
4. Expect to see the content of the **Gene-centric** tab.
5. Expect to see the **ExAC Constraint Scores** table to only render 2 rows -- **All ExAC** and **Non-psych**.
![image](https://cloud.githubusercontent.com/assets/6956310/22526862/c0835348-e881-11e6-9e7f-405860960854.png)
