### PR TITLE
Connects to #1266. Connects to #1279. Connects to #1284. Connects to #1285. Changes to provisional curation dropdown

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -203,7 +203,7 @@ var RecordHeader = module.exports.RecordHeader = React.createClass({
                                                             </div>
                                                         </div>
                                                     :
-                                                        <div className="provisional-data-left"><span>No Reported Evidence</span></div>
+                                                        <div className="provisional-data-left"><span>None</span></div>
                                                 }
                                             </td>
                                             <td className="button-box" rowSpan="2">

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -782,10 +782,10 @@ var ProvisionalCuration = React.createClass({
                                                                         wrapperClassName="col-sm-9" defaultValue={this.state.alteredClassification}
                                                                         groupClassName="form-group">
                                                                         <option value="No Selection">No Selection</option>
-                                                                        <option value="Definitive" disabled={autoClassification === 'Definitive' ? 'disabled' : false}>Definitive</option>
-                                                                        <option value="Strong" disabled={autoClassification === 'Strong' ? 'disabled' : false}>Strong</option>
-                                                                        <option value="Moderate" disabled={autoClassification === 'Moderate' ? 'disabled' : false}>Moderate</option>
-                                                                        <option value="Limited" disabled={autoClassification === 'Limited' ? 'disabled' : false}>Limited</option>
+                                                                        {autoClassification === 'Definitive' ? null : <option value="Definitive">Definitive</option>}
+                                                                        {autoClassification === 'Strong' ? null : <option value="Strong">Strong</option>}
+                                                                        {autoClassification === 'Moderate' ? null : <option value="Moderate">Moderate</option>}
+                                                                        {autoClassification === 'Limited' ? null : <option value="Limited">Limited</option>}
                                                                         <option value="Disputed">Disputed</option>
                                                                         <option value="Refuted">Refuted</option>
                                                                         <option value="No Reported Evidence">No Reported Evidence</option>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -635,7 +635,7 @@ var ProvisionalCuration = React.createClass({
                                                             </tr>
                                                             <tr>
                                                                 <td rowSpan="2" className="header">Autosomal Recessive Disorder</td>
-                                                                <td>Two variants (not prediced/proven null) with some evidence of gene impact in <i>trans</i></td>
+                                                                <td>Two variants (not predicted/proven null) with some evidence of gene impact in <i>trans</i></td>
                                                                 <td>{scoreTableValues['twoVariantsNotProvenCount']}</td>
                                                                 <td>{scoreTableValues['twoVariantsNotProvenPoints']}</td>
                                                                 <td rowSpan="2">{scoreTableValues['autosomalRecessivePointsCounted']}</td>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -788,7 +788,7 @@ var ProvisionalCuration = React.createClass({
                                                                         {autoClassification === 'Limited' ? null : <option value="Limited">Limited</option>}
                                                                         <option value="Disputed">Disputed</option>
                                                                         <option value="Refuted">Refuted</option>
-                                                                        <option value="No Reported Evidence">No Reported Evidence</option>
+                                                                        <option value="No Reported Evidence">No Reported Evidence (score is based on Experimental evidence only)</option>
                                                                     </Input>
                                                                 </td>
                                                             </tr>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -782,10 +782,10 @@ var ProvisionalCuration = React.createClass({
                                                                         wrapperClassName="col-sm-9" defaultValue={this.state.alteredClassification}
                                                                         groupClassName="form-group">
                                                                         <option value="No Selection">No Selection</option>
-                                                                        <option value="Definitive">Definitive</option>
-                                                                        <option value="Strong">Strong</option>
-                                                                        <option value="Moderate">Moderate</option>
-                                                                        <option value="Limited">Limited</option>
+                                                                        <option value="Definitive" disabled={autoClassification === 'Definitive' ? 'disabled' : false}>Definitive</option>
+                                                                        <option value="Strong" disabled={autoClassification === 'Strong' ? 'disabled' : false}>Strong</option>
+                                                                        <option value="Moderate" disabled={autoClassification === 'Moderate' ? 'disabled' : false}>Moderate</option>
+                                                                        <option value="Limited" disabled={autoClassification === 'Limited' ? 'disabled' : false}>Limited</option>
                                                                         <option value="Disputed">Disputed</option>
                                                                         <option value="Refuted">Refuted</option>
                                                                     </Input>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -788,7 +788,7 @@ var ProvisionalCuration = React.createClass({
                                                                         {autoClassification === 'Limited' ? null : <option value="Limited">Limited</option>}
                                                                         <option value="Disputed">Disputed</option>
                                                                         <option value="Refuted">Refuted</option>
-                                                                        <option value="No Reported Evidence">No Reported Evidence (score is based on Experimental evidence only)</option>
+                                                                        <option value="No Reported Evidence">No Reported Evidence (calculated score is based on Experimental evidence only)</option>
                                                                     </Input>
                                                                 </td>
                                                             </tr>

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -788,6 +788,7 @@ var ProvisionalCuration = React.createClass({
                                                                         <option value="Limited" disabled={autoClassification === 'Limited' ? 'disabled' : false}>Limited</option>
                                                                         <option value="Disputed">Disputed</option>
                                                                         <option value="Refuted">Refuted</option>
+                                                                        <option value="No Reported Evidence">No Reported Evidence</option>
                                                                     </Input>
                                                                 </td>
                                                             </tr>


### PR DESCRIPTION
### #1266
Fixed typo:
![image](https://cloud.githubusercontent.com/assets/4326866/22865519/d0cbba0a-f11a-11e6-9eb2-42935e0d54c5.png)

### #1279:
'No Reported Evidence' option added to dropdown. Text is "No Reported Evidence (score is based on Experimental evidence only)" but saved value is 'No Reported Evidence'.

Testing:
1. Create GDM
2. Create classification, and save as 'No Reported Evidence (score..'. Confirm that saved value is 'No Reported Evidence'

![image](https://cloud.githubusercontent.com/assets/4326866/22998210/9aaf3c04-f38a-11e6-9b51-efc121f41cdd.png)

### #1284:
Removes dropdown value for the calculated classification.

Testing:
1. Create GDM
2. Enter create classification. Confirm that all options are available.
3. Add evidence to bring score up to Limited. Confirm that the Limited option is gone from dropdown.
4. Repeat above for Moderate, Strong, and Definitive.

Definitive:
![image](https://cloud.githubusercontent.com/assets/4326866/22874345/5915f330-f17a-11e6-81fe-47c6ad4cf16d.png)

Strong:
![image](https://cloud.githubusercontent.com/assets/4326866/22874336/4e2f0fb0-f17a-11e6-971b-1a526e2e354e.png)

Moderate:
![image](https://cloud.githubusercontent.com/assets/4326866/22874320/3d4abbae-f17a-11e6-9590-57ec82a60638.png)

Limited:
![image](https://cloud.githubusercontent.com/assets/4326866/22874308/28a4976a-f17a-11e6-8071-75f04006dc2a.png)

No automatic classification:
![image](https://cloud.githubusercontent.com/assets/4326866/22874364/74180b14-f17a-11e6-998b-9303d4244c16.png)

### #1285:
When GDM has no provisional curation set, text now displays 'None' in upper left instead of 'No Reported Evidence':

![image](https://cloud.githubusercontent.com/assets/4326866/22999198/1c17cbae-f38f-11e6-994b-80c2da1baec1.png)
