### PR TITLE
Connects to #1592. Connects to #1519.

### DIFF
--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     constructor(props) {
@@ -40,11 +41,18 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                 <td className="evidence-disease">
                     {evidence.diseaseId && evidence.diseaseTerm ?
                         <span>{evidence.diseaseTerm}
-                            <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span> : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span>({this.props.hpoTermList.join(', ')})</span> : null)}</span>
+                            <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span>
+                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br /><strong>HPO term(s):</strong><HpoTerms hpoIds={evidence.diseasePhenotypes} /></span> : null)
+                            }
+                            </span>
                         </span>
                         :
                         <span>
-                            {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                            {evidence.hpoIdInDiagnosis.length ?
+                                <span><strong>HPO term(s):</strong>
+                                    <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} />
+                                </span> 
+                                : null}
                             {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                         </span>
                     }
@@ -177,8 +185,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseControl.propTypes = {
-    caseControlEvidenceList: PropTypes.array,
-    hpoTermList: PropTypes.array
+    caseControlEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummaryCaseControl;

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -98,9 +98,9 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                             );
                         })
                         : null}
-                </td>
-                <td className="evidence-genotyping-method-description">
-                    {evidence.specificMutationsGenotypedMethod}
+                    {evidence.specificMutationsGenotypedMethod && evidence.specificMutationsGenotypedMethod.length ?
+                        <span className="genotyping-method-description"><strong>Description of genotyping method:</strong>{evidence.specificMutationsGenotypedMethod}</span>
+                        : null}
                 </td>
                 <td className="evidence-score-status">
                     {<span className={evidence.scoreStatus}>{evidence.scoreStatus}</span>}
@@ -177,7 +177,6 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     <th colSpan="4">Segregations</th>
                                     <th rowSpan="2">Proband previous testing</th>
                                     <th rowSpan="2">Proband methods of detection</th>
-                                    <th rowSpan="2">Description of genotyping method</th>
                                     <th rowSpan="2">Score status</th>
                                     <th rowSpan="2">Proband points (default points)</th>
                                     <th rowSpan="2">Reason for changed score</th>
@@ -194,7 +193,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     return (self.renderCaseLevelEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="16" className="total-score-label">Total points:</td>
+                                    <td colSpan="15" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -99,6 +99,9 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                         })
                         : null}
                 </td>
+                <td className="evidence-genotyping-method-description">
+                    {evidence.specificMutationsGenotypedMethod}
+                </td>
                 <td className="evidence-score-status">
                     {<span className={evidence.scoreStatus}>{evidence.scoreStatus}</span>}
                 </td>
@@ -174,6 +177,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     <th colSpan="4">Segregations</th>
                                     <th rowSpan="2">Proband previous testing</th>
                                     <th rowSpan="2">Proband methods of detection</th>
+                                    <th rowSpan="2">Description of genotyping method</th>
                                     <th rowSpan="2">Score status</th>
                                     <th rowSpan="2">Proband points (default points)</th>
                                     <th rowSpan="2">Reason for changed score</th>
@@ -190,7 +194,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                     return (self.renderCaseLevelEvidence(item, i));
                                 })}
                                 <tr>
-                                    <td colSpan="15" className="total-score-label">Total points:</td>
+                                    <td colSpan="16" className="total-score-label">Total points:</td>
                                     <td colSpan="2" className="total-score-value">{this.getTotalScore(sortedEvidenceList)}</td>
                                 </tr>
                             </tbody>

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
     constructor(props) {
@@ -63,7 +64,11 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                     {evidence.ethnicity}
                 </td>
                 <td className="evidence-phenotypes">
-                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                    {evidence.hpoIdInDiagnosis.length ?
+                        <span><strong>HPO term(s):</strong>
+                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} />
+                        </span> 
+                        : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
                 <td className="evidence-segregation-num-affected">
@@ -202,8 +207,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseLevel.propTypes = {
-    caseLevelEvidenceList: PropTypes.array,
-    hpoTermList: PropTypes.array
+    caseLevelEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummaryCaseLevel;

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummarySegregation extends Component {
     constructor(props) {
@@ -41,7 +42,11 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                     {evidence.ethnicity}
                 </td>
                 <td className="evidence-phenotypes">
-                    {evidence.hpoIdInDiagnosis.length ? <span><strong>HPO term(s):</strong><br />{this.props.hpoTermList.map((term, i) => <span key={i}>{term}<br /></span>)}</span> : null}
+                    {evidence.hpoIdInDiagnosis.length ?
+                        <span><strong>HPO term(s):</strong>
+                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} />
+                        </span> 
+                        : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
                 <td className="evidence-segregation-num-affected">
@@ -145,8 +150,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
 }
 
 GeneDiseaseEvidenceSummarySegregation.propTypes = {
-    segregationEvidenceList: PropTypes.array,
-    hpoTermList: PropTypes.array
+    segregationEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummarySegregation;

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -237,6 +237,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                 caseLevelEvidence['termsInDiagnosis'] = proband.termsInDiagnosis && proband.termsInDiagnosis.length ? proband.termsInDiagnosis : '';
                                 caseLevelEvidence['previousTestingDescription'] = proband.method && proband.method.previousTestingDescription ? proband.method.previousTestingDescription : '';
                                 caseLevelEvidence['genotypingMethods'] = proband.method && proband.method.genotypingMethods && proband.method.genotypingMethods.length ? proband.method.genotypingMethods : [];
+                                caseLevelEvidence['specificMutationsGenotypedMethod'] = proband.method && proband.method.specificMutationsGenotypedMethod ? proband.method.specificMutationsGenotypedMethod : '';
                                 caseLevelEvidence['scoreStatus'] = score.scoreStatus;
                                 caseLevelEvidence['defaultScore'] = score.calculatedScore ? score.calculatedScore : null;
                                 caseLevelEvidence['modifiedScore'] = score.hasOwnProperty('score') ? score.score : null;

--- a/src/clincoded/static/libs/get_hpo_term.js
+++ b/src/clincoded/static/libs/get_hpo_term.js
@@ -17,7 +17,7 @@ class HpoTerms extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            hpoTermList: undefined
+            hpoTermList: null
         };
     }
 

--- a/src/clincoded/static/libs/get_hpo_term.js
+++ b/src/clincoded/static/libs/get_hpo_term.js
@@ -1,0 +1,79 @@
+'use strict';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { external_url_map } from '../components/globals';
+
+/**
+ * Stateful component to render the HPO term names given 
+ * a list of HPO IDs passed as a prop.
+ * 
+ * Dependent on OLS API service to return data
+ * If no data found, simply return the HPO IDs themselves
+ * 
+ * Due to the XHR requests upon receiving the prop, it relies
+ * on changing the state to trigger the re-rendering.
+ */
+class HpoTerms extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            hpoTermList: undefined
+        };
+    }
+
+    componentDidMount() {
+        this.fetchHpoTerms(this.props.hpoIds);
+    }
+
+    fetchHpoTerms(ids) {
+        let hpoTermList = [];
+        ids.forEach(id => {
+            let hpoTerm;
+            let url = external_url_map['HPOApi'] + id.replace(':', '_');
+            // Make the OLS REST API call
+            this.context.fetch(url, {
+                method: 'GET',
+                headers: {'Accept': 'application/json'}
+            }).then(response => {
+                if (!response.ok) throw response;
+                return response.json();
+            }).then(result => {
+                let termLabel = result['_embedded']['terms'][0]['label'];
+                if (termLabel) {
+                    hpoTerm = termLabel;
+                } else {
+                    hpoTerm = id + ' (note: term not found)';
+                }
+                hpoTermList.push(hpoTerm);
+                this.setState({hpoTermList: hpoTermList});
+            }, error => {
+                // Unsuccessful retrieval
+                console.warn('Error in fetching HPO data =: %o', error);
+                hpoTerm = id + ' (note: term not found)';
+                hpoTermList.push(hpoTerm);
+                this.setState({hpoTermList: hpoTermList});
+            });
+        });
+    }
+
+    render() {
+        let hpoTermList = this.state.hpoTermList;
+        return (
+            <ul className="hpo-terms-list">
+                {hpoTermList && hpoTermList.length ?
+                    hpoTermList.map((term, i) => <li key={i} className="hpo-term-item"><span>{term}</span></li>)
+                    : null}
+            </ul>
+        );
+    }
+}
+
+HpoTerms.propTypes = {
+    hpoIds: PropTypes.array
+};
+
+HpoTerms.contextTypes = {
+    fetch: PropTypes.func
+};
+
+export default HpoTerms;

--- a/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
@@ -102,6 +102,14 @@
                     margin: 6px 0;
                 }
             }
+
+            .evidence-detection-methods {
+                .genotyping-method-description {
+                    strong {
+                        display: block;
+                    }
+                }
+            }
         }
 
         &.panel-experimental {

--- a/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
@@ -132,5 +132,21 @@
                 }
             }
         }
+
+        .hpo-terms-list {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+
+            .hpo-term-item {
+                span:after {
+                    content: ',';
+                }
+
+                &:last-child span:after {
+                    content: '';
+                }
+            }
+        }
     }
 }

--- a/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
@@ -140,7 +140,7 @@
 
             .hpo-term-item {
                 span:after {
-                    content: ',';
+                    content: ';';
                 }
 
                 &:last-child span:after {


### PR DESCRIPTION
**Steps to test #1592:**
1. In a Gene-Disease Record, add 2 **Individual** evidence and score both of them. In each of the evidence, add HPO IDs **"HP:0002629, HP:0002627"** and **"HP:0002626"** respectively in the **Phenotype(s) (HPO ID(s)):** textfield.
2. In the same record, add 2 **Family** evidence and produce LOD score for both of them. In each of the evidence, add HPO IDs **"HP:0002625, HP:0002624"** and **"HP:3000043"** respectively in the **Phenotype(s) in Common (HPO ID(s)):** textfield.
3. In the same record, add 2 **Case-Control** evidence and score both of them. In each of the evidence, instead of associating with a disease, add HPO IDs **"HP:0025491, HP:3000059"** and **"HP:0001015"** respectively in the **Phenotype(s) in Common (HPO ID(s)):** textfield for CaseCohort.
![image](https://user-images.githubusercontent.com/6956310/35756571-b56539f8-0820-11e8-8863-732b7d458d85.png)
4. Return to the record's page and click on the **Preview Evidence Summary** button at the upper-right.
5. In the newly open window/tab, expect to see the correct HPO terms being displayed in the Phenotypes columns of the scored evidence tables on the Evidence Summary.
![image](https://user-images.githubusercontent.com/6956310/35757491-2107a15c-0824-11e8-8b23-84cfdb9c80f2.png)

**Steps to test #1519:**
1. Return to the record's page, and edit each of the **Individual** evidence by filling in out the testing method fields, particularly the **Description of genotyping method** text fields.
![image](https://user-images.githubusercontent.com/6956310/35757624-daf5887c-0824-11e8-96bc-f4f60d2bb809.png)
2. Upon saving the changes, preview the Evidence Summary again.
3. In **Case Level** genetic evidence summary table on the page, expect to see the **Description of genotyping method** information being shown in the same table column with the detection methods..
![image](https://user-images.githubusercontent.com/6956310/35757688-2c857594-0825-11e8-946e-341cc9476e8a.png)
