### PR TITLE
Connects to #1330. Adding evidence summary text box in VCI.

### DIFF
--- a/src/clincoded/schemas/provisional_variant.json
+++ b/src/clincoded/schemas/provisional_variant.json
@@ -31,6 +31,11 @@
             "title": "Reasons",
             "description": "Reasons user change the classification.",
             "type": "string"
+        },
+        "evidenceSummary": {
+            "title": "Evidence Summary",
+            "description": "Evidence summary for the variant interpretation",
+            "type": "string"
         }
     },
     "columns": {

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2307,7 +2307,7 @@ function flattenProvisional(provisional) {
 
 
 var provisionalVariantSimpleProps = [
-    "autoClassification", "alteredClassification", "reasons"
+    "autoClassification", "alteredClassification", "reasons", "evidenceSummary"
 ];
 
 function flattenProvisionalVariant(provisional_variant) {

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -58,7 +58,8 @@ var VariantCurationHub = createReactClass({
             autoClassification: null,
             provisionalPathogenicity: null,
             provisionalReason: null,
-            provisionalInterpretation: false
+            provisionalInterpretation: false,
+            evidenceSummary: null
         };
     },
 
@@ -72,7 +73,8 @@ var VariantCurationHub = createReactClass({
                         this.setState({
                             autoClassification: interpretation.provisional_variant[0].autoClassification,
                             provisionalPathogenicity: interpretation.provisional_variant[0].alteredClassification,
-                            provisionalReason: interpretation.provisional_variant[0].reason
+                            provisionalReason: interpretation.provisional_variant[0].reason,
+                            evidenceSummary: interpretation.provisional_variant[0].evidenceSummary ? interpretation.provisional_variant[0].evidenceSummary : null
                         });
                     }
                     // Return interpretation object's 'maskAsProvisional' property
@@ -411,6 +413,9 @@ var VariantCurationHub = createReactClass({
         if (field === 'provisional-interpretation' && this.state.provisionalInterpretation !== value) {
             this.setState({provisionalInterpretation: value});
         }
+        if (field === 'evidence-summary' && this.state.evidenceSummary !== value) {
+            this.setState({evidenceSummary: value});
+        }
     },
 
     render: function() {
@@ -465,7 +470,8 @@ var VariantCurationHub = createReactClass({
                         setProvisionalEvaluation={this.setProvisionalEvaluation}
                         provisionalPathogenicity={this.state.provisionalPathogenicity}
                         provisionalReason={this.state.provisionalReason}
-                        provisionalInterpretation={this.state.provisionalInterpretation} />
+                        provisionalInterpretation={this.state.provisionalInterpretation}
+                        evidenceSummary={this.state.evidenceSummary} />
                 }
             </div>
         );

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -468,7 +468,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = createReactClass({
                                             <div className="evaluation-provision evidence-summary">
                                                 <Input type="textarea" ref="evaluation-evidence-summary" label="Evidence Summary:"
                                                     value={evidenceSummary} handleChange={this.handleChange}
-                                                    placeholder="You may provide a summary of the evidence here (optional)." rows="5"
+                                                    placeholder="Summary of the evidence and rationale for the clinical significance (optional)." rows="5"
                                                     labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-8" groupClassName="form-group" />
                                             </div>
                                             <div className="provisional-submit">

--- a/src/clincoded/static/components/variant_central/interpretation/summary.js
+++ b/src/clincoded/static/components/variant_central/interpretation/summary.js
@@ -29,6 +29,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = createReactClass({
             provisionalPathogenicity: this.props.provisionalPathogenicity,
             provisionalReason: this.props.provisionalReason,
             provisionalInterpretation: this.props.provisionalInterpretation,
+            evidenceSummary: '',
             disabledCheckbox: false,
             disabledFormSumbit: false,
             submitBusy: false, // spinner for Save button
@@ -240,6 +241,14 @@ var EvaluationSummary = module.exports.EvaluationSummary = createReactClass({
                 this.props.setProvisionalEvaluation('provisional-interpretation', this.state.provisionalInterpretation);
             });
         }
+        // Handle freetext evaluation evidence summary
+        if (ref === 'evaluation-evidence-summary') {
+            if (this.refs[ref].getValue()) {
+                this.setState({evidenceSummary: this.refs[ref].getValue()});
+            } else {
+                this.setState({evidenceSummary: ''});
+            }
+        }
     },
 
     submitForm: function(e) {
@@ -341,7 +350,7 @@ var EvaluationSummary = module.exports.EvaluationSummary = createReactClass({
         }
     },
 
-    render: function() {
+    render() {
         let interpretation = this.state.interpretation;
         let evaluations = interpretation ? interpretation.evaluations : null;
         let sortedEvaluations = evaluations ? sortByStrength(evaluations) : null;
@@ -431,22 +440,23 @@ var EvaluationSummary = module.exports.EvaluationSummary = createReactClass({
                                             <div className="evaluation-provision provisional-interpretation">
                                                 <div>
                                                     <i className="icon icon-question-circle"></i>
-                                                    <span>Change status to "Provisional Interpretation" <i>(optional)</i>:</span>
+                                                    <span>Mark status as "Provisional Interpretation" <i>(optional)</i>:</span>
                                                     <Input type="checkbox" ref="provisional-interpretation" inputDisabled={disabledCheckbox} checked={provisionalInterpretation}
                                                         labelClassName="col-sm-6 control-label" wrapperClassName="col-sm-6" groupClassName="form-group" handleChange={this.handleChange} />
                                                 </div>
                                             </div>
-                                            <div className="alert alert-warning">
-                                                Note: If the Calculated Pathogenicity is "Likely Pathogenic" or "Pathogenic,"
-                                                a disease must first be associated with the interpretation before it can be marked
-                                                as a "Provisional Interpretation". Please select "Return to Interpretation" to add a disease.
+                                            <div className="evaluation-provision evidence-summary">
+                                                <Input type="textarea" ref="evaluation-evidence-summary" label="Evidence Summary:"
+                                                    value={this.state.evidenceSummary} handleChange={this.handleChange}
+                                                    placeholder="You may provide a summary of the evidence here (optional)." rows="5"
+                                                    labelClassName="col-sm-4 control-label" wrapperClassName="col-sm-8" groupClassName="form-group" />
                                             </div>
                                             <div className="provisional-submit">
                                                 <Input type="submit" inputClassName={(provisionalVariant ? "btn-info" : "btn-primary") + " pull-right btn-inline-spacer"}
                                                     id="submit" title={provisionalVariant ? "Update" : "Save"} submitBusy={this.state.submitBusy} inputDisabled={disabledFormSumbit} />
                                                 {this.state.updateMsg ?
                                                     <div className="submit-info pull-right">{this.state.updateMsg}</div>
-                                                : null}
+                                                    : null}
                                             </div>
                                         </div>
                                     </div>

--- a/src/clincoded/static/libs/bootstrap/alert.js
+++ b/src/clincoded/static/libs/bootstrap/alert.js
@@ -1,0 +1,34 @@
+'use strict';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const AlertMessage = ({visible, message, type, customClasses}) => {
+    let defaultClasses = 'feedback-message alert';
+    // Config visibility class
+    let visibilityClass = 'isHidden';
+    if (visible) {
+        visibilityClass = 'isVisible';
+    } else {
+        visibilityClass = 'isHidden';
+    }
+
+    let componentClasses = [defaultClasses, type, visibilityClass, customClasses];
+
+    return (
+        <div className={componentClasses.join(' ')}>
+            <span className="feedback-message-text">{message}</span>
+        </div>
+    );
+};
+
+AlertMessage.propTypes = {
+    visible: PropTypes.bool.isRequired,
+    type: PropTypes.string, // 'alert-success', 'alert-info', alert-warning', 'alert-danger'
+    message: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.string
+    ]),
+    customClasses: PropTypes.string
+};
+
+export default AlertMessage;

--- a/src/clincoded/static/libs/bootstrap/popover.js
+++ b/src/clincoded/static/libs/bootstrap/popover.js
@@ -22,7 +22,7 @@ export default class PopOverComponent extends React.Component {
         super(props);
         this.state = {
             isPopOverOpen: false
-        }
+        };
         this.handlePopOver = this.handlePopOver.bind(this);
         this.closePopOver = this.closePopOver.bind(this);
     }
@@ -35,7 +35,7 @@ export default class PopOverComponent extends React.Component {
         this.props.popOverRef(null);
     }
 
-     // Called by the actuator (link/button to toggle the popover)
+    // Called by the actuator (link/button to toggle the popover)
     handlePopOver() {
         this.setState({ isPopOverOpen: !this.state.isPopOverOpen });
     }
@@ -50,8 +50,8 @@ export default class PopOverComponent extends React.Component {
             <div className={'popover-component ' + this.props.popOverWrapperClass}>
                 {this.props.actuatorTitle ?
                     <a className="popover-actuator" onClick={() => this.handlePopOver()}>{this.props.actuatorTitle}</a>
-                : null}
-                <PopOver isPopOverOpen={this.state.isPopOverOpen} closePopOver={this.closePopOver}>
+                    : null}
+                <PopOver isPopOverOpen={this.state.isPopOverOpen} closePopOver={this.closePopOver} popOverStyleClass={this.props.popOverStyleClass}>
                     {this.props.children}
                 </PopOver>
             </div>
@@ -61,6 +61,7 @@ export default class PopOverComponent extends React.Component {
 
 PopOverComponent.propTypes = {
     popOverWrapperClass: PropTypes.string, // CSS class for popover DOM wrapper
+    popOverStyleClass: PropTypes.string, // CSS class for popover style (e.g. alert-info, alert-warning)
     actuatorTitle: PropTypes.oneOfType([ // Text for link to invoke popover
         PropTypes.object,
         PropTypes.string
@@ -75,7 +76,7 @@ class PopOver extends React.Component {
         }
 
         return (
-            <div className="popover-wrapper" style={{display: 'block'}}>
+            <div className={'popover-wrapper ' + this.props.popOverStyleClass} style={{display: 'block'}}>
                 <a className="closePopOver" aria-label="Close" onClick={this.props.closePopOver}>
                     <span aria-hidden="true"><i className="icon icon-times"></i></span>
                 </a>
@@ -89,5 +90,6 @@ class PopOver extends React.Component {
 
 PopOver.propTypes = {
     closePopOver: PropTypes.func,
-    isPopOverOpen: PropTypes.bool
+    isPopOverOpen: PropTypes.bool,
+    popOverStyleClass: PropTypes.string
 };

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2321,7 +2321,7 @@ dl.inline-dl {
                     color: #fff;
                     text-align: center;
                     border-radius: 3px;
-                    padding: 5px 0;
+                    padding: 7px 0;
                     position: absolute;
                     visibility: hidden;
                     width: 370px;
@@ -2329,7 +2329,7 @@ dl.inline-dl {
                     font-family: "Helvetica";
                     font-weight: bold;
                     z-index: 1;
-                    top: 25px;
+                    top: 22px;
                     left: 0;
                 }
 
@@ -2377,6 +2377,19 @@ dl.inline-dl {
                 &[disabled] {
                     color: #bbb;
                 }
+            }
+        }
+
+        &.evidence-summary {
+            margin-top: 25px;
+
+            label {
+                padding-right: 0;
+                padding-top: 0;
+            }
+
+            .form-error {
+                display: none;
             }
         }
     }

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -2307,13 +2307,18 @@ dl.inline-dl {
                 margin-left: -15px;
             }
 
+            .popover-provisional-status-help {
+                display: inline-block;
+                z-index: 999;
+            }
+
             .icon-question-circle {
                 cursor: pointer;
                 color: #2697d1;
                 font-size: 120%;
                 margin-right: 8px;
                 position: relative;
-
+                /*
                 &:after {
                     content: "Editing interpretation is permitted after selecting this option";
                     background-color: #000;
@@ -2336,6 +2341,7 @@ dl.inline-dl {
                 &:hover:after {
                     visibility: visible;
                 }
+                */
             }
 
             .form-group {
@@ -3023,4 +3029,32 @@ table.login-users-interpretations {
             margin-bottom: 20px;
         }
     }
+}
+
+/**
+ * Styles alerts to fade in and out
+ */
+.feedback-message {
+    -webkit-transition: opacity 2s ease 0.25s, visibility 2s ease 0.25s;
+    -moz-transition: opacity 2s ease 0.25s, visibility 2s ease 0.25s;
+    -ms-transition: opacity 2s ease 0.25s, visibility 2s ease 0.25s;
+    -o-transition: opacity 2s ease 0.25s, visibility 2s ease 0.25s;
+    transition: opacity 2s ease 0.25s, visibility 2s ease 0.25s;
+    opacity: 0;
+    visibility: hidden;
+}
+
+.feedback-message.alert {
+    margin: 0 10px;
+    padding: 6px 15px;
+}
+
+.feedback-message.isVisible {
+    opacity: 1;
+    visibility: visible; 
+}
+
+.feedback-message.isHidden {
+    opacity: 0;
+    visibility: hidden; 
 }

--- a/src/clincoded/static/scss/clincoded/modules/_popover.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_popover.scss
@@ -22,5 +22,18 @@
         .popover-content {
             margin: 13px 16px;
         }
+
+        &.alert {
+            .popover-content {
+                margin: 0 3px;
+                width: 360px;
+            }
+        }
+
+        &.alert-info {
+            background-color: #d9edf7;
+            border-color: #2697d1;
+            color: #31708f;
+        }
     }
 }


### PR DESCRIPTION
**Steps to test:**
1. Start a new VCI interpretation and evaluate some of the criteria so that a calculated pathogenicity is generated.
2. Click the **View Summary** button at the upper right hand corner to load the VCI Evaluation Summary page.
3. On the summary page, expect to see a new "Evidence Summary" label and its text field.
4. Enter some text into the "Evidence Summary" text field and click the **Save** button. Expect to see the form to be successfully saved and a green alert appearing next the button upon successful form submission (and disappearing in 6 seconds).
![image](https://user-images.githubusercontent.com/6956310/29334192-6f28b12c-81bb-11e7-8b16-13ab0a0c52bf.png)
5. Click on the blue **?** icon with the "Mark status..." label above the text field and expect to see a popover appearing with new **Help** description. Click on the **?** icon again and expect to see it disappearing.
![image](https://user-images.githubusercontent.com/6956310/29334277-ba39cd7c-81bb-11e7-9969-8dafb11d50ee.png)
6. Expect to see that the yellow warning text box about "disease needed to be associated for Likely Pathogenicity or Pathogenicity" is no longer present below the blue **?** icon with the "Mark status..." label.