### PR TITLE
Connects to #1461. Changes and fixes for R12 release candidate 2.

### DIFF
--- a/src/clincoded/static/components/errors.js
+++ b/src/clincoded/static/components/errors.js
@@ -93,7 +93,7 @@ export class LoginDenied extends Component {
                                         <li>Intended use of ClinGen interface(s) -- select all that apply:
                                             <ol>
                                                 <li>ClinGen curation activity</li>
-                                                <li>Non-ClinGen variant curation (please note the Variant Curation Interface is open for public use but the Gene Curation Interface is currently restricted to use by ClinGen curators – contact ClinGen at <a href='mailto:clingen@clinicalgenome.org'>clingen@clinicalgenome.org <i className="icon icon-envelope"></i></a> if you wish to collaborate on gene curation)</li>
+                                                <li>Non-ClinGen variant curation (note: the Variant Curation Interface is open for public use but the Gene Curation Interface is currently restricted to use by ClinGen curators. If you wish to collaborate on gene curation please contact ClinGen at <a href='mailto:clingen@clinicalgenome.org'>clingen@clinicalgenome.org <i className="icon icon-envelope"></i></a>)</li>
                                                 <li>Demo only exploration of the interfaces using test data and your own account and display name</li>
                                             </ol>
                                         </li>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -430,7 +430,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             // Or there is no ExAC data object in the return myvariant.info JSON response
             if (!this.state.ext_singleNucleotide || !this.state.hasExacData) {
                 exacLink = external_url_map['ExACRegion'] + chrom + '-' + regionStart + '-' + regionEnd;
-                linkText = 'View the coverage in the ExAC region';
+                linkText = 'View the coverage of this region (+/- 30 bp) in ExAC';
             }
             /*
             if (response.clinvar) {

--- a/src/clincoded/static/scss/clincoded/modules/_modal_disease.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_modal_disease.scss
@@ -31,7 +31,9 @@
                                 padding-left: 15px;
 
                                 li {
+                                    display: list-item;
                                     margin-top: 10px;
+                                    padding: 0
                                 }
                             }
 


### PR DESCRIPTION
**Technical notes:**
1. Fixed list items' display issue in the disease modal when we are in the Group, Family, Individual and Case-Control curation forms.
2. Updated the instructional text in the Auth0-related error messages.

**Steps to test #1461:**
1. Create a new Group/Family/Individual/Case-Control curation in GCI.
2. Click on the add disease button (e.g. **"Disease+"**) to invoke the disease modal.
3. Expect to see the MonDO disease term search list item being displayed as the following:
![image](https://user-images.githubusercontent.com/6956310/29895958-f5e12304-8d8f-11e7-938f-91bff1f6d472.png)