### PR TITLE
Connects to #1578.  Remove word "allele" from case control

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1417,7 +1417,7 @@ function GroupPower(groupType) {
             <div>
                 <div className="form-group allele-frequency">
                     <div className="col-sm-5">
-                        <span>{type + ' Allele Frequency:'}</span>
+                        <span>{type + ' Frequency:'}</span>
                     </div>
                     <div className="col-sm-7">
                         {alleleFreqDisplay}
@@ -1867,7 +1867,7 @@ var CaseControlViewer = createReactClass({
                                         </div>
 
                                         <div>
-                                            <dt>Case Frequency</dt>
+                                            <dt>Control Frequency</dt>
                                             <dd>{renderAlleleFrequency(controlCohort.numberWithVariant, controlCohort.numberAllGenotypedSequenced, controlCohort.alleleFrequency)}</dd>
                                         </div>
                                     </dl>

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1847,7 +1847,7 @@ var CaseControlViewer = createReactClass({
                                         </div>
 
                                         <div>
-                                            <dt>Case Allele Frequency</dt>
+                                            <dt>Case Frequency</dt>
                                             <dd>{renderAlleleFrequency(caseCohort.numberWithVariant, caseCohort.numberAllGenotypedSequenced, caseCohort.alleleFrequency)}</dd>
                                         </div>
                                     </dl>
@@ -1867,7 +1867,7 @@ var CaseControlViewer = createReactClass({
                                         </div>
 
                                         <div>
-                                            <dt>Case Allele Frequency</dt>
+                                            <dt>Case Frequency</dt>
                                             <dd>{renderAlleleFrequency(controlCohort.numberWithVariant, controlCohort.numberAllGenotypedSequenced, controlCohort.alleleFrequency)}</dd>
                                         </div>
                                     </dl>


### PR DESCRIPTION
Update:
 -- Removed word "Allele" from case_control_curation.js
 -- Corrected the B Power Section to "Control Frequency".

Testing:
 -- Users should log in and when curating Case and Case Control Power sections you should only see "Case Frequency" and not "Case Allele Frequency.
-- Users should also see "Control Frequency" instead of Case Frequency under B power section.