### PR TITLE
Connects to #1295. Computational object scores

### DIFF
--- a/src/clincoded/schemas/computational.json
+++ b/src/clincoded/schemas/computational.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "variant": {
             "title": "Variant",

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -341,7 +341,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             <tr key={key}>
                 <td>{rowName}</td>
                 <td>{otherPred[key].score_range}</td>
-                <td>{otherPred[key].score ? otherPred[key].score : '--'}</td>
+                <td>{otherPred[key].score ? (Array.isArray(otherPred[key].score) ? otherPred[key].score.join(', ') : otherPred[key].score) : '--'}</td>
                 <td>{otherPred[key].prediction ? otherPred[key].prediction : '--'}</td>
             </tr>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -272,20 +272,21 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         return newStr;
     },
 
-    // Method to convert score array to string
+    // Method to convert score value to array of numbers
     handleScoreObj: function(obj) {
-        var newArr = [], newStr = '';
+        let newArr = [];
         if (Array.isArray(obj)) {
             for (let value of obj.values()) {
                 if (!isNaN(value) && value !== null) {
-                    newArr.push(value);
+                    newArr.push(Number(value));
                 }
             }
-            newStr = newArr.join(', ');
         } else {
-            newStr = obj;
+            if (!isNaN(obj) && obj !== null) {
+                newArr = [Number(obj)];
+            }
         }
-        return newStr;
+        return newArr;
     },
 
     // Method to assign conservation scores data to global computation object

--- a/src/clincoded/upgrade/computational.py
+++ b/src/clincoded/upgrade/computational.py
@@ -1,0 +1,26 @@
+from contentbase.upgrader import upgrade_step
+
+
+# for use in computational_1_2 step
+# converts value to to float or int based on presence of decimal
+def cast_to_intfloat(value):
+    if '.' in str(value):
+        return float(value)
+    else:
+        return int(value)
+
+
+@upgrade_step('computational', '1', '2')
+def computational_1_2(value, system):
+    # https://github.com/ClinGen/clincoded/issues/1295
+    # list of predictors that may have malformed score data
+    predictors = ['sift', 'polyphen2_hdiv', 'polyphen2_hvar', 'lrt',
+                  'mutationtaster', 'mutationassessor', 'fathmm', 'provean',
+                  'metasvm', 'metalr', 'fathmm_mkl', 'fitcons']
+    if 'computationalData' in value:
+        if 'other_predictors' in value['computationalData']:
+            # other_predictors is present, so loop through predictors to check
+            for predictor in predictors:
+                if predictor in value['computationalData']['other_predictors']:
+                    if 'score' in value['computationalData']['other_predictors'][predictor]:
+                        value['computationalData']['other_predictors'][predictor]['score'] = [cast_to_intfloat(x) for x in str(value['computationalData']['other_predictors'][predictor]['score']).split(', ')]

--- a/src/clincoded/upgrade/computational.py
+++ b/src/clincoded/upgrade/computational.py
@@ -18,12 +18,9 @@ def computational_1_2(value, system):
                   'mutationtaster', 'mutationassessor', 'fathmm', 'provean',
                   'metasvm', 'metalr', 'fathmm_mkl', 'fitcons']
     if 'computationalData' in value:
-        print('computational')
         if 'other_predictors' in value['computationalData']:
-            print('other_predictors')
             # other_predictors is present, so loop through predictors to check
             for predictor in predictors:
                 if predictor in value['computationalData']['other_predictors']:
-                    print(predictor)
                     if 'score' in value['computationalData']['other_predictors'][predictor]:
                         value['computationalData']['other_predictors'][predictor]['score'] = [cast_to_intfloat(x) for x in str(value['computationalData']['other_predictors'][predictor]['score']).split(', ')]

--- a/src/clincoded/upgrade/computational.py
+++ b/src/clincoded/upgrade/computational.py
@@ -18,9 +18,12 @@ def computational_1_2(value, system):
                   'mutationtaster', 'mutationassessor', 'fathmm', 'provean',
                   'metasvm', 'metalr', 'fathmm_mkl', 'fitcons']
     if 'computationalData' in value:
+        print('computational')
         if 'other_predictors' in value['computationalData']:
+            print('other_predictors')
             # other_predictors is present, so loop through predictors to check
             for predictor in predictors:
                 if predictor in value['computationalData']['other_predictors']:
+                    print(predictor)
                     if 'score' in value['computationalData']['other_predictors'][predictor]:
                         value['computationalData']['other_predictors'][predictor]['score'] = [cast_to_intfloat(x) for x in str(value['computationalData']['other_predictors'][predictor]['score']).split(', ')]

--- a/src/clincoded/upgrade/computational.py
+++ b/src/clincoded/upgrade/computational.py
@@ -4,7 +4,7 @@ from contentbase.upgrader import upgrade_step
 # for use in computational_1_2 step
 # converts value to to float or int based on presence of decimal
 def cast_to_intfloat(value):
-    if '.' in str(value):
+    if '.' in str(value) or 'e' in str(value):
         return float(value)
     else:
         return int(value)
@@ -23,4 +23,5 @@ def computational_1_2(value, system):
             for predictor in predictors:
                 if predictor in value['computationalData']['other_predictors']:
                     if 'score' in value['computationalData']['other_predictors'][predictor]:
-                        value['computationalData']['other_predictors'][predictor]['score'] = [cast_to_intfloat(x) for x in str(value['computationalData']['other_predictors'][predictor]['score']).split(', ')]
+                        if value['computationalData']['other_predictors'][predictor]['score'] is not None:
+                            value['computationalData']['other_predictors'][predictor]['score'] = [cast_to_intfloat(x) for x in str(value['computationalData']['other_predictors'][predictor]['score']).split(', ')]


### PR DESCRIPTION
Includes upgrade script to fix previous inconsistently-saved computational objects, and frontend code change to cast data to the same types.

Please see #1295 for additional information

Testing:
1. Begin fresh instance
2. Add variant 102905 to VCI. This variant returns a SIFT score of 1 from myVariantInfo, then save an evaluation under the Predictors tab
3. Add variant 102902 to VCI. This variant returns SIFT scores of [0.028, 0.023], which is converted by the UI to the string '0.028, 0.023', then save an evaluation under the Predictors tab
4. Confirm that the computational values for these contain arrays of numbers, instead of strings or integers.

Testing upgrade:
1. Load up instance w/ production data
2. Confirm that previously-saved computational objects have scores saved as array of numbers
   * /computational/55aed9ca-42a0-49b2-8f41-07730c05409f/?format=json
   * /computational/85cbb1ff-7b99-477b-bb16-b7f7c1c34b5d/?format=json