### PR TITLE
Connects to #1312. Fix pubdate ternary

### DIFF
--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -131,7 +131,7 @@ function pubmedDatePublished($PubmedArticle, $Journal){
                 day = $ArticleDate.getElementsByTagName('Day')[0] ? $ArticleDate.getElementsByTagName('Day')[0].textContent.trim() : null;
                 month = $ArticleDate.getElementsByTagName('Month')[0] ? $ArticleDate.getElementsByTagName('Month')[0].textContent.trim() : null;
                 year = $ArticleDate.getElementsByTagName('Year')[0] ? $ArticleDate.getElementsByTagName('Year')[0].textContent.trim() : null;
-                pubdate = pubdate.length < parseDate(day, month, year).length ? parseDate(day, month, year) : pubdate;
+                pubdate = pubdate && pubdate.length < parseDate(day, month, year).length ? parseDate(day, month, year) : pubdate;
             }
         }
         if (!pubdate) {


### PR DESCRIPTION
The following line would fail when `pubdate` is `null`, as returned by `parseDate()` previously in the `pubmedDatePublished()` function of `parse-pubmed.js`, specifically when the `PubDate` field in the XML specifically would have no Year, Month, and Day data (example pubmed [19464396](https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=PubMed&retmode=xml&id=19464396)), causing an infinite spinning wheel on data retrieval w/ no data showing up:
```javascript
pubdate = pubdate.length < parseDate(day, month, year).length ? parseDate(day, month, year) : pubdate;
```
This PR has fixed the ternary so that it checks for a truth `pubdate` value first before checking for its `length`.:

![image](https://cloud.githubusercontent.com/assets/4326866/23565657/57826200-0003-11e7-8ceb-df9a0ea80aef.png)

Testing:
1. Attempt to add pubmed ID 19464396 via any pubmed add modal and confirm that it works