### PR TITLE
correct repo language representation on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+
+DEV_TEST_DB_DUMP* linguist-generated=true


### PR DESCRIPTION
@jimmyzhen 
 
Only adds a `.gitattributes` file so that GitHub's language detector will ignore the generated db dumps (currently it mis-identifies these large files as Roff files and therefore the language percentage on the repo is substantially incorrect).

![image](https://user-images.githubusercontent.com/1878194/33637092-d4d43dfa-d9d3-11e7-9fc8-618caadb756f.png)

_Note:_ I am not sure if the overall GitHub language percentage display will be updated when dev is eventually merged to master or if it will display immediately since dev is the default branch.



To test locally
- `gem install github-linguist`
- In the dev branch run
`linguist`
```
93.38%  Roff
4.64%   JavaScript
1.58%   Python
0.35%   CSS
0.04%   Gherkin
0.01%   HTML
0.00%   Shell
0.00%   Ruby
0.00%   Makefile 
```

- In this branch run
`linguist`
```
70.12%  JavaScript
23.79%  Python
5.23%   CSS
0.63%   Gherkin
0.14%   HTML
0.05%   Shell
0.03%   Ruby
0.01%   Makefile
```

_Note:_  If you have have an error installing github-linguist you may need to do this:
 - `brew install cmake`   _a  dependency for the required `rugged` gem_
 - `brew install icu4c`   _a dependency to build the `charlock_holmes` dependency_
 - `gem install rugged`

and if you still see errors (seen in some sierra installations) about charlock_holmes which is another github-linguist dependency:
 - `gem install charlock_holmes -- --with-icu-dir=/usr/local/opt/icu4c --with-cxxflags=\'-Wno-reserved-user-defined-literal -std=c++11\'`


_Note:_ Ruby 2.3 or 2.4 may be required