### PR TITLE
Connects to #1532. Connects to #1531.

### DIFF
--- a/src/clincoded/static/components/provisional_classification/index.js
+++ b/src/clincoded/static/components/provisional_classification/index.js
@@ -409,21 +409,7 @@ const ProvisionalClassification = createReactClass({
             scoreTableValues['segregationPointsCounted'] = 2.5;
         } else if (scoreTableValues['segregationPoints'] >= 1.5 && scoreTableValues['segregationPoints'] <= 1.74) {
             scoreTableValues['segregationPointsCounted'] = 3;
-        } else if (scoreTableValues['segregationPoints'] >= 1.75 && scoreTableValues['segregationPoints'] <= 1.99) {
-            scoreTableValues['segregationPointsCounted'] = 3.5;
-        } else if (scoreTableValues['segregationPoints'] >= 2 && scoreTableValues['segregationPoints'] <= 2.49) {
-            scoreTableValues['segregationPointsCounted'] = 4;
-        } else if (scoreTableValues['segregationPoints'] >= 2.5 && scoreTableValues['segregationPoints'] <= 2.99) {
-            scoreTableValues['segregationPointsCounted'] = 4.5;
-        } else if (scoreTableValues['segregationPoints'] >= 3 && scoreTableValues['segregationPoints'] <= 3.49) {
-            scoreTableValues['segregationPointsCounted'] = 5;
-        } else if (scoreTableValues['segregationPoints'] >= 3.5 && scoreTableValues['segregationPoints'] <= 3.99) {
-            scoreTableValues['segregationPointsCounted'] = 5.5;
-        } else if (scoreTableValues['segregationPoints'] >= 4 && scoreTableValues['segregationPoints'] <= 4.49) {
-            scoreTableValues['segregationPointsCounted'] = 6;
-        } else if (scoreTableValues['segregationPoints'] >= 4.5 && scoreTableValues['segregationPoints'] <= 4.99) {
-            scoreTableValues['segregationPointsCounted'] = 6.5;
-        } else if (scoreTableValues['segregationPoints'] >= 5) {
+        } else if (scoreTableValues['segregationPoints'] >= 1.75) {
             scoreTableValues['segregationPointsCounted'] = MAX_SCORE_CONSTANTS.SEGREGATION;
         }
 

--- a/src/clincoded/static/components/provisional_classification/index.js
+++ b/src/clincoded/static/components/provisional_classification/index.js
@@ -207,7 +207,7 @@ const ProvisionalClassification = createReactClass({
             PREDICTED_OR_PROVEN_NULL_VARIANT: 10,
             OTHER_VARIANT_TYPE_WITH_GENE_IMPACT: 7,
             AUTOSOMAL_RECESSIVE: 12,
-            SEGREGATION: 7,
+            SEGREGATION: 3,
             CASE_CONTROL: 12,
             FUNCTIONAL: 2,
             FUNCTIONAL_ALTERATION: 2,

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -560,21 +560,7 @@ var ProvisionalCuration = createReactClass({
             scoreTableValues['segregationPointsCounted'] = 2.5;
         } else if (scoreTableValues['segregationPoints'] >= 1.5 && scoreTableValues['segregationPoints'] <= 1.74) {
             scoreTableValues['segregationPointsCounted'] = 3;
-        } else if (scoreTableValues['segregationPoints'] >= 1.75 && scoreTableValues['segregationPoints'] <= 1.99) {
-            scoreTableValues['segregationPointsCounted'] = 3.5;
-        } else if (scoreTableValues['segregationPoints'] >= 2 && scoreTableValues['segregationPoints'] <= 2.49) {
-            scoreTableValues['segregationPointsCounted'] = 4;
-        } else if (scoreTableValues['segregationPoints'] >= 2.5 && scoreTableValues['segregationPoints'] <= 2.99) {
-            scoreTableValues['segregationPointsCounted'] = 4.5;
-        } else if (scoreTableValues['segregationPoints'] >= 3 && scoreTableValues['segregationPoints'] <= 3.49) {
-            scoreTableValues['segregationPointsCounted'] = 5;
-        } else if (scoreTableValues['segregationPoints'] >= 3.5 && scoreTableValues['segregationPoints'] <= 3.99) {
-            scoreTableValues['segregationPointsCounted'] = 5.5;
-        } else if (scoreTableValues['segregationPoints'] >= 4 && scoreTableValues['segregationPoints'] <= 4.49) {
-            scoreTableValues['segregationPointsCounted'] = 6;
-        } else if (scoreTableValues['segregationPoints'] >= 4.5 && scoreTableValues['segregationPoints'] <= 4.99) {
-            scoreTableValues['segregationPointsCounted'] = 6.5;
-        } else if (scoreTableValues['segregationPoints'] >= 5) {
+        } else if (scoreTableValues['segregationPoints'] >= 1.75) {
             scoreTableValues['segregationPointsCounted'] = MAX_SCORE_CONSTANTS.SEGREGATION;
         }
 

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -358,7 +358,7 @@ var ProvisionalCuration = createReactClass({
             PREDICTED_OR_PROVEN_NULL_VARIANT: 10,
             OTHER_VARIANT_TYPE_WITH_GENE_IMPACT: 7,
             AUTOSOMAL_RECESSIVE: 12,
-            SEGREGATION: 7,
+            SEGREGATION: 3,
             CASE_CONTROL: 12,
             FUNCTIONAL: 2,
             FUNCTIONAL_ALTERATION: 2,

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -95,7 +95,7 @@ var VariantCurationHub = createReactClass({
             this.setState({variantObj: response});
             // ping out external resources (all async)
             this.fetchClinVarEutils(this.state.variantObj);
-            this.fetchPageData(this.state.variantObj);
+            // this.fetchPageData(this.state.variantObj); // Temporarily suppressing PAGE data table display until service api access issue is resolved
             this.fetchMyVariantInfo(this.state.variantObj);
             this.fetchEnsemblVariation(this.state.variantObj);
             this.fetchEnsemblHGVSVEP(this.state.variantObj);

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -960,6 +960,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             </div>
                         }
                     </div>
+                    {/* Temporarily suppressing PAGE data table display until service api access issue is resolved
                     <div className="panel panel-info datasource-PAGE">
                         <div className="panel-heading">
                             {this.renderPageHeader(this.state.hasPageData, this.state.loading_pageData, pageVariant, singleNucleotide)}
@@ -1000,6 +1001,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             }
                         </div>
                     </div>
+                    */}
                     <div className="panel panel-info datasource-1000G">
                         <div className="panel-heading">
                             {this.renderTGenomesHeader(this.state.hasTGenomesData, this.state.loading_ensemblVariation, tGenomes, singleNucleotide)}


### PR DESCRIPTION
**Steps to test #1532:**
1. From the VCI variant selection interface, choose the ClinVar **139214** ID and proceed to the evidence-only view.
2. Click on the **Population** tab and _expect_ to see the display of the PAGE data table being suppressed.

**Steps to test #1531:**
1. In a new or existing GDM, create a new Family evidence curation and fill out the _required_ fields.
2. Select "Yes" for the **Published LOD score?:** option.
3. Enter "1.75" in the **Published Calculated LOD score:** input field.
4. Select "Yes" for the **Include LOD score in final aggregate calculation?** option.
5. Save the form without entering any proband information.
6. Return to Curation Central and click on the **View Classification Matrix** button at the upper right hand corner.
7. On the subsequent page, expect to see the _Segregation_ total points counted being maxed out at 3 in the matrix.
![image](https://user-images.githubusercontent.com/6956310/32638153-a507259e-c572-11e7-9679-dcc2d02b5483.png)
8. Expect to see the same behavior on the subsequent page upon clicking the _**Save**_ button at the bottom.