### PR TITLE
Connects to #1106. Connects to #1347. Connects to #1450.

### DIFF
--- a/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
+++ b/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
@@ -39,8 +39,12 @@ export function getHgvsNotation(variant, assembly, omitChrString) {
         }
     }
 
-    // Handle deleted genomic HGVS
-    if (hgvs && hgvs.indexOf('del') > 0) {
+    /**
+     * Handle 'deletion' genomic GRCh38 HGVS
+     * The ensembl vep/human rest api only accepts the identifier up to the 'del' marker
+     * in the hgvs string, such as in 'chr7:g.117120152_117120270del119ins299'
+     */
+    if (hgvs && hgvs.indexOf('del') > 0 && assembly === 'GRCh38') {
         hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
     }
 

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -216,7 +216,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                     {this.state.selectedTab == 'segregation-case' ?
                     <div role="tabpanel" className="tab-panel">
                         <CurationInterpretationSegregation data={variant} data={variant} href_url={this.props.href_url} session={this.props.session}
-                            interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                            interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} ext_myGeneInfo={this.state.ext_myGeneInfo} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'gene-centric' ?

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -156,7 +156,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('population')} aria-selected={this.state.selectedTab == 'population'}>Population {completedSections.indexOf('population') > -1 ? <span>&#10003;</span> : null}</li>
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('predictors')} aria-selected={this.state.selectedTab == 'predictors'}>Predictors {completedSections.indexOf('predictors') > -1 ? <span>&#10003;</span> : null}</li>
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('experimental')} aria-selected={this.state.selectedTab == 'experimental'}>Experimental {completedSections.indexOf('experimental') > -1 ? <span>&#10003;</span> : null}</li>
-                        <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('segregation-case')} aria-selected={this.state.selectedTab == 'segregation-case'}>Segregation/Case {completedSections.indexOf('segregation-case') > -1 ? <span>&#10003;</span> : null}</li>
+                        <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('segregation-case')} aria-selected={this.state.selectedTab == 'segregation-case'}>Case/Segregation {completedSections.indexOf('segregation-case') > -1 ? <span>&#10003;</span> : null}</li>
                         <li className="tab-label col-sm-2" role="tab" onClick={() => this.handleSelect('gene-centric')} aria-selected={this.state.selectedTab == 'gene-centric'}>Gene-centric</li>
                     </ul>
 

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -31,7 +31,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         updateInterpretationObj: PropTypes.func,
         getSelectedTab: PropTypes.func,
         ext_myVariantInfo: PropTypes.object,
-        ext_bustamante: PropTypes.object,
         ext_ensemblVariation: PropTypes.object,
         ext_ensemblHgvsVEP: PropTypes.array,
         ext_clinvarEutils: PropTypes.object,
@@ -48,7 +47,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         loading_ensemblVariation: PropTypes.bool,
         loading_myVariantInfo: PropTypes.bool,
         loading_myGeneInfo: PropTypes.bool,
-        loading_bustamante: PropTypes.bool,
         setCalculatedPathogenicity: PropTypes.func,
         selectedTab: PropTypes.string
     },
@@ -59,7 +57,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             interpretation: this.props.interpretation,
             ext_myGeneInfo: this.props.ext_myGeneInfo,
             ext_myVariantInfo: this.props.ext_myVariantInfo,
-            ext_bustamante: this.props.ext_bustamante,
             ext_ensemblVariation: this.props.ext_ensemblVariation,
             ext_ensemblHgvsVEP: this.props.ext_ensemblHgvsVEP,
             ext_clinvarEutils: this.props.ext_clinvarEutils,
@@ -76,7 +73,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             loading_ensemblVariation: this.props.loading_ensemblVariation,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_myGeneInfo: this.props.loading_myGeneInfo,
-            loading_bustamante: this.props.loading_bustamante,
             //remember current tab/subtab so user will land on that tab when interpretation starts
             selectedTab: (this.props.href_url.href ? (queryKeyValue('tab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('tab', this.props.href_url.href)) > -1 ? queryKeyValue('tab', this.props.href_url.href) : 'basic-info') : 'basic-info')  : 'basic-info')
         };
@@ -91,9 +87,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         if (nextProps.ext_myVariantInfo) {
             this.setState({ext_myVariantInfo: nextProps.ext_myVariantInfo});
-        }
-        if (nextProps.ext_bustamante) {
-            this.setState({ext_bustamante: nextProps.ext_bustamante});
         }
         if (nextProps.ext_ensemblVariation) {
             this.setState({ext_ensemblVariation: nextProps.ext_ensemblVariation});
@@ -126,7 +119,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
             loading_myGeneInfo: nextProps.loading_myGeneInfo,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
-            loading_bustamante: nextProps.loading_bustamante,
             loading_ensemblVariation: nextProps.loading_ensemblVariation,
             loading_ensemblHgvsVEP: nextProps.loading_ensemblHgvsVEP,
             loading_clinvarEutils: nextProps.loading_clinvarEutils,
@@ -198,11 +190,9 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                         <CurationInterpretationComputational data={variant} href_url={this.props.href_url} session={this.props.session}
                             interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
                             ext_myVariantInfo={this.state.ext_myVariantInfo}
-                            ext_bustamante={this.state.ext_bustamante}
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
-                            loading_bustamante={this.state.loading_bustamante}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch} />
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -102,7 +102,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                 },
                 clingen: {
                     revel: {score_range: '0 to 1', score: null, prediction: 'higher score = higher pathogenicity', visible: true},
-                    cftr: {score_range: '--', score: null, prediction: '--', visible: false}
+                    cftr: {score_range: '0 to 1', score: null, prediction: 'higher score = higher pathogenicity', visible: false}
                 }
             },
             computationObjDiff: null,
@@ -314,7 +314,13 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (clingenPred[key].visible === true) {
             return (
                 <tr key={key}>
-                    <td>{(rowName === 'REVEL') ? <span><a href="https://sites.google.com/site/revelgenomics/about" target="_blank" rel="noopener noreferrer">REVEL</a> (meta-predictor)</span> : rowName}</td>
+                    <td>
+                        {(rowName === 'REVEL') ?
+                            <span><a href="https://sites.google.com/site/revelgenomics/about" target="_blank" rel="noopener noreferrer">{rowName}</a> (meta-predictor)</span> 
+                            : 
+                            <span>{rowName} (meta-predictor)</span>
+                        }
+                    </td>
                     <td>{clingenPred[key].score_range}</td>
                     <td>{clingenPred[key].score ? clingenPred[key].score : 'No data found'}</td>
                     <td>{clingenPred[key].prediction}</td>

--- a/src/clincoded/static/components/variant_central/interpretation/computational.js
+++ b/src/clincoded/static/components/variant_central/interpretation/computational.js
@@ -15,15 +15,16 @@ import { PanelGroup, Panel } from '../../../libs/bootstrap/panel';
 import { findDiffKeyValuesMixin } from './shared/find_diff';
 import { CompleteSection } from './shared/complete_section';
 import { parseAndLogError } from '../../mixins';
+import { parseKeyValue } from '../helpers/parse_key_value';
 
-var vciFormHelper = require('./shared/form');
-var CurationInterpretationForm = vciFormHelper.CurationInterpretationForm;
-var genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
-var extraEvidence = require('./shared/extra_evidence');
+const vciFormHelper = require('./shared/form');
+const CurationInterpretationForm = vciFormHelper.CurationInterpretationForm;
+const genomic_chr_mapping = require('./mapping/NC_genomic_chr_format.json');
+const extraEvidence = require('./shared/extra_evidence');
 
-var validTabs = ['missense', 'lof', 'silent-intron', 'indel'];
+const validTabs = ['missense', 'lof', 'silent-intron', 'indel'];
 
-var computationStatic = {
+const computationStatic = {
     conservation: {
         _order: ['phylop7way', 'phylop20way', 'phastconsp7way', 'phastconsp20way', 'gerp', 'siphy'],
         _labels: {'phylop7way': 'phyloP100way', 'phylop20way': 'phyloP20way', 'phastconsp7way': 'phastCons100way', 'phastconsp20way': 'phastCons20way', 'gerp': 'GERP++', 'siphy': 'SiPhy'}
@@ -63,10 +64,8 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         updateInterpretationObj: PropTypes.func,
         href_url: PropTypes.object,
         ext_myVariantInfo: PropTypes.object,
-        ext_bustamante: PropTypes.object,
         ext_clinVarEsearch: PropTypes.object,
         ext_singleNucleotide: PropTypes.bool,
-        loading_bustamante: PropTypes.bool,
         loading_myVariantInfo: PropTypes.bool,
         loading_clinvarEsearch: PropTypes.bool
     },
@@ -78,7 +77,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             interpretation: this.props.interpretation,
             hasConservationData: false,
             hasOtherPredData: false,
-            hasBustamanteData: false,
             selectedSubtab: (this.props.href_url.href ? (queryKeyValue('subtab', this.props.href_url.href) ? (validTabs.indexOf(queryKeyValue('subtab', this.props.href_url.href)) > -1 ? queryKeyValue('subtab', this.props.href_url.href) : 'missense') : 'missense')  : 'missense'),
             codonObj: {},
             computationObj: {
@@ -108,7 +106,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
             computationObjDiff: null,
             computationObjDiffFlag: false,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
-            loading_bustamante: this.props.loading_bustamante,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch
         };
@@ -124,9 +121,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (this.props.ext_myVariantInfo) {
             this.parseOtherPredData(this.props.ext_myVariantInfo);
             this.parseConservationData(this.props.ext_myVariantInfo);
-        }
-        if (this.props.ext_bustamante) {
-            this.parseClingenPredData(this.props.ext_bustamante);
+            this.parseClingenPredData(this.props.ext_myVariantInfo);
         }
         if (this.props.ext_clinVarEsearch) {
             var codonObj = {};
@@ -147,9 +142,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         if (nextProps.ext_myVariantInfo) {
             this.parseOtherPredData(nextProps.ext_myVariantInfo);
             this.parseConservationData(nextProps.ext_myVariantInfo);
-        }
-        if (nextProps.ext_bustamante) {
-            this.parseClingenPredData(nextProps.ext_bustamante);
+            this.parseClingenPredData(nextProps.ext_myVariantInfo);
         }
         if (nextProps.ext_clinVarEsearch) {
             var codonObj = {};
@@ -163,7 +156,6 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
-            loading_bustamante: nextProps.loading_bustamante,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
             loading_clinvarEsearch: nextProps.loading_clinvarEsearch
         });
@@ -173,8 +165,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         window.history.replaceState(window.state, '', editQueryValue(window.location.href, 'subtab', null));
         this.setState({
             hasConservationData: false,
-            hasOtherPredData: false,
-            hasBustamanteData: false
+            hasOtherPredData: false
         });
     },
 
@@ -189,19 +180,30 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
         }
     },
 
-    // Method to assign clingen predictors data to global computation object
+    /**
+     * Method to assign clingen predictors data to global computation object
+     * REVEL data is now parsed from myvariant.info response
+     * It can be accessed via response['dbnsfp']['revel'] or using
+     * the 'parseKeyValue()' helper function which traverse the tree down to 2nd level
+     * 
+     * TBD on where the CFTR data is queried from after Bustamante lab is no longer the source
+     * And thus the CFTR data parsing in this method needs to be altered in the future
+     * 
+     * @param {object} response - The response object returned by myvariant.info
+     */
     parseClingenPredData: function(response) {
         let computationObj = this.state.computationObj;
-        if (response.results[0]) {
-            if (response.results[0].predictions) {
-                let predictions = response.results[0].predictions;
-                computationObj.clingen.revel.score = (predictions.revel) ? this.numToString(predictions.revel.score) : null;
-                computationObj.clingen.cftr.score = (predictions.CFTR) ? this.numToString(predictions.CFTR.score): null;
-                computationObj.clingen.cftr.visible = (predictions.CFTR) ? true : false;
-            }
-            // update computationObj, and set flag indicating that we have clingen predictors data
-            this.setState({hasBustamanteData: true, computationObj: computationObj});
+        let revel = parseKeyValue(response, 'revel'),
+            cftr = parseKeyValue(response, 'cftr');
+        if (revel) {
+            computationObj.clingen.revel.score = (revel.score) ? this.numToString(revel.score) : null;
         }
+        if (cftr) {
+            computationObj.clingen.cftr.score = (cftr.score) ? this.numToString(cftr.score): null;
+            computationObj.clingen.cftr.visible = (cftr.score) ? true : false;
+        }
+        // update computationObj, and set flag indicating that we have clingen predictors data
+        this.setState({computationObj: computationObj});
     },
 
     // Method to assign other predictors data to global computation object
@@ -470,7 +472,7 @@ var CurationInterpretationComputational = module.exports.CurationInterpretationC
                             <div className="panel panel-info datasource-clingen">
                                 <div className="panel-heading"><h3 className="panel-title">ClinGen Predictors</h3></div>
                                 <div className="panel-content-wrapper">
-                                    {this.state.loading_bustamante ? showActivityIndicator('Retrieving data... ') : null}
+                                    {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                                     {!singleNucleotide ?
                                         <div className="panel-body"><span>These predictors only return data for missense variants.</span></div>
                                         :

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -416,7 +416,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     // Method to render external ExAC linkout when no ExAC population data found
     renderExacLinkout: function(response) {
-        let exacLink;
+        let exacLink, linkText;
         // If no ExAC population data, construct external linkout for one of the following:
         // 1) clinvar/cadd data found & the variant type is substitution
         // 2) clinvar/cadd data found & the variant type is NOT substitution
@@ -426,11 +426,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             let pos = response.hg19 ? response.hg19.start : (response.clinvar.hg19 ? response.clinvar.hg19.start : response.cadd.hg19.start);
             let regionStart = response.hg19 ? parseInt(response.hg19.start) - 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.start) - 30 : parseInt(response.cadd.hg19.start) - 30);
             let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
+            // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
+            // Or there is no ExAC data object in the return myvariant.info JSON response
+            if (!this.state.ext_singleNucleotide || !this.state.hasExacData) {
+                exacLink = external_url_map['ExACRegion'] + chrom + '-' + regionStart + '-' + regionEnd;
+                linkText = 'Search ExAC Region';
+            }
+            /*
             if (response.clinvar) {
                 // Try 'clinvar' as primary data object
                 let clinvar = response.clinvar;
                 // Applies to substitution variant (e.g. C>T in which '>' means 'changes to')
-                if (clinvar.type && clinvar.type === 'single nucleotide variant') {
+                if (clinvar.type && clinvar.type === 'single nucleotide variant' && this.state.hasExacData) {
                     exacLink = 'http:' + external_url_map['EXAC'] + chrom + '-' + pos + '-' + clinvar.ref + '-' + clinvar.alt;
                 } else {
                     // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
@@ -439,16 +446,23 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             } else if (response.cadd) {
                 // Fallback to 'cadd' as alternative data object
                 let cadd = response.cadd;
-                if (cadd.type && cadd.type === 'SNV') {
+                if (cadd.type && cadd.type === 'SNV' && this.state.hasExacData) {
                     exacLink = 'http:' + external_url_map['EXAC'] + chrom + '-' + pos + '-' + cadd.ref + '-' + cadd.alt;
                 } else {
                     exacLink = external_url_map['ExACRegion'] + chrom + '-' + regionStart + '-' + regionEnd;
                 }
             }
+            */
         } else {
+            // 404 response from myvariant.info
             exacLink = external_url_map['EXACHome'];
+            linkText = 'Search ExAC';
         }
-        return exacLink;
+        return (
+            <span>
+                <a href={exacLink} target="_blank">{linkText}</a> for this variant.
+            </span>
+        );
     },
 
     /* the following methods are related to the rendering of population data tables */
@@ -819,7 +833,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                             {!singleNucleotide ?
                                 <div className="panel-body">
-                                    <span>Data is currently only returned for single nucleotide variants. <a href={this.renderExacLinkout(this.props.ext_myVariantInfo)} target="_blank">Search ExAC</a> for this variant.</span>
+                                    <span>Data is currently only returned for single nucleotide variants. {this.renderExacLinkout(this.props.ext_myVariantInfo)}</span>
                                 </div>
                                 :
                                 <div>
@@ -855,7 +869,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                         </div>
                                         :
                                         <div className="panel-body">
-                                            <span>No population data was found for this allele in ExAC. <a href={this.renderExacLinkout(this.props.ext_myVariantInfo)} target="_blank">Search ExAC</a> for this variant.</span>
+                                            <span>No population data was found for this allele in ExAC. {this.renderExacLinkout(this.props.ext_myVariantInfo)}</span>
                                         </div>
                                     }
                                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -797,7 +797,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                     <div className="bs-callout bs-callout-info clearfix">
                         <h4>Subpopulation with Highest Minor Allele Frequency</h4>
-                        <p>This reflects the highest MAF observed, as calculated by the interface, across all subpopulations in the versions of ExAC, 1000 Genomes and ESP shown below.</p>
+                        <p>This reflects the highest MAF observed, as calculated by the interface, across all subpopulations in the versions of ExAC, 1000 Genomes, and ESP shown below.</p>
                         <div className="clearfix">
                             <div className="bs-callout-content-container">
                                 <dl className="inline-dl clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -797,6 +797,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
                     <div className="bs-callout bs-callout-info clearfix">
                         <h4>Subpopulation with Highest Minor Allele Frequency</h4>
+                        <p>This reflects the highest MAF observed, as calculated by the interface, across all subpopulations in the versions of ExAC, 1000 Genomes and ESP shown below.</p>
                         <div className="clearfix">
                             <div className="bs-callout-content-container">
                                 <dl className="inline-dl clearfix">

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -724,6 +724,27 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         return gnomADLink;
     },
 
+    /**
+     * Sort population data table by allele frequency from highest to lowest
+     */
+    sortObjKeys(obj) {
+        let arr = []; // Array converted from object
+        let filteredArray = []; // filtered array without the '_tot' and '_extra' key/value pairs
+        let sortedArray = []; // Sorting the filtered array from highest to lowest allele frequency
+        let sortedKeys = []; // Sorted order for the rendering of populations
+        if (Object.keys(obj).length) {
+            arr = Object.entries(obj);
+            filteredArray = arr.filter(item => {
+                return item[0].indexOf('_') < 0;
+            });
+            sortedArray = filteredArray.sort((x, y) => y[1]['af'] - x[1]['af']);
+            sortedArray.forEach(item => {
+                sortedKeys.push(item[0]);
+            });
+        }
+        return sortedKeys;
+    },
+
     render: function() {
         var exacStatic = populationStatic.exac,
             tGenomesStatic = populationStatic.tGenomes,
@@ -735,7 +756,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         var desiredCI = this.state.populationObj && this.state.populationObj.desiredCI ? this.state.populationObj.desiredCI : CI_DEFAULT;
         var populationObjDiffFlag = this.state.populationObjDiffFlag;
         var singleNucleotide = this.state.ext_singleNucleotide;
-
+        let exacSortedAlleleFrequency = this.sortObjKeys(exac);
         const exacDataLinkout = 'http:' + external_url_map['EXAC'] + exac._extra.chrom + '-' + exac._extra.pos + '-' + exac._extra.ref + '-' + exac._extra.alt;
 
         return (
@@ -816,7 +837,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        {exacStatic._order.map(key => {
+                                                        {exacSortedAlleleFrequency.map(key => {
                                                             return (this.renderExacRow(key, exac, exacStatic));
                                                         })}
                                                     </tbody>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -415,17 +415,17 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render external ExAC linkout when no ExAC population data found
-    renderExacLinkout: function(response, singleNucleotide) {
+    renderExacLinkout: function(response) {
         let exacLink;
         // If no ExAC population data, construct external linkout for one of the following:
         // 1) clinvar/cadd data found & the variant type is substitution
         // 2) clinvar/cadd data found & the variant type is NOT substitution
         // 3) no data returned by myvariant.info
-        if (response && singleNucleotide) {
-            let chrom = response.chrom,
-                pos = response.hg19.start,
-                regionStart = parseInt(response.hg19.start) - 30,
-                regionEnd = parseInt(response.hg19.end) + 30;
+        if (response) {
+            let chrom = response.chrom;
+            let pos = response.hg19 ? response.hg19.start : (response.clinvar.hg19 ? response.clinvar.hg19.start : response.cadd.hg19.start);
+            let regionStart = response.hg19 ? parseInt(response.hg19.start) - 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.start) - 30 : parseInt(response.cadd.hg19.start) - 30);
+            let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
             if (response.clinvar) {
                 // Try 'clinvar' as primary data object
                 let clinvar = response.clinvar;

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -30,7 +30,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
             data: this.props.data,
             clinvar_id: null,
             interpretation: this.props.interpretation,
-            disableEvalForm: false // TRUE to disable form elements of Segregation's 'Reputable source' section if the gene is either BRCA1 or BRCA2
+            disableEvalForm: false // TRUE to disable form elements of Segregation's 'Reputable source' section if the gene is NEITHER BRCA1 or BRCA2
         };
     },
 
@@ -38,12 +38,12 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
         this.setState({data: nextProps.data, interpretation: nextProps.interpretation});
         /**
          * Disable form elements of Segregation's 'Reputable source' section
-         * when the associated gene is either BRCA1 or BRCA2
+         * when the associated gene is NEITHER BRCA1 or BRCA2
          */
         if (nextProps.ext_myGeneInfo && nextProps.ext_myGeneInfo.symbol) {
             let gene = nextProps.ext_myGeneInfo.symbol;
             this.setState({
-                disableEvalForm: (gene === 'BRCA1' || gene === 'BRCA2') ? true : false
+                disableEvalForm: (gene.indexOf('BRCA') < 0) ? true : false
             });
         }
     },
@@ -375,7 +375,11 @@ var criteriaGroup7Update = function(nextProps) {
 };
 
 
-// code for rendering of this group of interpretation forms
+/**
+ * Callback for rendering of this group of interpretation forms
+ * Disabling form currently only applies to 'BP6' and 'PP5' if the gene is NEITHER BRCA1 or BRCA2
+ * @param {boolean} disableEvalForm - The flag to disable criteria evaluation form
+ */
 var criteriaGroup8 = function(disableEvalForm) {
     let criteriaList1 = ['BP6', 'PP5'], // array of criteria code handled subgroup of this section
         hiddenList1 = [false, true]; // array indicating hidden status of explanation boxes for above list of criteria codes

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -21,22 +21,34 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
         data: PropTypes.object, // ClinVar data payload
         interpretation: PropTypes.object,
         updateInterpretationObj: PropTypes.func,
-        href_url: PropTypes.object
+        href_url: PropTypes.object,
+        ext_myGeneInfo: PropTypes.object
     },
 
-    getInitialState: function() {
+    getInitialState() {
         return {
             data: this.props.data,
             clinvar_id: null,
-            interpretation: this.props.interpretation
+            interpretation: this.props.interpretation,
+            disableEvalForm: false // TRUE to disable form elements of Segregation's 'Reputable source' section if the gene is either BRCA1 or BRCA2
         };
     },
 
-    componentWillReceiveProps: function(nextProps) {
+    componentWillReceiveProps(nextProps) {
         this.setState({data: nextProps.data, interpretation: nextProps.interpretation});
+        /**
+         * Disable form elements of Segregation's 'Reputable source' section
+         * when the associated gene is either BRCA1 or BRCA2
+         */
+        if (nextProps.ext_myGeneInfo && nextProps.ext_myGeneInfo.symbol) {
+            let gene = nextProps.ext_myGeneInfo.symbol;
+            this.setState({
+                disableEvalForm: (gene === 'BRCA1' || gene === 'BRCA2') ? true : false
+            });
+        }
     },
 
-    render: function() {
+    render() {
         return (
             <div className="variant-interpretation segregation">
                 <PanelGroup accordion><Panel title="Observed in healthy adult(s)" panelBodyClassName="panel-wide-content" open>
@@ -49,7 +61,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="observed-in-healthy" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Observed in healthy adult(s))</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -66,7 +78,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="case-control" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Case-control)</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -83,7 +95,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="segregation-data" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Segregation data)</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -100,7 +112,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="de-novo" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (<i>de novo</i> occurrence)</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -117,7 +129,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="allele-data" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Allele Data (<i>cis/trans</i>))</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -134,7 +146,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="alternate-mechanism" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Alternate mechanism for disease)</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -151,7 +163,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                     <extraEvidence.ExtraEvidenceTable category="case-segregation" subcategory="specificity-of-phenotype" session={this.props.session}
                         href_url={this.props.href_url} tableName={<span>Curated Literature Evidence (Specificity of phenotype)</span>}
                         variant={this.state.data} interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
@@ -162,18 +174,23 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                     {(this.state.data && this.state.interpretation) ?
                         <div className="row">
                             <div className="col-sm-12">
+                                <div className="alert alert-info">
+                                    The rules in this section currently only apply to BRCA1 and BRCA2 variants
+                                    using <a href="https://www.clinicalgenome.org/data-sharing/sharing-clinical-reports-project-scrp/" target="_blank" rel="noopener noreferrer">SCRP</a> data
+                                </div>
                                 <CurationInterpretationForm renderedFormContent={criteriaGroup8} criteria={['BP6', 'PP5']}
                                     evidenceData={null} evidenceDataUpdated={true} criteriaCrossCheck={[['BP6', 'PP5']]}
                                     formDataUpdater={criteriaGroup8Update} variantUuid={this.state.data['@id']} formChangeHandler={criteriaGroup8Change}
-                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
+                                    interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
+                                    disableEvalForm={this.state.disableEvalForm} />
                             </div>
                         </div>
-                    : null}
+                        : null}
                 </Panel></PanelGroup>
 
                 {this.state.interpretation ?
                     <CompleteSection interpretation={this.state.interpretation} tabName="segregation-case" updateInterpretationObj={this.props.updateInterpretationObj} />
-                : null}
+                    : null}
             </div>
         );
     }
@@ -359,15 +376,15 @@ var criteriaGroup7Update = function(nextProps) {
 
 
 // code for rendering of this group of interpretation forms
-var criteriaGroup8 = function() {
+var criteriaGroup8 = function(disableEvalForm) {
     let criteriaList1 = ['BP6', 'PP5'], // array of criteria code handled subgroup of this section
         hiddenList1 = [false, true]; // array indicating hidden status of explanation boxes for above list of criteria codes
     return (
         <div>
             {vciFormHelper.evalFormSectionWrapper.call(this,
                 vciFormHelper.evalFormNoteSectionWrapper.call(this, criteriaList1),
-                vciFormHelper.evalFormDropdownSectionWrapper.call(this, criteriaList1),
-                vciFormHelper.evalFormExplanationSectionWrapper.call(this, criteriaList1, hiddenList1, null, null),
+                vciFormHelper.evalFormDropdownSectionWrapper.call(this, criteriaList1, disableEvalForm),
+                vciFormHelper.evalFormExplanationSectionWrapper.call(this, criteriaList1, hiddenList1, null, null, disableEvalForm),
                 false
             )}
         </div>

--- a/src/clincoded/static/components/variant_central/interpretation/shared/complete_section.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/complete_section.js
@@ -12,7 +12,7 @@ var tabNames = {
     'population': 'Population',
     'predictors': 'Predictors',
     'experimental': 'Experimental',
-    'segregation-case': 'Segregation/Case'
+    'segregation-case': 'Case/Segregation'
 };
 
 // Recursive function to compare oldObj against newObj and its key:values. Creates diffObj that shares the keys (full-depth) with newObj,

--- a/src/clincoded/static/components/variant_central/interpretation/shared/form.js
+++ b/src/clincoded/static/components/variant_central/interpretation/shared/form.js
@@ -35,7 +35,7 @@ var CurationInterpretationForm = module.exports.CurationInterpretationForm = cre
         criteriaCrossCheck: PropTypes.array, // an array of arrays of criteria codes that are to be checked upon submitForm to make sure there are no more than one 'Met'
         interpretation: PropTypes.object, // parent interpretation object
         updateInterpretationObj: PropTypes.func, // function from index.js; this function will pass the updated interpretation object back to index.js
-        disableEvalForm: PropTypes.bool // Flag to disable form elements of Segregation's 'Reputable source' section if the gene is either BRCA1 or BRCA2
+        disableEvalForm: PropTypes.bool // TRUE to disable form elements of Segregation's 'Reputable source' section if the gene is NEITHER BRCA1 or BRCA2
     },
 
     contextTypes: {
@@ -455,8 +455,12 @@ export function evalFormNoteSectionWrapper(criteriaList) {
     );
 }
 
-// wrapper for rendering the dropdown section of eval form group. criteriaList should be an array of criteria codes being handled in the section.
-// calls evalFormValueDropdown() to render a dropdown for each criteria
+/**
+ * wrapper for rendering the dropdown section of eval form group. criteriaList should be an array of criteria codes being handled in the section.
+ * calls evalFormValueDropdown() to render a dropdown for each criteria
+ * @param {array} criteriaList - The list of criteria to be evaluated (e.g. ['BP6', 'PP5'])
+ * @param {boolean} disableEvalForm - The flag to disable criteria evaluation form
+ */
 export function evalFormDropdownSectionWrapper(criteriaList, disableEvalForm) {
     return (
         <div>
@@ -473,7 +477,11 @@ export function evalFormDropdownSectionWrapper(criteriaList, disableEvalForm) {
     );
 }
 
-// helper function for evalFormDropdownSectionWrapper() to generate the dropdown for each criteria
+/** 
+ * Helper function for evalFormDropdownSectionWrapper() to generate the dropdown for each criteria
+ * @param {string} criteria - The individual criteria to be evaluated (e.g. 'BP6' or 'PP5')
+ * @param {boolean} disableEvalForm - The flag to disable criteria evaluation form
+ */
 function evalFormValueDropdown(criteria, disableEvalForm) {
     // ADD FOLLOWING LINE TO <INPUT> BELOW FOR DISEASE DEPENDENCY RESTRICTION
     // inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated}
@@ -494,12 +502,16 @@ function evalFormValueDropdown(criteria, disableEvalForm) {
     );
 }
 
-// wrapper for rendering the explanation section of eval form group
-// criteriaList should be an array of criteria codes being handled in the section
-// hiddenList should be an array of booleans mirroring the size and order of criteriaList, with the booleans indicating whether or not the explanation input for
-//      that criteria should be visible. this should generally be used with shareExplanation()
-// customContentBefore should be HTML for any elements to render before the explanation inputs, in that column (optional)
-// customContentAfter should be HTML for any elements to render after the explanation inputs, in that column (optional)
+/**
+ * wrapper for rendering the explanation section of eval form group
+ * criteriaList should be an array of criteria codes being handled in the section
+ * hiddenList should be an array of booleans mirroring the size and order of criteriaList, with the booleans indicating whether or not the explanation input for
+ *      that criteria should be visible. this should generally be used with shareExplanation()
+ * customContentBefore should be HTML for any elements to render before the explanation inputs, in that column (optional)
+ * customContentAfter should be HTML for any elements to render after the explanation inputs, in that column (optional)
+ * @param {array} criteriaList - The list of criteria to be evaluated (e.g. ['BP6', 'PP5'])
+ * @param {boolean} disableEvalForm - The flag to disable criteria evaluation form
+ */
 export function evalFormExplanationSectionWrapper(criteriaList, hiddenList, customContentBefore, customContentAfter, disableEvalForm) {
     return (
         <div>
@@ -512,7 +524,12 @@ export function evalFormExplanationSectionWrapper(criteriaList, hiddenList, cust
     );
 }
 
-// helper function for evalFormExplanationSectionWrapper() to generate the explanation input for each criteria
+/**
+ * Helper function for evalFormExplanationSectionWrapper() to generate the explanation input for each criteria
+ * @param {string} criteria - The individual criteria to be evaluated (e.g. 'BP6' or 'PP5')
+ * @param {boolean} hidden - The flag to hide the form element in UI
+ * @param {boolean} disableEvalForm - The flag to disable criteria evaluation form
+ */
 function evalFormExplanationDefaultInput(criteria, hidden, disableEvalForm) {
     // ADD FOLLOWING LINE TO <INPUT> BELOW FOR DISEASE DEPENDENCY RESTRICTION
     // inputDisabled={evidenceCodes[criteria].diseaseDependent && !this.state.diseaseAssociated}

--- a/src/clincoded/tests/features/variant_curation_tabs.feature
+++ b/src/clincoded/tests/features/variant_curation_tabs.feature
@@ -31,7 +31,7 @@ Feature: Variant Curation Tabs
         When I press the tab "Experimental "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Hotspot or functional domain)"
-        When I press the tab "Segregation/Case "
+        When I press the tab "Case/Segregation "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Observed in healthy adult(s))"
         When I press the tab "Gene-centric"
@@ -75,7 +75,7 @@ Feature: Variant Curation Tabs
         When I press the tab "Experimental "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Hotspot or functional domain)"
-        When I press the tab "Segregation/Case "
+        When I press the tab "Case/Segregation "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Observed in healthy adult(s))"
         When I press the tab "Gene-centric"
@@ -119,7 +119,7 @@ Feature: Variant Curation Tabs
         When I press the tab "Experimental "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Hotspot or functional domain)"
-        When I press the tab "Segregation/Case "
+        When I press the tab "Case/Segregation "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Observed in healthy adult(s))"
         When I press the tab "Gene-centric"
@@ -163,7 +163,7 @@ Feature: Variant Curation Tabs
         When I press the tab "Experimental "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Hotspot or functional domain)"
-        When I press the tab "Segregation/Case "
+        When I press the tab "Case/Segregation "
         And I wait for 1 seconds
         Then I should see "Curated Literature Evidence (Observed in healthy adult(s))"
         When I press the tab "Gene-centric"


### PR DESCRIPTION
**Steps to test #1106:**
1. Visit the variant curation interface and select a variant (e.g. 55847). Proceed to the VCI evidence view.
2. Click on the **Population** tab and in the **Subpopulation with Highest Minor Allele Frequency** section, expect to see a newly added note text "This reflects the highest MAF observed, as calculated by the interface, across all subpopulations in the versions of ExAC, 1000 Genomes, and ESP shown below."

**Steps to test #1347:**
1. While still in the VCI, expect to see the **Segregation/Case** tab has been renamed to **Case/Segregation**.

**Steps to test #1450:**
1. While still in the VCI, click the **Predictors** tab and in the **ClinGen Predictors** table under the **Missense** sub-tab, expect to see the **0.329** REVEL score for the **55847** ClinVar ID.
![image](https://user-images.githubusercontent.com/6956310/29737435-53600332-89c2-11e7-8988-ee5799c49faf.png)
