### PR TITLE
Connects to #1501. Connects to #1503. Evidence Summary fixes.

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1342,15 +1342,15 @@ function GroupPower(groupType) {
             }
             ****/}
             <Input type="number" inputClassName="integer-only" ref={numGroupVariant} label={'Number of ' + type + 's with variant(s) in the gene in question:'}
-                value={group && group.numberWithVariant ? group.numberWithVariant : ''}
+                value={group && typeof group.numberWithVariant === 'number' ? group.numberWithVariant : ''}
                 error={this.getFormError(numGroupVariant)} clearError={this.clrFormErrors.bind(null, numGroupVariant)} placeholder="Number only"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="number" inputClassName="integer-only" ref={numGroupGenotyped} label={'Number of all ' + type + 's genotyped/sequenced:'}
-                value={group && group.numberAllGenotypedSequenced ? group.numberAllGenotypedSequenced : ''}
+                value={group && typeof group.numberAllGenotypedSequenced === 'number' ? group.numberAllGenotypedSequenced : ''}
                 error={this.getFormError(numGroupGenotyped)} clearError={this.clrFormErrors.bind(null, numGroupGenotyped)} placeholder="Number only"
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <Input type="number" ref={calcAlleleFreq} label={type + ' Allele Frequency:'} handleChange={this.handleChange}
-                value={group && group.alleleFrequency ? group.alleleFrequency : ''}
+                value={group && typeof group.alleleFrequency === 'number' ? group.alleleFrequency : ''}
                 error={this.getFormError(calcAlleleFreq)} clearError={this.clrFormErrors.bind(null, calcAlleleFreq)}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" placeholder="Number only" />
         </div>

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -47,14 +47,14 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                     {evidence.comments}
                 </td>
                 <td className="evidence-statistics-case-cohort-numberWithVariant">
-                    {evidence.caseCohort_numberWithVariant ? evidence.caseCohort_numberWithVariant : null}
-                    {evidence.caseCohort_numberWithVariant && evidence.caseCohort_numberAllGenotypedSequenced ? <span>/</span> : null}
-                    {evidence.caseCohort_numberAllGenotypedSequenced ? evidence.caseCohort_numberAllGenotypedSequenced : null}
+                    {typeof evidence.caseCohort_numberWithVariant === 'number' ? evidence.caseCohort_numberWithVariant : null}
+                    {typeof evidence.caseCohort_numberWithVariant === 'number' && evidence.caseCohort_numberAllGenotypedSequenced ? <span>/</span> : null}
+                    {typeof evidence.caseCohort_numberAllGenotypedSequenced === 'number' ? evidence.caseCohort_numberAllGenotypedSequenced : null}
                 </td>
                 <td className="evidence-statistics-control-cohort-numberWithVariant">
-                    {evidence.controlCohort_numberWithVariant ? evidence.controlCohort_numberWithVariant : null}
-                    {evidence.controlCohort_numberWithVariant && evidence.controlCohort_numberAllGenotypedSequenced ? <span>/</span> : null}
-                    {evidence.controlCohort_numberAllGenotypedSequenced ? evidence.controlCohort_numberAllGenotypedSequenced : null}
+                    {typeof evidence.controlCohort_numberWithVariant === 'number' ? evidence.controlCohort_numberWithVariant : null}
+                    {typeof evidence.controlCohort_numberWithVariant === 'number' && typeof evidence.controlCohort_numberAllGenotypedSequenced === 'number' ? <span>/</span> : null}
+                    {typeof evidence.controlCohort_numberAllGenotypedSequenced === 'number' ? evidence.controlCohort_numberAllGenotypedSequenced : null}
                 </td>
                 <td className="evidence-statistics-value">
                     {evidence.statisticValueType ? <strong>{evidence.statisticValueType}: </strong> : null}
@@ -124,7 +124,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                                     <th colSpan="2">Power</th>
                                     <th rowSpan="2">Bias confounding</th>
                                     <th colSpan="5">Statistics</th>
-                                    <th rowSpan="2">Score</th>
+                                    <th rowSpan="2">Points</th>
                                 </tr>
                                 <tr>
                                     <th># of cases genotyped/sequenced</th>
@@ -141,7 +141,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                                     return (self.renderCaseControlEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="12" className="total-score-label">Total score:</td>
+                                    <td colSpan="12" className="total-score-label">Total points:</td>
                                     <td className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -8,10 +8,15 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
         super(props);
         this.state = {
             caseControlEvidenceList: this.props.caseControlEvidenceList,
-            hpoTermList: this.props.hpoTermList
+            hpoTermList: this.props.hpoTermList,
+            mounted: false
         };
     }
 
+    componentDidMount() {
+        this.setState({mounted: true});
+    }
+    /*
     componentWillReceiveProps(nextProps) {
         if (nextProps.caseControlEvidenceList) {
             this.setState({caseControlEvidenceList: nextProps.caseControlEvidenceList});
@@ -20,7 +25,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
             this.setState({hpoTermList: nextProps.hpoTermList});
         }
     }
-
+    */
     /**
      * Method to render individual table row of the logged-in user's scored evidence
      * @param {object} evidence - scored evidence and its associated case-control evidence
@@ -34,7 +39,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                 </td>
                 <td className="evidence-disease">
                     <span>{evidence.diseaseTerm}
-                        <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span> : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span>({this.state.hpoTermList.join(', ')})</span> : null)}</span>
+                        <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span> : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span>({this.props.hpoTermList.join(', ')})</span> : null)}</span>
                     </span>
                 </td>
                 <td className="evidence-study-type">
@@ -109,8 +114,8 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     }
 
     render() {
-        const caseControlEvidenceList = this.state.caseControlEvidenceList;
-        let sortedEvidenceList = this.sortListbyColName(caseControlEvidenceList, 'studyType');
+        const caseControlEvidenceList = this.props.caseControlEvidenceList;
+        let sortedEvidenceList = this.state.mounted ? this.sortListbyColName(caseControlEvidenceList, 'studyType') : caseControlEvidenceList;
         let self = this;
 
         return (

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -7,8 +7,6 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            caseControlEvidenceList: this.props.caseControlEvidenceList,
-            hpoTermList: this.props.hpoTermList,
             mounted: false
         };
     }
@@ -16,16 +14,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     componentDidMount() {
         this.setState({mounted: true});
     }
-    /*
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.caseControlEvidenceList) {
-            this.setState({caseControlEvidenceList: nextProps.caseControlEvidenceList});
-        }
-        if (nextProps.hpoTermList && nextProps.hpoTermList.length) {
-            this.setState({hpoTermList: nextProps.hpoTermList});
-        }
-    }
-    */
+
     /**
      * Method to render individual table row of the logged-in user's scored evidence
      * @param {object} evidence - scored evidence and its associated case-control evidence

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -7,18 +7,12 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            caseLevelEvidenceList: this.props.caseLevelEvidenceList,
-            hpoTermList: this.props.hpoTermList
+            mounted: false
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.caseLevelEvidenceList) {
-            this.setState({caseLevelEvidenceList: nextProps.caseLevelEvidenceList});
-        }
-        if (nextProps.hpoTermList && nextProps.hpoTermList.length) {
-            this.setState({hpoTermList: nextProps.hpoTermList});
-        }
+    componentDidMount() {
+        this.setState({mounted: true});
     }
 
     /**
@@ -58,7 +52,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                     {evidence.ethnicity}
                 </td>
                 <td className="evidence-phenotypes">
-                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.state.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
                 <td className="evidence-segregation-num-affected">
@@ -139,8 +133,8 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
     }
 
     render() {
-        const caseLevelEvidenceList = this.state.caseLevelEvidenceList;
-        let sortedEvidenceList = this.sortListbyColName(caseLevelEvidenceList, 'variantType');
+        const caseLevelEvidenceList = this.props.caseLevelEvidenceList;
+        let sortedEvidenceList = this.state.mounted ? this.sortListbyColName(caseLevelEvidenceList, 'variantType') : caseLevelEvidenceList;
         let self = this;
 
         return (

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -158,7 +158,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     <th rowSpan="2">Proband previous testing</th>
                                     <th rowSpan="2">Proband methods of detection</th>
                                     <th rowSpan="2">Score status</th>
-                                    <th rowSpan="2">Proband score (default)</th>
+                                    <th rowSpan="2">Proband points (default points)</th>
                                     <th rowSpan="2">Reason for changed score</th>
                                 </tr>
                                 <tr>
@@ -173,7 +173,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     return (self.renderCaseLevelEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="14" className="total-score-label">Total score:</td>
+                                    <td colSpan="14" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -116,7 +116,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                                     return (self.renderSegregationEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="5" className="total-score-label">Total score:</td>
+                                    <td colSpan="5" className="total-score-label">Total LOD score:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -7,18 +7,12 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            segregationEvidenceList: this.props.segregationEvidenceList,
-            hpoTermList: this.props.hpoTermList
+            mounted: false
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.segregationEvidenceList) {
-            this.setState({segregationEvidenceList: nextProps.segregationEvidenceList});
-        }
-        if (nextProps.hpoTermList && nextProps.hpoTermList.length) {
-            this.setState({hpoTermList: nextProps.hpoTermList});
-        }
+    componentDidMount() {
+        this.setState({mounted: true});
     }
 
     /**
@@ -36,7 +30,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                     {evidence.ethnicity}
                 </td>
                 <td className="evidence-phenotypes">
-                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.state.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
                 <td className="evidence-segregation-num-affected">
@@ -94,8 +88,8 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
     }
 
     render() {
-        const segregationEvidenceList = this.state.segregationEvidenceList;
-        let sortedEvidenceList = this.sortListbyColName(segregationEvidenceList);
+        const segregationEvidenceList = this.props.segregationEvidenceList;
+        let sortedEvidenceList = this.state.mounted ? this.sortListbyColName(segregationEvidenceList) : segregationEvidenceList;
         let self = this;
 
         return (

--- a/src/clincoded/static/components/gene_disease_summary/experimental.js
+++ b/src/clincoded/static/components/gene_disease_summary/experimental.js
@@ -7,14 +7,12 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            experimentalEvidenceList: this.props.experimentalEvidenceList
+            mounted: false
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.experimentalEvidenceList) {
-            this.setState({experimentalEvidenceList: nextProps.experimentalEvidenceList});
-        }
+    componentDidMount() {
+        this.setState({mounted: true});
     }
 
     /**
@@ -80,8 +78,8 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
     }
 
     render() {
-        const experimentalEvidenceList = this.state.experimentalEvidenceList;
-        let sortedEvidenceList = this.sortListbyColName(experimentalEvidenceList, 'evidenceType');
+        const experimentalEvidenceList = this.props.experimentalEvidenceList;
+        let sortedEvidenceList = this.state.mounted ? this.sortListbyColName(experimentalEvidenceList, 'evidenceType') : experimentalEvidenceList;
         let self = this;
 
         return (

--- a/src/clincoded/static/components/gene_disease_summary/experimental.js
+++ b/src/clincoded/static/components/gene_disease_summary/experimental.js
@@ -96,7 +96,7 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
                                     <th>Reference</th>
                                     <th>Explanation</th>
                                     <th>Score status</th>
-                                    <th>Score (default score)</th>
+                                    <th>Points (default points)</th>
                                     <th>Reason for changed score</th>
                                 </tr>
                             </thead>
@@ -105,7 +105,7 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
                                     return (self.renderExperimentalEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="4" className="total-score-label">Total score:</td>
+                                    <td colSpan="4" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/header.js
+++ b/src/clincoded/static/components/gene_disease_summary/header.js
@@ -61,7 +61,7 @@ class GeneDiseaseEvidenceSummaryHeader extends Component {
                             {provisional ?
                                 <div>
                                     <dt>Date classification saved:</dt>
-                                    <dd className="classificationSaved">{provisional ? moment(provisional.last_modified).format("YYYY MMM DD, h:mm a") : null}</dd>
+                                    <dd className="classificationSaved">{provisional.last_modified ? moment(provisional.last_modified).format("YYYY MMM DD, h:mm a") : null}</dd>
                                 </div>
                                 : null}
                             <dt>Disease:</dt>

--- a/src/clincoded/static/components/gene_disease_summary/header.js
+++ b/src/clincoded/static/components/gene_disease_summary/header.js
@@ -7,24 +7,10 @@ import { external_url_map } from '../globals';
 class GeneDiseaseEvidenceSummaryHeader extends Component {
     constructor(props) {
         super(props);
-        this.state = {
-            gdm: this.props.gdm,
-            provisional: this.props.provisional
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.gdm) {
-            this.setState({gdm: nextProps.gdm});
-        }
-        if (nextProps.provisional) {
-            this.setState({provisional: nextProps.provisional});
-        }
     }
 
     render() {
-        const gdm = this.state.gdm;
-        const provisional = this.state.provisional;
+        const { gdm, provisional } = this.props;
         // Expecting the required fields of a GDM to always have values:
         // e.g. gene, disease, mode of inheritance
         const gene = gdm && gdm.gene, disease = gdm && gdm.disease;

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -638,7 +638,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
      * @param {*} e - Window event
      */
     handleWindowClose(e) {
-        e.preventDefault(e);
+        e.preventDefault();
         window.close();
     },
 
@@ -647,7 +647,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
      * @param {*} e - Window event
      */
     handlePrintPDF(e) {
-        e.preventDefault(e);
+        e.preventDefault();
         window.print();
     },
 

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -638,7 +638,6 @@ const GeneDiseaseEvidenceSummary = createReactClass({
      * @param {*} e - Window event
      */
     handleWindowClose(e) {
-        e.preventDefault();
         window.close();
     },
 
@@ -647,7 +646,6 @@ const GeneDiseaseEvidenceSummary = createReactClass({
      * @param {*} e - Window event
      */
     handlePrintPDF(e) {
-        e.preventDefault();
         window.print();
     },
 

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -429,10 +429,10 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                             caseControlEvidence['pubYear'] = pubDate[1];
                                             caseControlEvidence['studyType'] = caseControl.studyType ? caseControl.studyType : '';
                                             caseControlEvidence['detectionMethod'] = caseControl.caseCohort && caseControl.caseCohort.method ? caseControl.caseCohort.method.specificMutationsGenotypedMethod : '';
-                                            caseControlEvidence['caseCohort_numberWithVariant'] = caseControl.caseCohort.numberWithVariant ? caseControl.caseCohort.numberWithVariant : null;
-                                            caseControlEvidence['caseCohort_numberAllGenotypedSequenced'] = caseControl.caseCohort.numberAllGenotypedSequenced ? caseControl.caseCohort.numberAllGenotypedSequenced : null;
-                                            caseControlEvidence['controlCohort_numberWithVariant'] = caseControl.controlCohort.numberWithVariant ? caseControl.controlCohort.numberWithVariant : null;
-                                            caseControlEvidence['controlCohort_numberAllGenotypedSequenced'] = caseControl.controlCohort.numberAllGenotypedSequenced ? caseControl.controlCohort.numberAllGenotypedSequenced : null;
+                                            caseControlEvidence['caseCohort_numberWithVariant'] = typeof caseControl.caseCohort.numberWithVariant === 'number' ? caseControl.caseCohort.numberWithVariant : null;
+                                            caseControlEvidence['caseCohort_numberAllGenotypedSequenced'] = typeof caseControl.caseCohort.numberAllGenotypedSequenced === 'number' ? caseControl.caseCohort.numberAllGenotypedSequenced : null;
+                                            caseControlEvidence['controlCohort_numberWithVariant'] = typeof caseControl.controlCohort.numberWithVariant === 'number' ? caseControl.controlCohort.numberWithVariant : null;
+                                            caseControlEvidence['controlCohort_numberAllGenotypedSequenced'] = typeof caseControl.controlCohort.numberAllGenotypedSequenced === 'number' ? caseControl.controlCohort.numberAllGenotypedSequenced : null;
                                             caseControlEvidence['comments'] = caseControl.comments ? caseControl.comments : '';
                                             caseControlEvidence['explanationForDifference'] = caseControl.explanationForDifference ? caseControl.explanationForDifference : '';
                                             caseControlEvidence['statisticValueType'] = caseControl.statisticalValues[0].valueType ? caseControl.statisticalValues[0].valueType : '';

--- a/src/clincoded/static/components/provisional_classification/index.js
+++ b/src/clincoded/static/components/provisional_classification/index.js
@@ -489,7 +489,7 @@ const ProvisionalClassification = createReactClass({
     },
 
     viewEvidenceSummary(e) {
-        window.location.href = '/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid;
+        window.open('/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid, '_blank');
     },
 
     render() {

--- a/src/clincoded/static/components/provisional_classification/index.js
+++ b/src/clincoded/static/components/provisional_classification/index.js
@@ -489,7 +489,7 @@ const ProvisionalClassification = createReactClass({
     },
 
     viewEvidenceSummary(e) {
-        window.open('/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid, '_blank');
+        window.open('/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid);
     },
 
     render() {

--- a/src/clincoded/static/components/provisional_classification/index.js
+++ b/src/clincoded/static/components/provisional_classification/index.js
@@ -489,7 +489,7 @@ const ProvisionalClassification = createReactClass({
     },
 
     viewEvidenceSummary(e) {
-        window.open('/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid);
+        window.location.href = '/gene-disease-evidence-summary/?gdm=' + this.state.gdm.uuid;
     },
 
     render() {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -1065,31 +1065,11 @@
             }
 
             input[type="checkbox"] {
+                font-size: 30px;
                 margin-top: 0;
                 position: relative;
-                top: 3px;
+                top: 5px;
                 left: -15px;
-                visibility: hidden;
-
-                &:after,
-                &:checked:after {
-                    font-family: FontAwesome;
-                    font-size: 120%;
-                    display: inline-block;
-                    visibility: visible;
-                }
-
-                &:after {
-                    content: "\f096";
-                }
-
-                &:checked:after {
-                    content: "\f14a";
-                }
-
-                &[disabled] {
-                    color: #bbb;
-                }
             }
         }
 


### PR DESCRIPTION
**Technical notes:**
1. Firefox browser is required to test a CSS bug associated with the checkbox for marking classification "Provisional".
2. A timezone change (to East Coast time) is required to test the rendering bug associated with the Evidence Summary page.

**Steps to test 1501:**
1. Create a new GDM.
2. Add 2-3 PMIDs to the GDM.
3. For each PMID in the GDM, add various types of evidence and score each one of them. For testing purpose, please have at least 3 scored proband evidence (with or without segregation), 2 segregation evidence without probands but with LOD scores, 2 scored case-control evidence, and 3 scored experimental evidence.
4. Upon having the minimum set of evidence added and scored, click the "View Classification Matrix" button at the upper right hand corner and expect to be taken to the Classification Matrix page consisting of the score matrix and the classification form group.
5. In the Classification form group, expect to see be able to see the checkbox for marking classification "Provisional" in _Firefox_, _Chrome_, _Safari_ and _IE_.
6. Select and fill out all 4 form inputs (including the "Evidence Summary") and click on the "Save" button.
7. Then expect to be taken to the non-editable Classification Matrix page consisting of the score matrix and view-only classification information filled out on the previous page.
8. Now temporarily change your computer's timezone to East Coast time.
9. Click on the "View Evidence Summary" button at the bottom of the page and expect to be taken to a new window/tab consisting of the Evidence Summary.
10. Expect to see your evidence data being rendering in the corresponding tables.
11. Then change the computer's timezone back to West Coast time.
12. Refresh the Evidence Summary page and expect to see the same data shown in the tables.

**Steps to test 1503:**
1. Create a new Case-Control curation and fill out all required fields.
2. Under the **Power** section, enter **"0"** value in the **Number of Cases with variant(s) in the gene in question** or the **Number of all Cases genotyped/sequenced** fields.
3. Save the curation form and return to it via **"Edit"**.
4. Expect to see the **"0"** value being shown in the fields.