### PR TITLE
Connects to #1538. Removal of PAGE data attribution and updated help docs.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -1091,7 +1091,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     <CompleteSection interpretation={this.state.interpretation} tabName="population" updateInterpretationObj={this.props.updateInterpretationObj} />
                 : null}
 
-                {renderDataCredit('pagestudy')}
+                {/* renderDataCredit('pagestudy') */}
 
                 {renderDataCredit('myvariant')}
 


### PR DESCRIPTION
**Steps to test:**
1. In the VCI's variant selection interface, choose the ClinVar **139214** ID and proceed to the evidence-only view.
2. Click on the **Population** tab and expect to see the PAGE data attribution text being removed from the bottom of the tab.
3. From the **Help** dropdown in the top nav, select either the **Gene Curation** or **Variant Curation** options.
4. Expect to see the updated MONDO disease lookup section in these docs.