### PR TITLE
Connects to #1315. Bug in which the 'Additional Information about Control Cohort' data did not get saved.

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -691,7 +691,7 @@ const CaseControlCuration = React.createClass({
 
                     value = this.getFormValue(prefix + 'additionalInfoGroup');
                     if (value) {
-                        newCaseGroup.additionalInformation = value;
+                        newControlGroup.additionalInformation = value;
                     }
 
                     /*****************************************************/


### PR DESCRIPTION
**Steps to test:**
1. Create a new GDM and add a new CaseControl evidence.
2. On the CaseControl curation form page, fill out all the required fields.
3. Make sure to enter data in the **Additional Information about Control Cohort** textarea.
3. Save the curation form and then go to the CaseControl **edit page** and/or **view page**.
4. Expect to see the data entered for "Additional Information about Control Cohort" being displayed.