### PR TITLE
Changes and fixes for R12 release candidate 1

### DIFF
--- a/src/clincoded/static/components/errors.js
+++ b/src/clincoded/static/components/errors.js
@@ -81,9 +81,6 @@ export class LoginDenied extends Component {
                     <div className="row">
                         <div className="col-sm-12">
                             <div className="page-header"><h1><i className="icon icon-exclamation-triangle"></i> Registration not yet complete</h1></div>
-                            <div className="alert alert-info">
-                                <span>If you do not wish to continue registering for the interfaces but want to explore a demo version of the interfaces, you may select the "Demo Login" button located at <a href="https://curation-test.clinicalgenome.org" target="_blank" rel="noopener noreferrer">curation-test.clinicalgenome.org</a>. Your name will display as "ClinGen Test Curator" in the interfaces, along with others who use the "Demo Login."</span>
-                            </div>
                             <div className="panel panel-default">
                                 <div className="panel-body">
                                     <p>If you wish to continue registering your own account and display name, please follow the instructions below:</p>
@@ -96,13 +93,16 @@ export class LoginDenied extends Component {
                                         <li>Intended use of ClinGen interface(s) -- select all that apply:
                                             <ol>
                                                 <li>ClinGen curation activity</li>
-                                                <li>Non-ClinGen variant curation (please note the Variant Curation Interface is open for public use but the Gene Curation Interface is currently restricted to use by ClinGen curators – contact ClinGen if you wish to collaborate on gene curation)</li>
+                                                <li>Non-ClinGen variant curation (please note the Variant Curation Interface is open for public use but the Gene Curation Interface is currently restricted to use by ClinGen curators – contact ClinGen at <a href='mailto:clingen@clinicalgenome.org'>clingen@clinicalgenome.org <i className="icon icon-envelope"></i></a> if you wish to collaborate on gene curation)</li>
                                                 <li>Demo only exploration of the interfaces using test data and your own account and display name</li>
                                             </ol>
                                         </li>
                                     </ol>
                                     <p>Please contact us with any questions regarding registration at <a href='mailto:clingen-helpdesk@lists.stanford.edu'>clingen-helpdesk@lists.stanford.edu <i className="icon icon-envelope"></i></a></p>
                                 </div>
+                            </div>
+                            <div className="alert alert-info">
+                                <span>If you do not wish to continue registering for the interfaces but want to explore a demo version of the interfaces, you may select the "Demo Login" button located at <a href="https://curation-test.clinicalgenome.org" target="_blank" rel="noopener noreferrer">curation-test.clinicalgenome.org</a>. Your name will display as "ClinGen Test Curator" in the interfaces, along with others who use the "Demo Login."</span>
                             </div>
                         </div>
                     </div>
@@ -126,8 +126,8 @@ export class LoginNotVerified extends Component {
                             <div className="page-header"><h1><i className="icon icon-exclamation-triangle"></i> Auth0 account not yet verified</h1></div>
                             <div className="panel panel-default">
                                 <div className="panel-body">
-                                    <p>Once you have created an account with Auth0, you must verify it via email - please check your inbox for an email from Auth0 and verify it according to their instructions.</p>
-                                    <p>Additionally, the same email you use for Auth0 must be registered for use with the interfaces. If you have not yet registered your email for the ClinGen interfaces, please send an email to <a href='mailto:clingen-helpdesk@lists.stanford.edu'>clingen-helpdesk@lists.stanford.edu <i className="icon icon-envelope"></i></a>, supplying the email you used for your Auth0 account and your preferred display name within the interfaces.</p>
+                                    <p>Auth0 account activation requires email verification - please check your inbox for an email from Auth0 and verify it according to their instructions.</p>
+                                    <p>Once you have completed Auth0 account activation you must also register to use the ClinGen interfaces. To complete your registration please send the email address you verified with Auth0 and your preferred display name within the interfaces to <a href='mailto:clingen-helpdesk@lists.stanford.edu'>clingen-helpdesk@lists.stanford.edu <i className="icon icon-envelope"></i></a></p>
                                     <p>Please note that access to the ClinGen interfaces is currently restricted to ClinGen curators.</p>
                                 </div>
                             </div>

--- a/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
+++ b/src/clincoded/static/components/variant_central/helpers/hgvs_notation.js
@@ -40,12 +40,27 @@ export function getHgvsNotation(variant, assembly, omitChrString) {
     }
 
     /**
-     * Handle 'deletion' genomic GRCh38 HGVS
+     * Handle 'deletion' genomic GRCh38 HGVS (compliant with VEP)
      * The ensembl vep/human rest api only accepts the identifier up to the 'del' marker
      * in the hgvs string, such as in 'chr7:g.117120152_117120270del119ins299'
+     * 
+     * Also handle 'deletion' genomic GRCh37 HGVS (compliant with myvariant.info)
+     * The myvariant.info api only accepts the identifier up to the 'del' marker
+     * if the 'variationType' is 'Deletion' (e.g. 'chr7:g.117188858delG').
+     * However, myvariant.info would accept the entire HGVS string if
+     * the 'variationType' is 'Indel' (e.g. 'chr7:g.117120152_117120270del119ins299'),
+     * or 'Insertion' (e.g. 'chr7:g.117175364_117175365insT').
      */
-    if (hgvs && hgvs.indexOf('del') > 0 && assembly === 'GRCh38') {
-        hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
+    if (assembly === 'GRCh38') {
+        if (hgvs && hgvs.indexOf('del') > 0) {
+            hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
+        }
+    } else if (assembly === 'GRCh37') {
+        if (variant.variationType && variant.variationType === 'Deletion') {
+            if (hgvs && hgvs.indexOf('del') > 0) {
+                hgvs = hgvs.substring(0, hgvs.indexOf('del') + 3);
+            }
+        }
     }
 
     return hgvs;

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -430,7 +430,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Or there is no ExAC data object in the return myvariant.info JSON response
             if (!this.state.ext_singleNucleotide || !this.state.hasExacData) {
                 exacLink = external_url_map['ExACRegion'] + chrom + '-' + regionStart + '-' + regionEnd;
-                linkText = 'Search ExAC Region';
+                linkText = 'View the coverage in the ExAC region';
             }
             /*
             if (response.clinvar) {

--- a/src/clincoded/static/scss/clincoded/modules/_modal_disease.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_modal_disease.scss
@@ -29,6 +29,10 @@
                         label {
                             ol {
                                 padding-left: 15px;
+
+                                li {
+                                    margin-top: 10px;
+                                }
                             }
 
                             .required-field {


### PR DESCRIPTION
**Changes and fixes in this PR:**
1. Added spacing in the order list for MonDO disease term search in the disease modal.
2. Updated the instructional text in the Auth0-related error messages.
3. Changed the external linkout text to "View the coverage in the ExAC region" in the ExAC population table when there is no ExAC data available.
4. Fixed the "View the coverage in the ExAC region" external linkout for "Deletion" variation type.