### PR TITLE
update fix for postgres for prod

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -95,10 +95,7 @@ runcmd:
 - sudo echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 - sudo apt-get update
-- if test "%(ROLE)s" = "demo"
-- then
--   sudo mv /etc/postgresql/9.4/main/recovery.conf /etc/postgresql/9.4/main/recovery-demo.conf
-- fi
+- sudo mv /etc/postgresql/9.4/main/recovery.conf /etc/postgresql/9.4/main/recovery-demo.conf
 - sudo apt-get -y install postgresql-9.4
 - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 - sudo apt-get install -y nodejs
@@ -131,10 +128,6 @@ runcmd:
 - if test "%(BACKUPDB)s" = "s3_data"
 - then
 -   echo "====== restoring data from backup"
--   if test "%(ROLE)s" != "demo"
--     then
--       sudo mv /etc/postgresql/9.4/main/recovery.conf /etc/postgresql/9.4/main/recovery-demo.conf
--   fi
 -   /etc/init.d/postgresql stop
 -   sudo -u postgres /opt/wal-e/bin/wal-e --aws-instance-profile --s3-prefix="$(cat /etc/postgresql/9.4/main/wale_s3_prefix | tr -d "\n")" backup-fetch /var/lib/postgresql/9.4/main LATEST
 -   sudo -u postgres ln -s /etc/postgresql/9.4/main/recovery-demo.conf /var/lib/postgresql/9.4/main/recovery.conf


### PR DESCRIPTION
Fixes Postgres issue by changing the recovery file name out right regardless of what type of instance is built. This will allow production to be built.