### PR TITLE
Connects to #1329. RCV table removal on VCI Basic Info tab.

### DIFF
--- a/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
+++ b/src/clincoded/static/components/variant_central/helpers/clinvar_interpretations.js
@@ -17,7 +17,7 @@ export function getClinvarInterpretations(xml) {
             if (ObservationList) {
                 let ObservationNodes = ObservationList.getElementsByTagName('Observation');
                 if (ObservationNodes && ObservationNodes.length) {
-                    let ReviewStatus, Description, DateLastEvaluated, SubmissionCount;
+                    let ReviewStatus, Description, DateLastEvaluated, SubmissionCount, Explanation;
                     for (var i = 0; i < ObservationNodes.length; i++) {
                         let ObservationType = ObservationNodes[i].getAttribute('ObservationType');
                         if (ObservationType === 'primary') {
@@ -27,12 +27,14 @@ export function getClinvarInterpretations(xml) {
                             if (ClinicalSignificance) {
                                 DateLastEvaluated = ClinicalSignificance.getAttribute('DateLastEvaluated');
                                 Description = ClinicalSignificance.getElementsByTagName('Description')[0];
+                                Explanation = ClinicalSignificance.getElementsByTagName('Explanation')[0];
                             }
                         }
                     }
                     interpretationSummary = {
                         'ReviewStatus': ReviewStatus.textContent,
-                        'ClinicalSignificance': Description.textContent,
+                        'ClinicalSignificance': Description ? Description.textContent : null,
+                        'Explanation': Explanation ? Explanation.textContent : null,
                         'DateLastEvaluated': DateLastEvaluated,
                         'SubmissionCount': SubmissionCount
                     };

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -16,7 +16,7 @@ var parseClinvar = require('../../libs/parse-resources').parseClinvar;
 import { getHgvsNotation } from './helpers/hgvs_notation';
 import { setPrimaryTranscript } from './helpers/primary_transcript';
 import { parseKeyValue } from './helpers/parse_key_value';
-import { getClinvarInterpretations, getClinvarRCVs, parseClinvarInterpretation } from './helpers/clinvar_interpretations';
+import { getClinvarInterpretations } from './helpers/clinvar_interpretations';
 
 var CurationInterpretationCriteria = require('./interpretation/criteria').CurationInterpretationCriteria;
 var EvaluationSummary = require('./interpretation/summary').EvaluationSummary;
@@ -41,7 +41,6 @@ var VariantCurationHub = React.createClass({
             ext_ensemblHgvsVEP: null,
             ext_clinvarEutils: null,
             ext_clinVarEsearch: null,
-            ext_clinVarRCV: null,
             ext_clinvarInterpretationSummary: null,
             ext_myGeneInfo_MyVariant: null,
             ext_myGeneInfo_VEP: null,
@@ -51,7 +50,6 @@ var VariantCurationHub = React.createClass({
             ext_singleNucleotide: true,
             loading_clinvarEutils: true,
             loading_clinvarEsearch: true,
-            loading_clinvarRCV: true,
             loading_ensemblHgvsVEP: true,
             loading_ensemblVariation: true,
             loading_myVariantInfo: true,
@@ -136,35 +134,9 @@ var VariantCurationHub = React.createClass({
                         this.setState({loading_myGeneInfo: false});
                     }
                     this.handleCodonEsearch(variantData);
-                    let clinVarRCVs = getClinvarRCVs(xml);
-                    return Promise.resolve(clinVarRCVs);
-                }).then(RCVs => {
-                    // If RCVs is not an empty array,
-                    // parse associated disease and clinical significance for each id
-                    if (RCVs.length) {
-                        let clinvarInterpretations = [];
-                        let Urls = [];
-                        for (let RCV of RCVs.values()) {
-                            Urls.push(external_url_map['ClinVarEfetch'] + '&rettype=clinvarset&id=' + RCV);
-                        }
-                        return this.getRestDatasXml(Urls).then(xml => {
-                            xml.forEach(result => {
-                                let clinvarInterpretation = parseClinvarInterpretation(result);
-                                clinvarInterpretations.push(clinvarInterpretation);
-                                this.setState({ext_clinVarRCV: clinvarInterpretations});
-                            });
-                            this.setState({loading_clinvarRCV: false});
-                        }).catch(err => {
-                            this.setState({loading_clinvarRCV: false});
-                            console.log('ClinVarEfetch for RCV Error=: %o', err);
-                        });
-                    } else {
-                        this.setState({loading_clinvarRCV: false});
-                    }
                 }).catch(err => {
                     this.setState({
                         loading_clinvarEutils: false,
-                        loading_clinvarRCV: false,
                         loading_clinvarEsearch: false
                     });
                     console.log('ClinVarEutils Fetch Error=: %o', err);
@@ -172,7 +144,6 @@ var VariantCurationHub = React.createClass({
             } else {
                 this.setState({
                     loading_clinvarEutils: false,
-                    loading_clinvarRCV: false,
                     loading_clinvarEsearch: false
                 });
             }
@@ -469,14 +440,12 @@ var VariantCurationHub = React.createClass({
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
-                            ext_clinVarRCV={this.state.ext_clinVarRCV}
                             ext_clinvarInterpretationSummary={this.state.ext_clinvarInterpretationSummary}
                             ext_ensemblGeneId={this.state.ext_ensemblGeneId}
                             ext_geneSynonyms={this.state.ext_geneSynonyms}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
                             loading_clinvarEutils={this.state.loading_clinvarEutils}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
-                            loading_clinvarRCV={this.state.loading_clinvarRCV}
                             loading_ensemblHgvsVEP={this.state.loading_ensemblHgvsVEP}
                             loading_ensemblVariation={this.state.loading_ensemblVariation}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -39,14 +39,12 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
         ext_clinVarEsearch: React.PropTypes.object,
-        ext_clinVarRCV: React.PropTypes.array,
         ext_clinvarInterpretationSummary: React.PropTypes.object,
         ext_ensemblGeneId: React.PropTypes.string,
         ext_geneSynonyms: React.PropTypes.array,
         ext_singleNucleotide: React.PropTypes.bool,
         loading_clinvarEutils: React.PropTypes.bool,
         loading_clinvarEsearch: React.PropTypes.bool,
-        loading_clinvarRCV: React.PropTypes.bool,
         loading_ensemblHgvsVEP: React.PropTypes.bool,
         loading_ensemblVariation: React.PropTypes.bool,
         loading_myVariantInfo: React.PropTypes.bool,
@@ -67,14 +65,12 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_ensemblHgvsVEP: this.props.ext_ensemblHgvsVEP,
             ext_clinvarEutils: this.props.ext_clinvarEutils,
             ext_clinVarEsearch: this.props.ext_clinVarEsearch,
-            ext_clinVarRCV: this.props.ext_clinVarRCV,
             ext_clinvarInterpretationSummary: this.props.ext_clinvarInterpretationSummary,
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch,
-            loading_clinvarRCV: this.props.loading_clinvarRCV,
             loading_ensemblHgvsVEP: this.props.loading_ensemblHgvsVEP,
             loading_ensemblVariation: this.props.loading_ensemblVariation,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
@@ -110,9 +106,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         if (nextProps.ext_clinVarEsearch) {
             this.setState({ext_clinVarEsearch: nextProps.ext_clinVarEsearch});
         }
-        if (nextProps.ext_clinVarRCV) {
-            this.setState({ext_clinVarRCV: nextProps.ext_clinVarRCV});
-        }
         if (nextProps.ext_clinvarInterpretationSummary) {
             this.setState({ext_clinvarInterpretationSummary: nextProps.ext_clinvarInterpretationSummary});
         }
@@ -133,8 +126,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             loading_ensemblVariation: nextProps.loading_ensemblVariation,
             loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
             loading_clinvarEutils: nextProps.loading_clinvarEutils,
-            loading_clinvarEsearch: nextProps.loading_clinvarEsearch,
-            loading_clinvarRCV: nextProps.loading_clinvarRCV
+            loading_clinvarEsearch: nextProps.loading_clinvarEsearch
         });
     },
 
@@ -177,10 +169,8 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
-                            ext_clinVarRCV={this.state.ext_clinVarRCV}
                             ext_clinvarInterpretationSummary={this.state.ext_clinvarInterpretationSummary}
                             loading_clinvarEutils={this.state.loading_clinvarEutils}
-                            loading_clinvarRCV={this.state.loading_clinvarRCV}
                             loading_ensemblHgvsVEP={this.state.loading_ensemblHgvsVEP} />
                     </div>
                     : null}

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -207,8 +207,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
     },
 
-    // TODO: Need to merge with SCV table rendering from #941
-
     // Method to render each associated condition, which also consists of multiple identifiers
     handleCondition: function(condition, key) {
         let self = this;

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -24,10 +24,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         href_url: React.PropTypes.object,
         ext_ensemblHgvsVEP: React.PropTypes.array,
         ext_clinvarEutils: React.PropTypes.object,
-        ext_clinVarRCV: React.PropTypes.array,
         ext_clinvarInterpretationSummary: React.PropTypes.object,
         loading_clinvarEutils: React.PropTypes.bool,
-        loading_clinvarRCV: React.PropTypes.bool,
         loading_ensemblHgvsVEP: React.PropTypes.bool
     },
 
@@ -42,7 +40,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             ensembl_transcripts: [],
             sequence_location: [],
             primary_transcript: {},
-            clinVarRCV: [],
             clinVarInterpretationSummary: {},
             hgvs_GRCh37: null,
             hgvs_GRCh38: null,
@@ -51,7 +48,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             gene_symbol: null,
             uniprot_id: null,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
-            loading_clinvarRCV: this.props.loading_clinvarRCV,
             loading_ensemblHgvsVEP: this.props.loading_ensemblHgvsVEP
         };
     },
@@ -67,9 +63,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
         if (this.props.ext_clinvarEutils) {
             this.parseClinVarEutils(this.props.ext_clinvarEutils);
-        }
-        if (this.props.ext_clinVarRCV) {
-            this.setState({clinVarRCV: this.props.ext_clinVarRCV});
         }
         if (this.props.ext_clinvarInterpretationSummary) {
             this.setState({clinVarInterpretationSummary: this.props.ext_clinvarInterpretationSummary});
@@ -87,16 +80,12 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         if (nextProps.ext_clinvarEutils) {
             this.parseClinVarEutils(nextProps.ext_clinvarEutils);
         }
-        if (nextProps.ext_clinVarRCV) {
-            this.setState({clinVarRCV: nextProps.ext_clinVarRCV});
-        }
         if (nextProps.ext_clinvarInterpretationSummary) {
             this.setState({clinVarInterpretationSummary: nextProps.ext_clinvarInterpretationSummary});
         }
         this.setState({
             loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
-            loading_clinvarEutils: nextProps.loading_clinvarEutils,
-            loading_clinvarRCV: nextProps.loading_clinvarRCV
+            loading_clinvarEutils: nextProps.loading_clinvarEutils
         });
     },
 
@@ -216,23 +205,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 </tr>
             );
         }
-    },
-
-    // Render ClinVar Interpretations table rows
-    renderClinvarInterpretations: function(item, key) {
-        let self = this;
-        return (
-            <tr key={key} className="clinvar-interpretation">
-                <td className="accession"><a href={external_url_map['ClinVar'] + item.RCV} target="_blank">{item.RCV}</a></td>
-                <td className="review-status">{item.reviewStatus}</td>
-                <td className="clinical-significance">{item.clinicalSignificance}</td>
-                <td className="disease">
-                    {item.conditions.map(function(condition, i) {
-                        return (self.handleCondition(condition, i));
-                    })}
-                </td>
-            </tr>
-        );
     },
 
     // Method to render each associated condition, which also consists of multiple identifiers
@@ -394,7 +366,6 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         var GRCh37 = this.state.hgvs_GRCh37;
         var GRCh38 = this.state.hgvs_GRCh38;
         var primary_transcript = this.state.primary_transcript;
-        var clinVarRCV = this.state.clinVarRCV;
         var clinVarInterpretationSummary = this.state.clinVarInterpretationSummary;
         var self = this;
 
@@ -420,36 +391,28 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                 </div>
 
                 <div className="panel panel-info datasource-clinvar-interpretaions">
-                    <div className="panel-heading"><h3 className="panel-title">ClinVar Interpretation and Supporting Records</h3></div>
+                    <div className="panel-heading">
+                        <h3 className="panel-title">ClinVar Interpretations
+                            {clinvar_id ? <a className="panel-subtitle pull-right" href={external_url_map['ClinVarSearch'] + clinvar_id} target="_blank">See data in ClinVar</a> : null}
+                        </h3>
+                    </div>
                     <div className="panel-content-wrapper">
-                        {this.state.loading_clinvarRCV ? showActivityIndicator('Retrieving data... ') : null}
-                        {(clinVarRCV.length > 0) ?
+                        {this.state.loading_clinvarEutils ? showActivityIndicator('Retrieving data... ') : null}
+                        {Object.keys(clinVarInterpretationSummary).length > 0 ?
                             <div className="clinvar-interpretaions-content-wrapper">
                                 <div className="panel-body clearfix clinvar-interpretation-summary">
-                                    <dl className="inline-dl clearfix col-sm-6">
+                                    <dl className="inline-dl clearfix col-sm-8">
                                         <dt>Review status:</dt><dd className="reviewStatus">{clinVarInterpretationSummary['ReviewStatus']}</dd>
-                                        <dt>Clinical significance:</dt><dd className="clinicalSignificance">{clinVarInterpretationSummary['ClinicalSignificance']}</dd>
+                                        <dt>Clinical significance:</dt>
+                                        <dd className="clinicalSignificance">
+                                            {clinVarInterpretationSummary['ClinicalSignificance']}<br/>{clinVarInterpretationSummary['Explanation']}
+                                        </dd>
                                     </dl>
-                                    <dl className="inline-dl clearfix col-sm-6">
+                                    <dl className="inline-dl clearfix col-sm-4">
                                         <dt>Last evaluated:</dt><dd className="dateLastEvaluated">{moment(clinVarInterpretationSummary['DateLastEvaluated']).format('MMM DD, YYYY')}</dd>
                                         <dt>Number of submission(s):</dt><dd className="submissionCount">{clinVarInterpretationSummary['SubmissionCount']}</dd>
                                     </dl>
                                 </div>
-                                <table className="table">
-                                    <thead>
-                                        <tr>
-                                            <th>Reference Accession</th>
-                                            <th>Review Status</th>
-                                            <th>Clinical Significance</th>
-                                            <th>Condition [Source]</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {clinVarRCV.map(function(item, i) {
-                                            return (self.renderClinvarInterpretations(item, i));
-                                        })}
-                                    </tbody>
-                                </table>
                             </div>
                             :
                             <div className="panel-body">

--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -207,6 +207,8 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
         }
     },
 
+    // TODO: Need to merge with SCV table rendering from #941
+
     // Method to render each associated condition, which also consists of multiple identifiers
     handleCondition: function(condition, key) {
         let self = this;

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1168,11 +1168,19 @@
 
             .basic-info .datasource-clinvar-interpretaions {
                 .clinvar-interpretation-summary {
-                    border: solid 1px #ddd;
-                    margin: 15px 15px 12px 15px;
-                    -webkit-border-radius: 2px;
-                    -moz-border-radius: 2px;
-                    border-radius: 2px;
+                    padding-left: 0;
+
+                    dl dt:first-child {
+                        margin-bottom: 6px;
+                    }
+
+                    dl:nth-child(odd) dt {
+                        width: 150px;
+                    }
+
+                    dl:nth-child(even) dt {
+                        width: 180px;
+                    }
 
                     .reviewStatus:first-letter {
                         text-transform: capitalize;

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -26,7 +26,7 @@ Feature: Select Variant
         Then I should see "NC_000015"
         When I press the button "Save and View Evidence"
         And I wait for 2 seconds
-        Then I should see "RCV000359576"
+        Then I should see "NM_005902.3:c.-28C>T"
         When I press the button "Interpretation "
         And I wait for 1 seconds
         Then I should see "Variant Interpretation Record"

--- a/src/clincoded/tests/features/variant_curation_tabs.feature
+++ b/src/clincoded/tests/features/variant_curation_tabs.feature
@@ -21,7 +21,7 @@ Feature: Variant Curation Tabs
         Then I should see "NC_000007"
         When I press the button "Save and View Evidence"
         And I wait for 2 seconds
-        Then I should see "RCV000047090"
+        Then I should see "NM_000492.3:c.412_414dupCTA"
         When I press the tab "Population "
         And I wait for 1 seconds
         Then I should see "Highest Minor Allele Frequency"
@@ -39,7 +39,7 @@ Feature: Variant Curation Tabs
         Then I should see "ENSG00000001626"
         When I press the tab "Basic Information"
         And I wait for 1 seconds
-        Then I should see "RCV000047090"
+        Then I should see "NM_000492.3:c.412_414dupCTA"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
         Then I should see "Access to these interfaces is currently restricted to ClinGen curators."
@@ -65,7 +65,7 @@ Feature: Variant Curation Tabs
         Then I should see "NC_000007"
         When I press the button "Save and View Evidence"
         And I wait for 2 seconds
-        Then I should see "RCV000046285"
+        Then I should see "NM_000492.3:c.1373delG"
         When I press the tab "Population "
         And I wait for 1 seconds
         Then I should see "Highest Minor Allele Frequency"
@@ -83,7 +83,7 @@ Feature: Variant Curation Tabs
         Then I should see "ENSG00000001626"
         When I press the tab "Basic Information"
         And I wait for 1 seconds
-        Then I should see "RCV000046285"
+        Then I should see "NM_000492.3:c.1373delG"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
         Then I should see "Access to these interfaces is currently restricted to ClinGen curators."
@@ -109,7 +109,7 @@ Feature: Variant Curation Tabs
         Then I should see "NC_000007"
         When I press the button "Save and View Evidence"
         And I wait for 2 seconds
-        Then I should see "RCV000047226"
+        Then I should see "NM_000492.3:c.642_643insT"
         When I press the tab "Population "
         And I wait for 1 seconds
         Then I should see "Highest Minor Allele Frequency"
@@ -127,7 +127,7 @@ Feature: Variant Curation Tabs
         Then I should see "ENSG00000001626"
         When I press the tab "Basic Information"
         And I wait for 1 seconds
-        Then I should see "RCV000047226"
+        Then I should see "NM_000492.3:c.642_643insT"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
         Then I should see "Access to these interfaces is currently restricted to ClinGen curators."
@@ -153,7 +153,7 @@ Feature: Variant Curation Tabs
         Then I should see "NC_000007"
         When I press the button "Save and View Evidence"
         And I wait for 2 seconds
-        Then I should see "RCV000047172"
+        Then I should see "NM_000492.3:c.4_53+69del119ins299"
         When I press the tab "Population "
         And I wait for 1 seconds
         Then I should see "Highest Minor Allele Frequency"
@@ -171,7 +171,7 @@ Feature: Variant Curation Tabs
         Then I should see "ENSG00000001626"
         When I press the tab "Basic Information"
         And I wait for 1 seconds
-        Then I should see "RCV000047172"
+        Then I should see "NM_000492.3:c.4_53+69del119ins299"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
         Then I should see "Access to these interfaces is currently restricted to ClinGen curators."


### PR DESCRIPTION
**Technical notes:**
Updated `select_variant.feature` and `variant_curation_tabs.feature` BDD test assertions since we have removed the RCV table entries on the Basic Info tab.

**Steps to test:**
1. In VCI, use **17000** for selecting the ClinVar and then proceed to the evidence view.
2. On the Basic Info tab, expect to see NO RCV entries being displayed in the **ClinVar Interpretations** table.
3. Also expect to see a line of text displayed below the **Clinical significance**, such as "Likely benign(5);Likely pathogenic(2);Pathogenic(7);Uncertain significance(3)", in the **ClinVar Interpretations** table. This is an "explanation" (included in the ClinVar API response) to the **Clinical significance**.