### PR TITLE
Connects to #1518. Connects to #1540. Connects to #1560. Connects to #1582. 

### DIFF
--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -35,9 +35,16 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                     <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
                 <td className="evidence-disease">
-                    <span>{evidence.diseaseTerm}
-                        <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span> : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span>({this.props.hpoTermList.join(', ')})</span> : null)}</span>
-                    </span>
+                    {evidence.diseaseId && evidence.diseaseTerm ?
+                        <span>{evidence.diseaseTerm}
+                            <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span> : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span>({this.props.hpoTermList.join(', ')})</span> : null)}</span>
+                        </span>
+                        :
+                        <span>
+                            {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                            {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
+                        </span>
+                    }
                 </td>
                 <td className="evidence-study-type">
                     {evidence.studyType}

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -21,10 +21,18 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
      * @param {number} key - unique key
      */
     renderCaseControlEvidence(evidence, key) {
+        let authors;
+        if (evidence.authors && evidence.authors.length) {
+            if (evidence.authors.length > 1) {
+                authors = evidence.authors[0] + ', et al.';
+            } else {
+                authors = evidence.authors[0];
+            }
+        }
         return (
             <tr key={key} className="scored-case-control-evidence">
                 <td className="evidence-reference">
-                    <span>{evidence.authors.join(', ')}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
+                    <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
                 <td className="evidence-disease">
                     <span>{evidence.diseaseTerm}

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -31,6 +31,9 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
         }
         return (
             <tr key={key} className="scored-case-control-evidence">
+                <td className="evidence-label">
+                    {evidence.label}
+                </td>
                 <td className="evidence-reference">
                     <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
@@ -132,6 +135,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                         <table className="table">
                             <thead>
                                 <tr>
+                                    <th rowSpan="2">Label</th>
                                     <th rowSpan="2">Reference (PMID)</th>
                                     <th rowSpan="2">Disease (Case)</th>
                                     <th rowSpan="2">Study type</th>
@@ -156,7 +160,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                                     return (self.renderCaseControlEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="12" className="total-score-label">Total points:</td>
+                                    <td colSpan="13" className="total-score-label">Total points:</td>
                                     <td className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -21,6 +21,14 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
      * @param {number} key - unique key
      */
     renderCaseLevelEvidence(evidence, key) {
+        let authors;
+        if (evidence.authors && evidence.authors.length) {
+            if (evidence.authors.length > 1) {
+                authors = evidence.authors[0] + ', et al.';
+            } else {
+                authors = evidence.authors[0];
+            }
+        }
         return (
             <tr key={key} className="scored-case-level-evidence">
                 <td className="evidence-variant-type">
@@ -40,7 +48,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                     })}
                 </td>
                 <td className="evidence-reference">
-                    <span>{evidence.authors.join(', ')}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
+                    <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
                 <td className="evidence-sex">
                     {evidence.sex}

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -31,6 +31,9 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
         }
         return (
             <tr key={key} className="scored-case-level-evidence">
+                <td className="evidence-label">
+                    {evidence.label}
+                </td>
                 <td className="evidence-variant-type">
                     {evidence.variantType}
                 </td>
@@ -155,6 +158,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                         <table className="table">
                             <thead>
                                 <tr>
+                                    <th rowSpan="2">Label</th>
                                     <th rowSpan="2">Variant type</th>
                                     <th rowSpan="2">Variant</th>
                                     <th rowSpan="2">Reference</th>
@@ -181,7 +185,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     return (self.renderCaseLevelEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="14" className="total-score-label">Total points:</td>
+                                    <td colSpan="15" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -21,10 +21,18 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
      * @param {number} key - unique key
      */
     renderSegregationEvidence(evidence, key) {
+        let authors;
+        if (evidence.authors && evidence.authors.length) {
+            if (evidence.authors.length > 1) {
+                authors = evidence.authors[0] + ', et al.';
+            } else {
+                authors = evidence.authors[0];
+            }
+        }
         return (
             <tr key={key} className="scored-segregation-evidence">
                 <td className="evidence-reference">
-                    <span>{evidence.authors.join(', ')}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
+                    <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
                 <td className="evidence-ethnicity">
                     {evidence.ethnicity}

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -31,6 +31,9 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
         }
         return (
             <tr key={key} className="scored-segregation-evidence">
+                <td className="evidence-label">
+                    {evidence.label}
+                </td>
                 <td className="evidence-reference">
                     <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
@@ -110,6 +113,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                         <table className="table">
                             <thead>
                                 <tr>
+                                    <th>Label</th>
                                     <th>Reference</th>
                                     <th>Family ethnicity</th>
                                     <th>Family phenotypes</th>
@@ -124,7 +128,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                                     return (self.renderSegregationEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="5" className="total-score-label">Total LOD score:</td>
+                                    <td colSpan="6" className="total-score-label">Total LOD score:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -107,7 +107,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
             <div className="evidence-summary panel-case-level-segregation">
                 <div className="panel panel-info">
                     <div className="panel-heading">
-                        <h3 className="panel-title">Genetic Evidence: Case Level (family segregation information without proband data)</h3>
+                        <h3 className="panel-title">Genetic Evidence: Case Level (family segregation information without proband data or scored proband data)</h3>
                     </div>
                     {sortedEvidenceList && sortedEvidenceList.length ?
                         <table className="table">

--- a/src/clincoded/static/components/gene_disease_summary/experimental.js
+++ b/src/clincoded/static/components/gene_disease_summary/experimental.js
@@ -31,6 +31,9 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
         }
         return (
             <tr key={key} className="scored-experimental-evidence">
+                <td className="evidence-label">
+                    {evidence.label}
+                </td>
                 <td className="evidence-category">
                     <strong>{evidence.evidenceType}</strong> {evidence.evidenceSubtype && evidence.evidenceSubtype.length ? <span>{evidence.evidenceSubtype}</span> : null}
                 </td>
@@ -100,6 +103,7 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
                         <table className="table">
                             <thead>
                                 <tr>
+                                    <th>Label</th>
                                     <th>Experimental category</th>
                                     <th>Reference</th>
                                     <th>Explanation</th>
@@ -113,7 +117,7 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
                                     return (self.renderExperimentalEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="4" className="total-score-label">Total points:</td>
+                                    <td colSpan="5" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/experimental.js
+++ b/src/clincoded/static/components/gene_disease_summary/experimental.js
@@ -21,13 +21,21 @@ class GeneDiseaseEvidenceSummaryExperimental extends Component {
      * @param {number} key - unique key
      */
     renderExperimentalEvidence(evidence, key) {
+        let authors;
+        if (evidence.authors && evidence.authors.length) {
+            if (evidence.authors.length > 1) {
+                authors = evidence.authors[0] + ', et al.';
+            } else {
+                authors = evidence.authors[0];
+            }
+        }
         return (
             <tr key={key} className="scored-experimental-evidence">
                 <td className="evidence-category">
                     <strong>{evidence.evidenceType}</strong> {evidence.evidenceSubtype && evidence.evidenceSubtype.length ? <span>{evidence.evidenceSubtype}</span> : null}
                 </td>
                 <td className="evidence-reference">
-                    <span>{evidence.authors.join(', ')}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
+                    <span>{authors}, <strong>{evidence.pubYear}</strong>, <a href={external_url_map['PubMed'] + evidence.pmid} target="_blank">PMID: {evidence.pmid}</a></span>
                 </td>
                 <td className="evidence-explanation">
                     {evidence.explanation}

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -268,7 +268,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
     },
 
     /**
-     * Method to loop through families (of GDM or of group) and find all family evidence without proband
+     * Method to loop through families (of GDM or of group) and find all family evidence without proband, or with proband but no score
      * @param {array} families - a list of family evidence
      * @param {array} familyMatched - list of matched family evidence
      */
@@ -279,6 +279,9 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     if (family.individualIncluded && family.individualIncluded.length) {
                         family.individualIncluded.forEach(individual => {
                             if (!individual.proband || typeof individual.proband === 'undefined') {
+                                familyMatched.push(family);
+                            }
+                            if (individual.proband && (!individual.scores || (individual.scores && !individual.scores.length))) {
                                 familyMatched.push(family);
                             }
                         });

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -235,6 +235,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                 caseLevelEvidence['authors'] = annotation.article.authors;
                                 caseLevelEvidence['pmid'] = annotation.article.pmid;
                                 caseLevelEvidence['pubYear'] = pubDate[1];
+                                caseLevelEvidence['label'] = proband.label ? proband.label : '';
                                 caseLevelEvidence['sex'] = proband.sex ? proband.sex : '';
                                 caseLevelEvidence['ageType'] = proband.ageType ? proband.ageType : '';
                                 caseLevelEvidence['ageValue'] = proband.ageValue ? proband.ageValue : null;
@@ -357,6 +358,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                         segregationEvidence['authors'] = annotation.article.authors;
                         segregationEvidence['pmid'] = annotation.article.pmid;
                         segregationEvidence['pubYear'] = pubDate[1];
+                        segregationEvidence['label'] = family.label ? family.label : '';
                         segregationEvidence['ethnicity'] = family.ethnicity ? family.ethnicity : '';
                         segregationEvidence['hpoIdInDiagnosis'] = family.hpoIdInDiagnosis && family.hpoIdInDiagnosis.length ? family.hpoIdInDiagnosis : [];
                         segregationEvidence['termsInDiagnosis'] = family.termsInDiagnosis && family.termsInDiagnosis.length ? family.termsInDiagnosis : '';
@@ -420,6 +422,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                         caseControlEvidence['authors'] = annotation.article.authors;
                                         caseControlEvidence['pmid'] = annotation.article.pmid;
                                         caseControlEvidence['pubYear'] = pubDate[1];
+                                        caseControlEvidence['label'] = caseControl.label ? caseControl.label : '';
                                         caseControlEvidence['studyType'] = caseControl.studyType ? caseControl.studyType : '';
                                         caseControlEvidence['detectionMethod'] = caseControl.caseCohort && caseControl.caseCohort.method ? caseControl.caseCohort.method.specificMutationsGenotypedMethod : '';
                                         caseControlEvidence['caseCohort_numberWithVariant'] = typeof caseControl.caseCohort.numberWithVariant === 'number' ? caseControl.caseCohort.numberWithVariant : null;
@@ -506,6 +509,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                 if ('scoreStatus' in score && (score.scoreStatus !== 'none' || score.scoreStatus !== '')) {
                                     let pubDate = (/^([\d]{4})(.*?)$/).exec(annotation.article.date);
                                     // Define object key/value pairs
+                                    experimentalEvidence['label'] = experimental.label ? experimental.label : '';
                                     experimentalEvidence['evidenceType'] = experimental.evidenceType;
                                     experimentalEvidence['evidenceSubtype'] = this.mapEvidenceSubtype(experimental);
                                     experimentalEvidence['pmid'] = annotation.article.pmid;


### PR DESCRIPTION
**Steps to test #1518:**
1. Add a **PMID** with multiple authors to an existing GDM or a newly created GDM.
2. Add and score evidence that can be scored, such as _Proband_, _Case-Control_ and _Experimental_.
3. Click on the **Preview Evidence Summary** button at the upper-right to open the **Evidence Summary** in a new tab/window.
4. In the **Evidence Summary** view, expect to see the authors of the paper (PMID) in the **Reference** columns of difference evidence tables to be shown in the format **"[lastname] [firstname Initial], et al."**

**Steps to test #1540:**
1. Close the _Evidence Summary_ tab/window and return to the GDM with the evidence from the previous testing steps.
2. Edit the **Case-Control** evidence by removing the associated disease and add an _HPO ID_ and/or a _free text Phenotype term_. Save it and return to the _Gene-Record_ page.
3. Click on the **Preview Evidence Summary** button at the upper-right again to open the **Evidence Summary** in a new tab/window.
4. In the **Evidence Summary** view, expect to see the evidence in the **Case-Control** and **Experimental** evidence tables being rendered properly.
5. In the **Case-Control** evidence table, expect to see the HPO ID and/or free text being shown in the **Disease (Case)** column in the absence of associated disease.

**Steps to test #1560:**
1. Close the _Evidence Summary_ tab/window and return to the GDM with the evidence from the previous testing steps.
2. Add a **Family** evidence and include a **LOD** score that is counted in the classification.
3. Add a **Proband** to this Family evidence and click the **Save** button to proceed to the intermediate page on which you are given the option to edit/score the _Proband_ evidence.
4. On the subsequent **Proband** evidence page, fill out the required field but _DO NOT_ score it. Save it and return to the Gene-Disease Record page.
5. Click on the **Preview Evidence Summary** button at the upper-right again to open the **Evidence Summary** in a new tab/window.
6. In the **Evidence Summary** view, expect to see the Family evidence being shown in the **Family** evidence table.

**Steps to test #1582:**
1. While still in the **Evidence Summary** view, expect to see a new **Label** column being added to all evidence tables and the names of the various evidence being shown in their respective _Label_ columns.