### PR TITLE
Connects to #966. Connects to #1288. Connects to #1290. Connects to #1291. Connects to #1293.

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1112,17 +1112,17 @@ function GroupCommonDiseases(groupType) {
             <Input type="text" ref={orphanetId} label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15" inputDisabled={inputDisabled}
                 error={this.getFormError(orphanetId)} clearError={this.clrMultiFormErrors.bind(null, [orphanetId, hpoId, phenoTerms])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="text" ref={hpoId} label={<LabelHpoId />} value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
+            <Input type="textarea" ref={hpoId} label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
                 error={this.getFormError(hpoId)} clearError={this.clrMultiFormErrors.bind(null, [orphanetId, hpoId, phenoTerms])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref={phenoTerms} label={<LabelPhenoTerms />} rows="5" value={group && group.termsInDiagnosis} inputDisabled={inputDisabled}
+            <Input type="textarea" ref={phenoTerms} label={<LabelPhenoTerms />} rows="2" value={group && group.termsInDiagnosis} inputDisabled={inputDisabled}
                 error={this.getFormError(phenoTerms)} clearError={this.clrMultiFormErrors.bind(null, [orphanetId, hpoId, phenoTerms])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in {cohortLabel}</em> if they are specifically noted in the paper.</p>
-            <Input type="text" ref={nothpoId} label={<LabelHpoId not />} value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
+            <Input type="textarea" ref={nothpoId} label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
                 error={this.getFormError(nothpoId)} clearError={this.clrFormErrors.bind(null, nothpoId)}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref={notphenoTerms} label={<LabelPhenoTerms not />} rows="5" value={group && group.termsInElimination} inputDisabled={inputDisabled}
+            <Input type="textarea" ref={notphenoTerms} label={<LabelPhenoTerms not />} rows="2" value={group && group.termsInElimination} inputDisabled={inputDisabled}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -215,7 +215,7 @@ const CaseControlCuration = React.createClass({
             if (orphaIds && orphaIds.length && _(orphaIds).any(function(id) { return id === null; })) {
                 // ORPHA list is bad
                 formError = true;
-                this.setFormErrors('caseCohort_orphanetId', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                this.setFormErrors('caseCohort_orphanetId', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
             } else if (orphaIds && orphaIds.length && !_(orphaIds).any(function(id) { return id === null; })) {
                 valid_orphaId = true;
             }
@@ -1109,7 +1109,7 @@ function GroupCommonDiseases(groupType) {
             <div className="col-sm-7 col-sm-offset-5">
                 <p className="alert alert-warning">Please enter an Orphanet ID(s) and/or HPO ID(s) and/or Phenotype free text (required).</p>
             </div>
-            <Input type="text" ref={orphanetId} label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15" inputDisabled={inputDisabled}
+            <Input type="text" ref={orphanetId} label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA:15 or ORPHA15" inputDisabled={inputDisabled}
                 error={this.getFormError(orphanetId)} clearError={this.clrMultiFormErrors.bind(null, [orphanetId, hpoId, phenoTerms])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             <Input type="textarea" ref={hpoId} label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -80,7 +80,7 @@ var CreateGeneDisease = React.createClass({
         if (valid) {
             valid = this.getFormValue('orphanetid').match(/^ORPHA:?[0-9]{1,6}$/i);
             if (!valid) {
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15)');
             }
         }
         return valid;
@@ -180,7 +180,7 @@ var CreateGeneDisease = React.createClass({
                                 <Input type="text" ref="hgncgene" label={<LabelHgncGene />} placeholder="e.g. DICER1"
                                     error={this.getFormError('hgncgene')} clearError={this.clrFormErrors.bind(null, 'hgncgene')}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
-                                <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15"
+                                <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA:15 or ORPHA15"
                                     error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                                     labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
                                 <Input type="select" ref="hpo" label="Mode of Inheritance" defaultValue="select" handleChange={this.handleChange}

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -78,7 +78,7 @@ var CreateGeneDisease = React.createClass({
 
         // Check if orphanetid
         if (valid) {
-            valid = this.getFormValue('orphanetid').match(/^ORPHA[0-9]{1,6}$/i);
+            valid = this.getFormValue('orphanetid').match(/^(ORPHA|ORPHA:)?[0-9]{1,6}$/i);
             if (!valid) {
                 this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
             }
@@ -104,7 +104,7 @@ var CreateGeneDisease = React.createClass({
         }
         if (this.validateForm()) {
             // Get the free-text values for the Orphanet ID and the Gene ID to check against the DB
-            var orphaId = this.getFormValue('orphanetid').match(/^ORPHA([0-9]{1,6})$/i)[1];
+            var orphaId = this.getFormValue('orphanetid').match(/^(ORPHA|ORPHA:)?([0-9]{1,6})$/i)[2];
             var geneId = this.getFormValue('hgncgene');
             var mode = this.getFormValue('hpo');
             let adjective = this.getFormValue('moiAdjective');

--- a/src/clincoded/static/components/create_gene_disease.js
+++ b/src/clincoded/static/components/create_gene_disease.js
@@ -78,7 +78,7 @@ var CreateGeneDisease = React.createClass({
 
         // Check if orphanetid
         if (valid) {
-            valid = this.getFormValue('orphanetid').match(/^(ORPHA|ORPHA:)?[0-9]{1,6}$/i);
+            valid = this.getFormValue('orphanetid').match(/^ORPHA:?[0-9]{1,6}$/i);
             if (!valid) {
                 this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
             }
@@ -104,7 +104,7 @@ var CreateGeneDisease = React.createClass({
         }
         if (this.validateForm()) {
             // Get the free-text values for the Orphanet ID and the Gene ID to check against the DB
-            var orphaId = this.getFormValue('orphanetid').match(/^(ORPHA|ORPHA:)?([0-9]{1,6})$/i)[2];
+            var orphaId = this.getFormValue('orphanetid').match(/^ORPHA:?([0-9]{1,6})$/i)[1];
             var geneId = this.getFormValue('hgncgene');
             var mode = this.getFormValue('hpo');
             let adjective = this.getFormValue('moiAdjective');

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -1395,7 +1395,7 @@ function captureBase(s, re, uppercase) {
 module.exports.capture = {
     // Find all the comma-separated 'orphaXX' occurrences. Return all valid orpha IDs in an array.
     orphas: function(s) {
-        return captureBase(s, /^\s*orpha(\d+)\s*$/i);
+        return captureBase(s, /^\s*orpha:?(\d+)\s*$/i);
     },
 
     // Find all the comma-separated gene-symbol occurrences. Return all valid symbols in an array.

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1510,7 +1510,7 @@ var TypeBiochemicalFunctionB = function() {
     return (
         <div>
             {curator.renderPhenotype(null, 'Experimental')}
-            <Input type="text" ref="geneFunctionConsistentWithPhenotype.phenotypeHPO" label={<LabelHPOIDs />}
+            <Input type="textarea" ref="geneFunctionConsistentWithPhenotype.phenotypeHPO" label={<LabelHPOIDs />} rows="1"
                 error={this.getFormError('geneFunctionConsistentWithPhenotype.phenotypeHPO')} clearError={this.clrFormErrors.bind(null, 'geneFunctionConsistentWithPhenotype.phenotypeHPO')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input"
                 value={biochemicalFunction.geneFunctionConsistentWithPhenotype.phenotypeHPO} placeholder="e.g. HP:0010704" handleChange={this.handleChange}
@@ -1518,7 +1518,7 @@ var TypeBiochemicalFunctionB = function() {
             <Input type="textarea" ref="geneFunctionConsistentWithPhenotype.phenotypeFreeText" label={<LabelPhenotypesFT />}
                 error={this.getFormError('geneFunctionConsistentWithPhenotype.phenotypeFreeText')} clearError={this.clrFormErrors.bind(null, 'geneFunctionConsistentWithPhenotype.phenotypeFreeText')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
-                rows="5" value={biochemicalFunction.geneFunctionConsistentWithPhenotype.phenotypeFreeText} handleChange={this.handleChange}
+                rows="2" value={biochemicalFunction.geneFunctionConsistentWithPhenotype.phenotypeFreeText} handleChange={this.handleChange}
                 inputDisabled={this.cv.othersAssessed} required={!this.state.biochemicalFunctionHPO} />
             <Input type="textarea" ref="geneFunctionConsistentWithPhenotype.explanation" label="Explanation of how phenotype is consistent with disease:"
                 error={this.getFormError('geneFunctionConsistentWithPhenotype.explanation')} clearError={this.clrFormErrors.bind(null, 'geneFunctionConsistentWithPhenotype.explanation')}
@@ -1866,7 +1866,7 @@ var TypeModelSystems = function() {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
                 rows="5" value={modelSystems.descriptionOfGeneAlteration} inputDisabled={this.cv.othersAssessed} required />
             {curator.renderPhenotype(null, 'Experimental')}
-            <Input type="text" ref="model.phenotypeHPOObserved" label={<LabelPhenotypeObserved />}
+            <Input type="textarea" ref="model.phenotypeHPOObserved" label={<LabelPhenotypeObserved />} rows="1"
                 error={this.getFormError('model.phenotypeHPOObserved')} clearError={this.clrFormErrors.bind(null, 'model.phenotypeHPOObserved')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input"
                 value={modelSystems.phenotypeHPOObserved} placeholder="e.g. HP:0010704" handleChange={this.handleChange}
@@ -1874,9 +1874,9 @@ var TypeModelSystems = function() {
             <Input type="textarea" ref="phenotypeFreetextObserved" label={<LabelPhenotypeObservedFT />}
                 error={this.getFormError('phenotypeFreetextObserved')} clearError={this.clrFormErrors.bind(null, 'phenotypeFreetextObserved')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
-                rows="5" value={modelSystems.phenotypeFreetextObserved} handleChange={this.handleChange}
+                rows="2" value={modelSystems.phenotypeFreetextObserved} handleChange={this.handleChange}
                 inputDisabled={this.cv.othersAssessed} required={!this.state.modelSystemsPOMSHPO} />
-            <Input type="text" ref="model.phenotypeHPO" label={<LabelPatientPhenotype />}
+            <Input type="textarea" ref="model.phenotypeHPO" label={<LabelPatientPhenotype />} rows="1"
                 error={this.getFormError('model.phenotypeHPO')} clearError={this.clrFormErrors.bind(null, 'model.phenotypeHPO')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input"
                 value={modelSystems.phenotypeHPO} placeholder="e.g. HP:0010704" handleChange={this.handleChange}
@@ -1884,7 +1884,7 @@ var TypeModelSystems = function() {
             <Input type="textarea" ref="model.phenotypeFreeText" label={<LabelPatientPhenotypeFT />}
                 error={this.getFormError('model.phenotypeFreeText')} clearError={this.clrFormErrors.bind(null, 'model.phenotypeFreeText')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
-                rows="5" value={modelSystems.phenotypeFreeText} handleChange={this.handleChange}
+                rows="2" value={modelSystems.phenotypeFreeText} handleChange={this.handleChange}
                 inputDisabled={this.cv.othersAssessed} required={!this.state.modelSystemsPPHPO} />
             <Input type="textarea" ref="explanation" label="Explanation of how model system phenotype is similar to phenotype observed in humans:"
                 error={this.getFormError('explanation')} clearError={this.clrFormErrors.bind(null, 'explanation')}
@@ -1976,7 +1976,7 @@ var TypeRescue = function() {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
                 rows="5" value={rescue.descriptionOfGeneAlteration} inputDisabled={this.cv.othersAssessed} required />
             {curator.renderPhenotype(null, 'Experimental')}
-            <Input type="text" ref="rescue.phenotypeHPO" label={<LabelPhenotypeRescue />}
+            <Input type="textarea" ref="rescue.phenotypearea" label={<LabelPhenotypeRescue />} rows="1"
                 error={this.getFormError('rescue.phenotypeHPO')} clearError={this.clrFormErrors.bind(null, 'rescue.phenotypeHPO')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input"
                 value={rescue.phenotypeHPO} placeholder="e.g. HP:0010704" handleChange={this.handleChange}
@@ -1984,7 +1984,7 @@ var TypeRescue = function() {
             <Input type="textarea" ref="rescue.phenotypeFreeText" label={<LabelPhenotypeRescueFT />}
                 error={this.getFormError('rescue.phenotypeFreeText')} clearError={this.clrFormErrors.bind(null, 'rescue.phenotypeFreeText')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group"
-                rows="5" value={rescue.phenotypeFreeText} handleChange={this.handleChange}
+                rows="2" value={rescue.phenotypeFreeText} handleChange={this.handleChange}
                 inputDisabled={this.cv.othersAssessed} required={!this.state.rescuePRHPO} />
             <Input type="textarea" ref="rescueMethod" label="Description of method used to rescue:"
                 error={this.getFormError('rescueMethod')} clearError={this.clrFormErrors.bind(null, 'rescueMethod')}

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -676,12 +676,12 @@ var ExperimentalCuration = React.createClass({
                 // check hpoIDs
                 if (this.getFormValue('model.phenotypeHPO') !== '') {
                     hpoIDs = curator.capture.hpoids(this.getFormValue('model.phenotypeHPO'));
-                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'model.phenotypeHPO', 1);
+                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'model.phenotypeHPO');
                 }
                 // check hpoIDs part 2
                 if (this.getFormValue('model.phenotypeHPOObserved') !== '') {
                     hpoIDs = curator.capture.hpoids(this.getFormValue('model.phenotypeHPOObserved'));
-                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'model.phenotypeHPOObserved', 1);
+                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'model.phenotypeHPOObserved');
                 }
             }
             else if (this.state.experimentalType == 'Rescue') {
@@ -701,7 +701,7 @@ var ExperimentalCuration = React.createClass({
                 // check hpoIDs
                 if (this.getFormValue('rescue.phenotypeHPO') !== '') {
                     hpoIDs = curator.capture.hpoids(this.getFormValue('rescue.phenotypeHPO'));
-                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'rescue.phenotypeHPO', 1);
+                    formError = this.validateFormTerms(formError, 'hpoIDs', hpoIDs, 'rescue.phenotypeHPO');
                 }
             }
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1451,13 +1451,13 @@ var FamilyCommonDiseases = function() {
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'hpo') : curator.renderPhenotype(null, 'Family', 'hpo')
             }
-            <Input type="text" ref="hpoid" label={<LabelHpoId />} value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="hpoid" label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'ft') : curator.renderPhenotype(null, 'Family', 'ft')
             }
-            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="5" value={family && family.termsInDiagnosis}
+            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={family && family.termsInDiagnosis}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
             <Input type="button" ref="phenotypecopygroup" wrapperClassName="col-sm-7 col-sm-offset-5 orphanet-copy" inputClassName="btn-default btn-last btn-sm" title="Copy all Phenotype(s) from Associated Group"
@@ -1465,10 +1465,10 @@ var FamilyCommonDiseases = function() {
             : null
             }
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Family</em> if they are specifically noted in the paper.</p>
-            <Input type="text" ref="nothpoid" label={<LabelHpoId not />} value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="nothpoid" label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="5" value={family && family.termsInElimination}
+            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={family && family.termsInElimination}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -577,7 +577,7 @@ var FamilyCuration = React.createClass({
             if (orphaIds && orphaIds.length && _(orphaIds).any(function(id) { return id === null; })) {
                 // ORPHA list is bad
                 formError = true;
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
             }
 
             // Check that all individual’s Orphanet IDs have the proper format (will check for existence later)
@@ -585,7 +585,7 @@ var FamilyCuration = React.createClass({
                 if (!indOrphaIds || !indOrphaIds.length || _(indOrphaIds).any(function(id) { return id === null; })) {
                     // Individual’s ORPHA list is bad
                     formError = true;
-                    this.setFormErrors('individualorphanetid', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                    this.setFormErrors('individualorphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
                 }
             }
 
@@ -1441,7 +1441,7 @@ var FamilyCommonDiseases = function() {
     return (
         <div className="row">
             {associatedGroups && associatedGroups[0].commonDiagnosis && associatedGroups[0].commonDiagnosis.length ? curator.renderOrphanets(associatedGroups, 'Group') : null}
-            <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15"
+            <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA:15 or ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')} handleChange={this.handleChange}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             {associatedGroups && associatedGroups[0].commonDiagnosis && associatedGroups[0].commonDiagnosis.length ?
@@ -1677,7 +1677,7 @@ var FamilyVariant = function() {
                         </div>
                         : null
                     }
-                    <Input type="text" ref="individualorphanetid" label="Orphanet Disease(s) for Individual" placeholder="e.g. ORPHA15" handleChange={this.handleChange}
+                    <Input type="text" ref="individualorphanetid" label="Orphanet Disease(s) for Individual" placeholder="e.g. ORPHA:15 or ORPHA15" handleChange={this.handleChange}
                         error={this.getFormError('individualorphanetid')} clearError={this.clrFormErrors.bind(null, 'individualorphanetid')}
                         buttonClassName="btn btn-default" buttonLabel="Copy From Family" buttonHandler={this.handleclick}
                         labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required={this.state.individualRequired} />

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -215,7 +215,9 @@ module.exports.external_url_map = {
     'EnsemblGRCh38': 'http://uswest.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
     'EnsemblGRCh37': 'http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r=',
     'Bustamante': '//predictvar.bustamante-lab.net/variant/position/',
-    'MeSH': 'https://www.ncbi.nlm.nih.gov/mesh?term='
+    'MeSH': 'https://www.ncbi.nlm.nih.gov/mesh?term=',
+    'gnomAD': '//gnomad.broadinstitute.org/variant/',
+    'gnomADHome': 'http://gnomad.broadinstitute.org/'
 };
 
 

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -153,7 +153,7 @@ var GroupCuration = React.createClass({
             if (orphaIds && orphaIds.length && _(orphaIds).any(function(id) { return id === null; })) {
                 // ORPHA list is bad
                 formError = true;
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
             }
             else if (orphaIds && orphaIds.length && !_(orphaIds).any(function(id) { return id === null; })) {
                 valid_orphaId = true;
@@ -607,7 +607,7 @@ var GroupCommonDiseases = function() {
             <div className="col-sm-7 col-sm-offset-5">
                 <p className="alert alert-warning">Please enter an Orphanet ID(s) and/or HPO ID(s) and/or Phenotype free text (required).</p>
             </div>
-            <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15"
+            <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA:15 or ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrMultiFormErrors.bind(null, ['orphanetid', 'hpoid', 'phenoterms'])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             <Input type="textarea" ref="hpoid" label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -610,17 +610,17 @@ var GroupCommonDiseases = function() {
             <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} value={orphanetidVal} placeholder="e.g. ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrMultiFormErrors.bind(null, ['orphanetid', 'hpoid', 'phenoterms'])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="text" ref="hpoid" label={<LabelHpoId />} value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="hpoid" label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('hpoid')} clearError={this.clrMultiFormErrors.bind(null, ['orphanetid', 'hpoid', 'phenoterms'])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="5" value={group && group.termsInDiagnosis}
+            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={group && group.termsInDiagnosis}
                 error={this.getFormError('phenoterms')} clearError={this.clrMultiFormErrors.bind(null, ['orphanetid', 'hpoid', 'phenoterms'])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Group</em> if they are specifically noted in the paper.</p>
-            <Input type="text" ref="nothpoid" label={<LabelHpoId not />} value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="nothpoid" label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="5" value={group && group.termsInElimination}
+            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={group && group.termsInElimination}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1117,7 +1117,7 @@ var IndividualCommonDiseases = function() {
                     curator.renderPhenotype(associatedFamilies, 'Individual', 'hpo') : curator.renderPhenotype(null, 'Individual', 'hpo')
                 )
             }
-            <Input type="text" ref="hpoid" label={<LabelHpoId />} value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="hpoid" label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
@@ -1127,7 +1127,7 @@ var IndividualCommonDiseases = function() {
                     curator.renderPhenotype(associatedFamilies, 'Individual', 'ft') : curator.renderPhenotype(null, 'Individual', 'ft')
                 )
             }
-            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="5" value={individual && individual.termsInDiagnosis}
+            <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={individual && individual.termsInDiagnosis}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
             <Input type="button" ref="phenotypecopygroup" wrapperClassName="col-sm-7 col-sm-offset-5 orphanet-copy" inputClassName="btn-default btn-last btn-sm" title="Copy Phenotype from Associated Group"
@@ -1140,10 +1140,10 @@ var IndividualCommonDiseases = function() {
             : null
             }
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Individual</em> if they are specifically noted in the paper.</p>
-            <Input type="text" ref="nothpoid" label={<LabelHpoId not />} value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
+            <Input type="textarea" ref="nothpoid" label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
-            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="5" value={individual && individual.termsInElimination}
+            <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={individual && individual.termsInElimination}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -337,10 +337,10 @@ var IndividualCuration = React.createClass({
                 // ORPHA is not required for non-proband individual
                 // ORPHA list is bad
                 formError = true;
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
             } else if (!this.state.proband_selected && (orphaIds && orphaIds.length && _(orphaIds).any(function(id) { return id === null; }))) {
                 formError = true;
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15) separated by commas');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15) separated by commas');
             }
 
             // Check that all gene symbols have the proper format (will check for existence later)
@@ -1094,11 +1094,11 @@ var IndividualCommonDiseases = function() {
             {associatedGroups && associatedGroups[0].commonDiagnosis && associatedGroups[0].commonDiagnosis.length ? curator.renderOrphanets(associatedGroups, 'Group') : null}
             {associatedFamilies && associatedFamilies[0].commonDiagnosis && associatedFamilies[0].commonDiagnosis.length > 0 ? curator.renderOrphanets(associatedFamilies, 'Family') : null}
             { this.state.proband_selected ?
-                <Input type="text" ref="orphanetid" label={<LabelOrphanetId probandLabel={probandLabel} />} value={orphanetidVal} placeholder="e.g. ORPHA15"
+                <Input type="text" ref="orphanetid" label={<LabelOrphanetId probandLabel={probandLabel} />} value={orphanetidVal} placeholder="e.g. ORPHA:15 or ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" required />
                 :
-                <Input type="text" ref="orphanetid" label={<LabelOrphanetId probandLabel={probandLabel} />} value={orphanetidVal} placeholder="e.g. ORPHA15"
+                <Input type="text" ref="orphanetid" label={<LabelOrphanetId probandLabel={probandLabel} />} value={orphanetidVal} placeholder="e.g. ORPHA:15 or ORPHA15"
                 error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             }

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -242,7 +242,7 @@ var AssociateDisease = React.createClass({
         if (valid) {
             valid = this.getFormValue('orphanetid').match(/^ORPHA:?[0-9]{1,6}$/i);
             if (!valid) {
-                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
+                this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA:15 or ORPHA15)');
             }
         }
         return valid;
@@ -399,7 +399,7 @@ var AssociateDisease = React.createClass({
             <Form submitHandler={this.submitForm} formClassName="form-std">
                 <div className="modal-box">
                     <div className="modal-body clearfix">
-                        <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA15" value={(disease_id) ? disease_id : null}
+                        <Input type="text" ref="orphanetid" label={<LabelOrphanetId />} placeholder="e.g. ORPHA:15 or ORPHA15" value={(disease_id) ? disease_id : null}
                             error={this.getFormError('orphanetid')} clearError={this.clrFormErrors.bind(null, 'orphanetid')} handleChange={this.handleChange}
                             labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
                     </div>

--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -240,7 +240,7 @@ var AssociateDisease = React.createClass({
         }
         // Check if orphanetid
         if (valid) {
-            valid = this.getFormValue('orphanetid').match(/^ORPHA[0-9]{1,6}$/i);
+            valid = this.getFormValue('orphanetid').match(/^ORPHA:?[0-9]{1,6}$/i);
             if (!valid) {
                 this.setFormErrors('orphanetid', 'Use Orphanet IDs (e.g. ORPHA15)');
             }
@@ -275,7 +275,7 @@ var AssociateDisease = React.createClass({
             var interpretationDisease, currInterpretation, flatInterpretation;
 
             if (orphaId !== '') {
-                orphaId = orphaId.match(/^ORPHA([0-9]{1,6})$/i)[1];
+                orphaId = orphaId.match(/^ORPHA:?([0-9]{1,6})$/i)[1];
                 // Get the disease orresponding to the given Orphanet ID.
                 // If either error out, set the form error fields
                 this.getRestDatas([

--- a/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
+++ b/src/clincoded/static/components/variant_central/interpretation/gene_specific.js
@@ -63,17 +63,32 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                 <tbody>
                     {allExac ?
                         <tr>
-                            <td>All ExAC</td><td>{this.parseFloatShort(allExac.p_li)}</td><td>{this.parseFloatShort(allExac.p_rec)}</td><td>{this.parseFloatShort(allExac.p_null)}</td>
+                            <td>All ExAC</td>
+                            <td>{this.parseFloatShort(allExac.p_li)}</td>
+                            <td>{this.parseFloatShort(allExac.p_rec)}</td>
+                            <td>{this.parseFloatShort(allExac.p_null)}</td>
+                            <td>{this.parseFloatShort(allExac.syn_z)}</td>
+                            <td>{this.parseFloatShort(allExac.mis_z)}</td>
                         </tr>
                     : null}
                     {nonPsych ?
                         <tr>
-                            <td>Non-psych</td><td>{this.parseFloatShort(nonPsych.p_li)}</td><td>{this.parseFloatShort(nonPsych.p_rec)}</td><td>{this.parseFloatShort(nonPsych.p_null)}</td>
+                            <td>Non-psych</td>
+                            <td>{this.parseFloatShort(nonPsych.p_li)}</td>
+                            <td>{this.parseFloatShort(nonPsych.p_rec)}</td>
+                            <td>{this.parseFloatShort(nonPsych.p_null)}</td>
+                            <td>{this.parseFloatShort(nonPsych.syn_z)}</td>
+                            <td>{this.parseFloatShort(nonPsych.mis_z)}</td>
                         </tr>
                     : null}
                     {nonTcga ?
                         <tr>
-                            <td>Non-TCGA</td><td>{this.parseFloatShort(nonTcga.p_li)}</td><td>{this.parseFloatShort(nonTcga.p_rec)}</td><td>{this.parseFloatShort(nonTcga.p_null)}</td>
+                            <td>Non-TCGA</td>
+                            <td>{this.parseFloatShort(nonTcga.p_li)}</td>
+                            <td>{this.parseFloatShort(nonTcga.p_rec)}</td>
+                            <td>{this.parseFloatShort(nonTcga.p_null)}</td>
+                            <td>{this.parseFloatShort(nonTcga.syn_z)}</td>
+                            <td>{this.parseFloatShort(nonTcga.mis_z)}</td>
                         </tr>
                     : null}
                 </tbody>
@@ -116,6 +131,8 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                                         <th>pLI</th>
                                         <th>pRec</th>
                                         <th>pNull</th>
+                                        <th>syn Z</th>
+                                        <th>mis Z</th>
                                     </tr>
                                 </thead>
 
@@ -123,7 +140,7 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
 
                                 <tfoot>
                                     <tr className="footnote">
-                                        <td colSpan="4">
+                                        <td colSpan="6">
                                             <dl className="inline-dl clearfix">
                                                 <dt>pLI:</dt><dd>the probability of being loss-of-function intolerant (intolerant of both heterozygous and homozygous LOF variants)</dd>
                                             </dl>
@@ -132,6 +149,12 @@ var CurationInterpretationGeneSpecific = module.exports.CurationInterpretationGe
                                             </dl>
                                             <dl className="inline-dl clearfix">
                                                 <dt>pNull:</dt><dd>the probability of being tolerant of both heterozygous and homozygous LOF variants</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>syn Z:</dt><dd>corrected synonymous Z score</dd>
+                                            </dl>
+                                            <dl className="inline-dl clearfix">
+                                                <dt>mis Z:</dt><dd>corrected missense Z score</dd>
                                             </dl>
                                         </td>
                                     </tr>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -841,9 +841,14 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </div>
                         :
                             <div className="panel-body">
-                                <div className="description"><span>gnomAD data is not currently available via API or download -- however, provided below are 2 links:</span></div>
-                                <a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Link to data for this variant in gnomAD</a>
-                                <a href={external_url_map['gnomADHome']} target="_blank">Search gnomAD for this variant</a>
+                                <div className="description">
+                                    <span>gnomAD data is not currently available via API or download &mdash; however, provided below are 2 links:
+                                        1) direct link to URL for variant in gnomAD and 2) link to gnomAD's home page.</span>
+                                </div>
+                                <ul>
+                                    <li><a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Link to data for this variant in gnomAD</a> (note: not all variants are present in gnomAD)</li>
+                                    <li><a href={external_url_map['gnomADHome']} target="_blank">Search gnomAD for this variant</a></li>
+                                </ul>
                             </div>
                         }
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -677,6 +677,56 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
     },
 
+    parseAlleleMyVariant(response) {
+        let alleleData = {};
+        if (response) {
+            let chrom = response.chrom,
+                pos = response.hg19.start;
+            if (response.clinvar) {
+                // Try 'clinvar' as primary data object
+                let clinvar = response.clinvar;
+                alleleData = {chrom: chrom, pos: pos, ref: clinvar.ref, alt: clinvar.alt};
+            } else if (response.cadd) {
+                // Fallback to 'cadd' as alternative data object
+                let cadd = response.cadd;
+                alleleData = {chrom: chrom, pos: cadd.pos, ref: cadd.ref, alt: cadd.alt};
+            } else if (response.vcf) {
+                // Fallback to 'cadd' as alternative data object
+                let vcf = response.vcf;
+                alleleData = {chrom: chrom, pos: vcf.pos, ref: vcf.ref, alt: vcf.alt};
+            }
+        }
+        return alleleData;
+    },
+
+    // Method to render gnomAD population table header content
+    rendergnomADHeader(data) {
+        let variantgnomAD = '';
+        if (data) {
+            let alleleData = this.parseAlleleMyVariant(data);
+            if (Object.keys(alleleData).length) {
+                variantgnomAD = alleleData.chrom + ':' + alleleData.pos + ' ' + alleleData.ref + '/' + alleleData.alt;
+            }
+        }
+        return (
+            <h3 className="panel-title">{variantgnomAD.length ? 'gnomAD ' + variantgnomAD : 'gnomAD'}</h3>
+        );
+    },
+
+    // Method to render external gnomAD linkouts
+    rendergnomADLinkout(data) {
+        let gnomADLink = external_url_map['gnomADHome'];
+        // 1) clinvar/cadd/vcf data found in myvariant.info
+        // 2) no data returned by myvariant.info
+        if (data) {
+            let alleleData = this.parseAlleleMyVariant(data);
+            if (Object.keys(alleleData).length) {
+                gnomADLink = 'http:' + external_url_map['gnomAD'] + alleleData.chrom + '-' + alleleData.pos + '-' + alleleData.ref + '-' + alleleData.alt;
+            }
+        }
+        return gnomADLink;
+    },
+
     render: function() {
         var exacStatic = populationStatic.exac,
             tGenomesStatic = populationStatic.tGenomes,
@@ -780,6 +830,22 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                 </div>
                             }
                         </div>
+                    </div>
+                    <div className="panel panel-info datasource-gnomAD">
+                        <div className="panel-heading">
+                            {this.rendergnomADHeader(this.props.ext_myVariantInfo)}
+                        </div>
+                        {!singleNucleotide ?
+                            <div className="panel-body">
+                                <span>Data is currently only returned for single nucleotide variants. <a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Search gnomAD</a> for this variant.</span>
+                            </div>
+                        :
+                            <div className="panel-body">
+                                <div className="description"><span>gnomAD data is not currently available via API or download -- however, provided below are 2 links:</span></div>
+                                <a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Link to data for this variant in gnomAD</a>
+                                <a href={external_url_map['gnomADHome']} target="_blank">Search gnomAD for this variant</a>
+                            </div>
+                        }
                     </div>
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -837,17 +837,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         {!singleNucleotide ?
                             <div className="panel-body">
-                                <span>Data is currently only returned for single nucleotide variants. <a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Search gnomAD</a> for this variant.</span>
+                                <span>Data is currently only returned for single nucleotide variants. <a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Search gnomAD</a></span>
                             </div>
                         :
                             <div className="panel-body">
                                 <div className="description">
-                                    <span>gnomAD data is not currently available via API or download &mdash; however, provided below are 2 links:
-                                        1) direct link to URL for variant in gnomAD and 2) link to gnomAD's home page.</span>
+                                    <span>gnomAD data is not currently available via API or download; however, a direct link to gnomAD is provided whenever possible in addition to a link to gnomAD's home page.</span>
                                 </div>
                                 <ul>
-                                    <li><a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Link to data for this variant in gnomAD</a> (note: not all variants are present in gnomAD)</li>
-                                    <li><a href={external_url_map['gnomADHome']} target="_blank">Search gnomAD for this variant</a></li>
+                                    <li><a href={this.rendergnomADLinkout(this.props.ext_myVariantInfo)} target="_blank">Link to this variant in gnomAD</a></li>
+                                    <li><a href={external_url_map['gnomADHome']} target="_blank">Search gnomAD</a></li>
                                 </ul>
                             </div>
                         }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1224,13 +1224,8 @@
 
             .population .datasource-gnomAD {
                 .panel-body {
-                    .description {
+                    .description, li {
                         margin-bottom: 5px;
-                    }
-
-                    a {
-                        display: inline-block;
-                        margin-right: 20px;
                     }
                 }
             }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1222,6 +1222,19 @@
                 width: 20%;
             }
 
+            .population .datasource-gnomAD {
+                .panel-body {
+                    .description {
+                        margin-bottom: 5px;
+                    }
+
+                    a {
+                        display: inline-block;
+                        margin-right: 20px;
+                    }
+                }
+            }
+
             .population .datasource-1000G .table tbody td,
             .population .datasource-1000G .table tfoot td,
             .population .datasource-ESP .table tbody td,

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1224,8 +1224,13 @@
 
             .population .datasource-gnomAD {
                 .panel-body {
-                    .description, li {
-                        margin-bottom: 5px;
+                    .description {
+                        font-style: italic;
+                        margin-bottom: 8px;
+                    }
+
+                    li {
+                        margin-top: 5px;
                     }
                 }
             }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1272,7 +1272,7 @@
 
             .gene-specific .datasource-constraint-scores .table thead td,
             .gene-specific .datasource-constraint-scores .table tbody td {
-                width: 25%;
+                width: 16.665%;
             }
 
             .gene-specific .datasource-constraint-scores .table tfoot td {


### PR DESCRIPTION
**Steps to test #966:**
1. Go to VCI and use ClinVar ID `139214` at the variant selection interface.
2. Upon page load, proceed to the **Gene-centric** tab.
3. Expect to see 2 new columns – **syn Z** and **mis Z** – in the **ExAC Constraint Scores** table, as well as their respective descriptions.
![image](https://cloud.githubusercontent.com/assets/6956310/22956431/dfbaca0c-f2d6-11e6-9716-eab4648e65d1.png)

**Steps to test #1288:**
1. Create a new GDM in GCI and add an Experimental evidence.
2. On the Experimental curation page, select **Model Systems** or **Rescue** as the Experiment type. Fill out other **required** fields.
3. In the input fields to add HPO IDs (2 for **Model Systems** and 1 for **Rescue**), enter multiple IDs (delimited with comma) and save the form.
4. Expect to see the form to be successfully submitted without errors indicating the limit of 1 HPO ID.
![image](https://cloud.githubusercontent.com/assets/6956310/22956782/e62a348e-f2d8-11e6-925e-7c4a2c02a5c1.png)

**Steps to test #1290:**
1. In the GCI's Create New GDM interface, add an **Orphanet ID** with or without a colon (e.g. **"ORPHA891"** or **"ORPHA:891"**). Fill out other **required** fields. Expect to be able to save the form without errors.
2. On the other curation form pages (e.g. Group, Family, Individual), also expect to be able to enter the **Orphanet ID** with or without a colon (e.g. **"ORPHA891"** or **"ORPHA:891"**) and save without errors.
![image](https://cloud.githubusercontent.com/assets/6956310/22957153/58dc4d1c-f2db-11e6-97b9-db0c194cd9da.png)
3. in the VCI, start a new Interpretation and add an associated disease. In the modal, also expect to be able to enter the **Orphanet ID** with or without a colon (e.g. **"ORPHA891"** or **"ORPHA:891"**) and save without errors.
![image](https://cloud.githubusercontent.com/assets/6956310/22957230/cdd86bf0-f2db-11e6-9a21-92fffe8c17c7.png)

**Steps to test #1291:**
1. While still in the VCI, go to the **Population** tab, expect to see a new **gnomAD** panel with 2 links.
![image](https://cloud.githubusercontent.com/assets/6956310/22911778/59b915fa-f216-11e6-8399-d5a4d59f6d9f.png)
2. Clicking on the first link will take the user to the gnomAD site in the attempt to retrieve/display the variant data (if any).
3. Clicking on the second link will take the user to the gnomAD homepage.

**Steps to test #1293:**
1. Return to the GCI's GDM, go into various curation form pages (e.g. Group, Family, Individual, Case-Control, Experimental), expect to see all instances of HPO IDs input fields have been changed from `text` type to `textarea` type.
![image](https://cloud.githubusercontent.com/assets/6956310/22957472/4e1149f8-f2dd-11e6-898a-b82daa3d7bac.png)
