### PR TITLE
Connects to #847. Connects to #874. Connects to #987.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -206,7 +206,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                     {this.state.selectedTab == 'segregation-case' ?
                     <div role="tabpanel" className="tab-panel">
                         <CurationInterpretationSegregation data={variant} data={variant} href_url={this.props.href_url} session={this.props.session}
-                            interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} ext_myGeneInfo={this.state.ext_myGeneInfo} />
+                            interpretation={interpretation} updateInterpretationObj={this.props.updateInterpretationObj} />
                     </div>
                     : null}
                     {this.state.selectedTab == 'gene-centric' ?

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -21,31 +21,19 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
         data: PropTypes.object, // ClinVar data payload
         interpretation: PropTypes.object,
         updateInterpretationObj: PropTypes.func,
-        href_url: PropTypes.object,
-        ext_myGeneInfo: PropTypes.object
+        href_url: PropTypes.object
     },
 
     getInitialState() {
         return {
             data: this.props.data,
             clinvar_id: null,
-            interpretation: this.props.interpretation,
-            disableEvalForm: false // TRUE to disable form elements of Segregation's 'Reputable source' section if the gene is NEITHER BRCA1 or BRCA2
+            interpretation: this.props.interpretation
         };
     },
 
     componentWillReceiveProps(nextProps) {
         this.setState({data: nextProps.data, interpretation: nextProps.interpretation});
-        /**
-         * Disable form elements of Segregation's 'Reputable source' section
-         * when the associated gene is NEITHER BRCA1 or BRCA2
-         */
-        if (nextProps.ext_myGeneInfo && nextProps.ext_myGeneInfo.symbol) {
-            let gene = nextProps.ext_myGeneInfo.symbol;
-            this.setState({
-                disableEvalForm: (gene.indexOf('BRCA') < 0) ? true : false
-            });
-        }
     },
 
     render() {
@@ -174,15 +162,11 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                     {(this.state.data && this.state.interpretation) ?
                         <div className="row">
                             <div className="col-sm-12">
-                                <div className="alert alert-info">
-                                    The rules in this section currently only apply to BRCA1 and BRCA2 variants
-                                    using <a href="https://www.clinicalgenome.org/data-sharing/sharing-clinical-reports-project-scrp/" target="_blank" rel="noopener noreferrer">SCRP</a> data
-                                </div>
                                 <CurationInterpretationForm renderedFormContent={criteriaGroup8} criteria={['BP6', 'PP5']}
                                     evidenceData={null} evidenceDataUpdated={true} criteriaCrossCheck={[['BP6', 'PP5']]}
                                     formDataUpdater={criteriaGroup8Update} variantUuid={this.state.data['@id']} formChangeHandler={criteriaGroup8Change}
                                     interpretation={this.state.interpretation} updateInterpretationObj={this.props.updateInterpretationObj}
-                                    disableEvalForm={this.state.disableEvalForm} />
+                                    disableEvalForm={true} />
                             </div>
                         </div>
                         : null}

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -158,7 +158,7 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
                         viewOnly={this.state.data && !this.state.interpretation} />
                 </Panel></PanelGroup>
 
-                <PanelGroup accordion><Panel title="Reputable source" panelBodyClassName="panel-wide-content" open>
+                <PanelGroup accordion><Panel title="Reputable source" panelBodyClassName="panel-wide-content reputable-source" open>
                     {(this.state.data && this.state.interpretation) ?
                         <div className="row">
                             <div className="col-sm-12">

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -3109,3 +3109,33 @@ table.login-users-interpretations {
         }
     }
 }
+
+ /* Styles for hovering tool tip upon mouseover disabled criteria */
+ .reputable-source .evaluation {
+    .col-xs-9 {
+        position: relative;
+
+        &:after {
+            content: "ClinGen has determined that this rule should not be applied in any context.";
+            background-color: #000;
+            background-color: hsla(0, 0%, 20%, 0.9);
+            color: #fff;
+            text-align: left;
+            border-radius: 4px;
+            padding: 8px 11px;
+            position: absolute;
+            visibility: hidden;
+            width: 232px;
+            font-size: 14px;
+            font-family: "Helvetica Neue", "Lato";
+            font-weight: normal;
+            z-index: 999;
+            top: -76px;
+            left: 15px;
+        }
+
+        &:hover:after {
+            visibility: visible;
+        }
+    }
+}


### PR DESCRIPTION
**Steps to test #847:**
1. Use the following example ClinVar IDs to test the **ExAC** linkout in the VCI's Popultation tab:
Substitution variants (with both clinvar and cadd objects):
http://myvariant.info/v1/variant/chr15:g.67358465C%3ET (VariationID: 139214)
http://myvariant.info/v1/variant/chr7:g.107423741C%3ET (VariationID: 55962)
Substitution variant (with only cadd object):
http://myvariant.info/v1/variant/chr1:g.957828A%3EC (CA501146)
Non-substitution variants (type "Duplication"):
http://myvariant.info/v1/variant/chr7:g.117232396dupA (VariationID: 7185)
http://myvariant.info/v1/variant/chr7:g.117171091_117171093dupCTA (VariationID: 53905)
Non-substitution variants (type "Deletion"):
http://myvariant.info/v1/variant/chr7:g.117188858del (VariationID: 53237)
http://myvariant.info/v1/variant/chr7:g.117182115_117182121del (VariationID: 53205)
Non-substitution variants (type "Insertion"):
http://myvariant.info/v1/variant/chr7:g.117175364_117175365insT (VariationID: 54032)
Non-substitution variants (type "Indel"):
http://myvariant.info/v1/variant/chr7:g.117120152_117120270del119ins299 (VariationID: 53981)
2. For any ClinVar IDs that don't have any ExAC data in the myvariant.info response or are non-substitution variants, click on the **ExAC** linkout and expect to be taken to the corresponding ExAC Region pages showing coverage data.

**Steps to test #874:**
1. Use the following example ClinVar IDs to test the **ExAC** population data table in the VCI's Population tab:
17591
139215
11831
2. Expect to see the population rows in the **ExAC** population data table to be sorted by descending "Allele Frequency"

**Steps to test #987:**
1. Start a new interpretation in VCI and click on the **Case/Segregation** tab.
2. Go to the last section of this tab, which is the **Reputable source** panel.
3. Expect to see the 2 selection dropdowns, the free text field and the _Save_ button all to be disabled.
4. Mouse over the 2 selection dropdowns and expect to see the tooltips to be displayed with a message in regards to the criteria.