### PR TITLE
Connects to #1541. Change "ClinGen Curator" display name to "ClinGen Test Curator" in demo version 

### DIFF
--- a/src/clincoded/static/components/dashboard.js
+++ b/src/clincoded/static/components/dashboard.js
@@ -55,7 +55,7 @@ var Dashboard = createReactClass({
     setUserData: function(props) {
         // sets the display name and curator status
         this.setState({
-            userName: props.first_name,
+            userName: props.first_name && props.last_name ? props.first_name + ' ' + props.last_name : '',
             userStatus: props.job_title,
             lastLogin: ''
         });


### PR DESCRIPTION
#Updates:
 --updated dashboard.js with props.last_name to show full demo username eg, Clingen Test Curator when demo user logs in.

Testing:
 --user should log in to demo with Demo Login and see "Clingen Test Curator" in Welcome text
 --Clingen Test User should be displayed where ever demo user edited or created any records.