### PR TITLE
Connects to #1626. Connects to #1628. Connects to #1629.

### DIFF
--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -960,7 +960,7 @@ var renderIndividual = function(individual, gdm, annotation, curatorMatch, evide
                     </span>
                 </div>
                 : null}
-            <a href={'/individual/' + individual.uuid} title="View individual in a new tab">View/Score</a>
+            <a href={'/individual/' + individual.uuid + '?gdm=' + gdm.uuid} title="View individual in a new tab">View/Score</a>
             {(individual.affiliation && curatorAffiliation && evidenceAffiliationMatch) || (!individual.affiliation && !curatorAffiliation && curatorMatch) ?
                 <span> | <a href={'/individual-curation/?editsc&gdm=' + gdm.uuid + '&evidence=' + annotation.uuid + '&individual=' + individual.uuid} title="Edit this individual">Edit</a></span>
                 : null}
@@ -1605,23 +1605,12 @@ var PmidDoiButtons = module.exports.PmidDoiButtons = createReactClass({
 });
 
 
-// Get the pathogenicity made by the curator with the given user UUID from the given variant.
-//var getPathogenicityFromVariant = function(variant, curatorUuid) {
-//  var pathogenicity = null;
-
-//    if (variant && variant.associatedPathogenicities.length > 0) {
-//        // At this point, we know the variant has a curation (pathogenicity)
-//        pathogenicity = _(variant.associatedPathogenicities).find(function(pathogenicity) {
-//            return pathogenicity.submitted_by.uuid === curatorUuid;
-//        });
-//    }
-//    return pathogenicity;
-//};
-var getPathogenicityFromVariant = module.exports.getPathogenicityFromVariant = function(gdm, curatorUuid, variantUuid, affiliation) {
+// Get the pathogenicity made by the curator with the given user UUID from the given variant
+export function getPathogenicityFromVariant(gdm, curatorUuid, variantUuid, affiliation) {
     var pathogenicity = null;
-    if (gdm.variantPathogenicity && gdm.variantPathogenicity.length > 0) {
+    if (gdm && gdm.variantPathogenicity && gdm.variantPathogenicity.length) {
         for (let object of gdm.variantPathogenicity) {
-            if (affiliation && object.affiliation && object.affiliation === affiliation.affiliation_id) {
+            if (affiliation && object.affiliation && object.affiliation === affiliation.affiliation_id && object.variant.uuid === variantUuid) {
                 pathogenicity = object;
             } else if (!affiliation && !object.affiliation && object.submitted_by.uuid === curatorUuid && object.variant.uuid === variantUuid) {
                 pathogenicity = object;
@@ -1629,7 +1618,7 @@ var getPathogenicityFromVariant = module.exports.getPathogenicityFromVariant = f
         }
     }
     return pathogenicity;
-};
+}
 
 
 // Collect references to all families and individuals within an annotation that reference the given variant

--- a/src/clincoded/static/components/experimental_curation.js
+++ b/src/clincoded/static/components/experimental_curation.js
@@ -1352,10 +1352,12 @@ var ExperimentalCuration = createReactClass({
                         newExperimental.variants = experimentalDataVariants;
                     }
 
-                    // If we add a new score, add it to the experimental object
-                    if (scoreArray && scoreArray.length) {
-                        newExperimental.scores = scoreArray;
-                    }
+                    // The scoreArray may contain:
+                    // 1. One new score
+                    // 2. New score and other curators' scores
+                    // 3. No new score but an updated score
+                    // 4. No score after the curator deletes the only score in the array
+                    newExperimental.scores = scoreArray;
 
                     if (this.state.experimental) {
                         // We're editing a experimental. PUT the new group object to the DB to update the existing one.

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -516,7 +516,8 @@ const IndividualCuration = createReactClass({
                     /*************************************************************/
                     /* Either update or create the score status object in the DB */
                     /*************************************************************/
-                    if (Object.keys(newUserScoreObj).length) {
+                    if (Object.keys(newUserScoreObj).length && newUserScoreObj.scoreStatus) {
+                        // Update and create score object when the score object has the scoreStatus key/value pair
                         if (this.state.userScoreObj.uuid) {
                             return this.putRestData('/evidencescore/' + this.state.userScoreObj.uuid, newUserScoreObj).then(modifiedScoreObj => {
                                 // Only need to update the evidence score object
@@ -528,6 +529,22 @@ const IndividualCuration = createReactClass({
                                     // Add the new score to array
                                     evidenceScores.push(newScoreObject['@graph'][0]['@id']);
                                 }
+                                return Promise.resolve(evidenceScores);
+                            });
+                        }
+                    } else if (Object.keys(newUserScoreObj).length && !newUserScoreObj.scoreStatus) {
+                        // If an existing score object has no scoreStatus key/value pair, the user likely removed score
+                        // Then delete the score entry from the score list associated with the evidence
+                        if (this.state.userScoreObj.uuid) {
+                            newUserScoreObj['status'] = 'deleted';
+                            return this.putRestData('/evidencescore/' + this.state.userScoreObj.uuid, newUserScoreObj).then(modifiedScoreObj => {
+                                evidenceScores.forEach(score => {
+                                    if (score === modifiedScoreObj['@graph'][0]['@id']) {
+                                        let index = evidenceScores.indexOf(score);
+                                        evidenceScores.splice(index, 1);
+                                    }
+                                });
+                                // Return the evidence score array without the deleted object
                                 return Promise.resolve(evidenceScores);
                             });
                         }
@@ -1697,39 +1714,79 @@ const IndividualViewer = createReactClass({
             /***********************************************************/
             /* Either update or create the user score object in the DB */
             /***********************************************************/
-            if (this.state.userScoreObj.uuid) {
-                return this.putRestData('/evidencescore/' + this.state.userScoreObj.uuid, newUserScoreObj).then(modifiedScoreObj => {
-                    this.setState({submitBusy: false});
-                    return Promise.resolve(modifiedScoreObj['@graph'][0]['@id']);
-                }).then(data => {
-                    this.handlePageRedirect();
-                });
-            } else {
-                return this.postRestData('/evidencescore/', newUserScoreObj).then(newScoreObject => {
-                    let newScoreObjectUuid = null;
-                    if (newScoreObject) {
-                        newScoreObjectUuid = newScoreObject['@graph'][0]['@id'];
-                    }
-                    return Promise.resolve(newScoreObjectUuid);
-                }).then(newScoreObjectUuid => {
-                    return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndividual => {
-                        // flatten both context and fresh individual
-                        let newIndividual = curator.flatten(individual);
-                        let freshFlatIndividual = curator.flatten(freshIndividual);
-                        // take only the scores from the fresh individual to not overwrite changes
-                        // in newIndividual
-                        newIndividual.scores = freshFlatIndividual.scores ? freshFlatIndividual.scores : [];
-                        // push new score uuid to newIndividual's scores list
-                        newIndividual.scores.push(newScoreObjectUuid);
-
-                        return this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {
-                            this.setState({submitBusy: false});
-                            return Promise.resolve(updatedIndividualObj['@graph'][0]);
-                        });
+            if (newUserScoreObj.scoreStatus) {
+                // Update and create score object when the score object has the scoreStatus key/value pair
+                if (this.state.userScoreObj.uuid) {
+                    return this.putRestData('/evidencescore/' + this.state.userScoreObj.uuid, newUserScoreObj).then(modifiedScoreObj => {
+                        this.setState({submitBusy: false});
+                        return Promise.resolve(modifiedScoreObj['@graph'][0]['@id']);
+                    }).then(data => {
+                        this.handlePageRedirect();
                     });
-                }).then(data => {
-                    this.handlePageRedirect();
-                });
+                } else {
+                    return this.postRestData('/evidencescore/', newUserScoreObj).then(newScoreObject => {
+                        let newScoreObjectUuid = null;
+                        if (newScoreObject) {
+                            newScoreObjectUuid = newScoreObject['@graph'][0]['@id'];
+                        }
+                        return Promise.resolve(newScoreObjectUuid);
+                    }).then(newScoreObjectUuid => {
+                        return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndividual => {
+                            // flatten both context and fresh individual
+                            let newIndividual = curator.flatten(individual);
+                            let freshFlatIndividual = curator.flatten(freshIndividual);
+                            // take only the scores from the fresh individual to not overwrite changes
+                            // in newIndividual
+                            newIndividual.scores = freshFlatIndividual.scores ? freshFlatIndividual.scores : [];
+                            // push new score uuid to newIndividual's scores list
+                            newIndividual.scores.push(newScoreObjectUuid);
+
+                            return this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {
+                                this.setState({submitBusy: false});
+                                return Promise.resolve(updatedIndividualObj['@graph'][0]);
+                            });
+                        });
+                    }).then(data => {
+                        this.handlePageRedirect();
+                    });
+                }
+            } else if (!newUserScoreObj.scoreStatus) {
+                // If an existing score object has no scoreStatus key/value pair, the user likely removed score
+                // Then delete the score entry from the score list associated with the evidence
+                if (this.state.userScoreObj.uuid) {
+                    newUserScoreObj['status'] = 'deleted';
+                    return this.putRestData('/evidencescore/' + this.state.userScoreObj.uuid, newUserScoreObj).then(modifiedScoreObj => {
+                        let modifiedScoreObjectUuid = null;
+                        if (modifiedScoreObj) {
+                            modifiedScoreObjectUuid = modifiedScoreObj['@graph'][0]['@id'];
+                        }
+                        return Promise.resolve(modifiedScoreObjectUuid);
+                    }).then(modifiedScoreObjectUuid => {
+                        return this.getRestData('/individual/' + individual.uuid, null, true).then(freshIndividual => {
+                            // flatten both context and fresh individual
+                            let newIndividual = curator.flatten(individual);
+                            let freshFlatIndividual = curator.flatten(freshIndividual);
+                            // take only the scores from the fresh individual to not overwrite changes
+                            // in newIndividual
+                            newIndividual.scores = freshFlatIndividual.scores ? freshFlatIndividual.scores : [];
+                            // push new score uuid to newIndividual's scores list
+                            if (newIndividual.scores.length) {
+                                newIndividual.scores.forEach(score => {
+                                    if (score === modifiedScoreObjectUuid) {
+                                        let index = newIndividual.scores.indexOf(score);
+                                        newIndividual.scores.splice(index, 1);
+                                    }
+                                });
+                            }
+                            return this.putRestData('/individual/' + individual.uuid, newIndividual).then(updatedIndividualObj => {
+                                this.setState({submitBusy: false});
+                                return Promise.resolve(updatedIndividualObj['@graph'][0]);
+                            });
+                        });
+                    }).then(data => {
+                        this.handlePageRedirect();
+                    });
+                }
             }
         }
     },
@@ -1750,7 +1807,7 @@ const IndividualViewer = createReactClass({
         let isEvidenceScored = false;
         if (evidenceScores.length) {
             evidenceScores.map(scoreObj => {
-                if (scoreObj.scoreStatus.match(/Score|Review|Contradicts/ig)) {
+                if (scoreObj.scoreStatus && scoreObj.scoreStatus.match(/Score|Review|Contradicts/ig)) {
                     isEvidenceScored = true;
                 }
             });

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1009,7 +1009,7 @@ const IndividualCuration = createReactClass({
                                                         <ScoreIndividual evidence={individual} modeInheritance={gdm.modeInheritance} evidenceType="Individual"
                                                             variantInfo={variantInfo} session={session} handleUserScoreObj={this.handleUserScoreObj}
                                                             scoreError={this.state.scoreError} scoreErrorMsg={this.state.scoreErrorMsg} affiliation={this.props.affiliation}
-                                                            gdmUuid={gdm && gdm.uuid ? gdm.uuid : null} pmid={pmid ? pmid : null} />
+                                                            gdm={gdm} pmid={pmid ? pmid : null} />
                                                     </Panel>
                                                 </PanelGroup>
                                             </div>
@@ -1665,11 +1665,23 @@ const IndividualViewer = createReactClass({
 
     getInitialState: function() {
         return {
+            gdmUuid: queryKeyValue('gdm', this.props.href),
+            gdm: null,
             userScoreObj: {}, // Logged-in user's score object
             submitBusy: false, // True while form is submitting
             scoreError: false,
             scoreErrorMsg: ''
         };
+    },
+
+    componentDidMount() {
+        if (this.state.gdmUuid) {
+            return this.getRestData('/gdm/' + this.state.gdmUuid).then(gdm => {
+                this.setState({gdm: gdm});
+            }).catch(err => {
+                console.log('Fetching gdm error =: %o', err);
+            });
+        }
     },
 
     // Called by child function props to update user score obj
@@ -2095,7 +2107,7 @@ const IndividualViewer = createReactClass({
                                         <ScoreIndividual evidence={individual} modeInheritance={tempGdm? tempGdm.modeInheritance : null} evidenceType="Individual"
                                             session={this.props.session} handleUserScoreObj={this.handleUserScoreObj} scoreSubmit={this.scoreSubmit}
                                             scoreError={this.state.scoreError} scoreErrorMsg={this.state.scoreErrorMsg} affiliation={affiliation}
-                                            variantInfo={variants} gdmUuid={tempGdm && tempGdm.uuid ? tempGdm.uuid : null} pmid={tempPmid ? tempPmid : null} />
+                                            variantInfo={variants} gdm={this.state.gdm} pmid={tempPmid ? tempPmid : null} />
                                         : null}
                                     {!isEvidenceScored && ((affiliation && !affiliatedIndividual) || (!affiliation && !userIndividual)) ?
                                         <div className="row">

--- a/src/clincoded/static/components/provisional_curation.js
+++ b/src/clincoded/static/components/provisional_curation.js
@@ -574,11 +574,11 @@ var ProvisionalCuration = createReactClass({
         });
 
         // calculate segregation counted points
-        scoreTableValues['segregationPoints'] = Math.round((scoreTableValues['segregationPoints'] + 0.00001) * 100) / 100;
-        if (scoreTableValues['segregationPoints'] >= 0.75 && scoreTableValues['segregationPoints'] <= 0.99) {
+        scoreTableValues['segregationPoints'] = this.classificationMathRound(scoreTableValues['segregationPoints']);
+        if (scoreTableValues['segregationPoints'] >= 0.72 && scoreTableValues['segregationPoints'] <= 0.99) {
             scoreTableValues['segregationPointsCounted'] = 1;
         } else if (scoreTableValues['segregationPoints'] >= 1 && scoreTableValues['segregationPoints'] <= 1.24) {
-            scoreTableValues['segregationPointsCounted'] = .5;
+            scoreTableValues['segregationPointsCounted'] = 1.5;
         } else if (scoreTableValues['segregationPoints'] >= 1.25 && scoreTableValues['segregationPoints'] <= 1.49) {
             scoreTableValues['segregationPointsCounted'] = 2.5;
         } else if (scoreTableValues['segregationPoints'] >= 1.5 && scoreTableValues['segregationPoints'] <= 1.74) {
@@ -590,12 +590,17 @@ var ProvisionalCuration = createReactClass({
         // calculate other counted points
         let tempPoints = 0;
 
+        scoreTableValues['probandOtherVariantPoints'] = this.classificationMathRound(scoreTableValues['probandOtherVariantPoints']);
         scoreTableValues['probandOtherVariantPointsCounted'] = scoreTableValues['probandOtherVariantPoints'] < MAX_SCORE_CONSTANTS.OTHER_VARIANT_TYPE_WITH_GENE_IMPACT ? scoreTableValues['probandOtherVariantPoints'] : MAX_SCORE_CONSTANTS.OTHER_VARIANT_TYPE_WITH_GENE_IMPACT;
 
+        scoreTableValues['probandNullVariantPoints'] = this.classificationMathRound(scoreTableValues['probandNullVariantPoints']);
         scoreTableValues['probandNullVariantPointsCounted'] = scoreTableValues['probandNullVariantPoints'] < MAX_SCORE_CONSTANTS.PREDICTED_OR_PROVEN_NULL_VARIANT ? scoreTableValues['probandNullVariantPoints'] : MAX_SCORE_CONSTANTS.PREDICTED_OR_PROVEN_NULL_VARIANT;
 
+        scoreTableValues['variantDenovoPoints'] = this.classificationMathRound(scoreTableValues['variantDenovoPoints']);
         scoreTableValues['variantDenovoPointsCounted'] = scoreTableValues['variantDenovoPoints'] < MAX_SCORE_CONSTANTS.VARIANT_IS_DE_NOVO ? scoreTableValues['variantDenovoPoints'] : MAX_SCORE_CONSTANTS.VARIANT_IS_DE_NOVO;
 
+        scoreTableValues['twoVariantsProvenPoints'] = this.classificationMathRound(scoreTableValues['twoVariantsProvenPoints']);
+        scoreTableValues['twoVariantsNotProvenPoints'] = this.classificationMathRound(scoreTableValues['twoVariantsNotProvenPoints']);
         tempPoints = scoreTableValues['twoVariantsProvenPoints'] + scoreTableValues['twoVariantsNotProvenPoints'];
         scoreTableValues['autosomalRecessivePointsCounted'] = tempPoints < MAX_SCORE_CONSTANTS.AUTOSOMAL_RECESSIVE ? tempPoints : MAX_SCORE_CONSTANTS.AUTOSOMAL_RECESSIVE;
 
@@ -612,15 +617,15 @@ var ProvisionalCuration = createReactClass({
         scoreTableValues['modelsRescuePointsCounted'] = tempPoints < MAX_SCORE_CONSTANTS.MODELS_RESCUE ? tempPoints : MAX_SCORE_CONSTANTS.MODELS_RESCUE;
 
         tempPoints = scoreTableValues['probandOtherVariantPointsCounted'] + scoreTableValues['probandNullVariantPointsCounted'] + scoreTableValues['variantDenovoPointsCounted'] + scoreTableValues['autosomalRecessivePointsCounted'] + scoreTableValues['segregationPointsCounted'] + scoreTableValues['caseControlPointsCounted'];
-        scoreTableValues['geneticEvidenceTotalPoints'] = tempPoints < MAX_SCORE_CONSTANTS.GENETIC_EVIDENCE ? parseFloat(tempPoints).toFixed(2) : MAX_SCORE_CONSTANTS.GENETIC_EVIDENCE;
+        scoreTableValues['geneticEvidenceTotalPoints'] = tempPoints < MAX_SCORE_CONSTANTS.GENETIC_EVIDENCE ? this.classificationMathRound(tempPoints) : MAX_SCORE_CONSTANTS.GENETIC_EVIDENCE;
 
         tempPoints = scoreTableValues['functionalPointsCounted'] + scoreTableValues['functionalAlterationPointsCounted'] + scoreTableValues['modelsRescuePointsCounted'];
-        scoreTableValues['experimentalEvidenceTotalPoints'] = tempPoints < MAX_SCORE_CONSTANTS.EXPERIMENTAL_EVIDENCE ? parseFloat(tempPoints).toFixed(2) : MAX_SCORE_CONSTANTS.EXPERIMENTAL_EVIDENCE;
+        scoreTableValues['experimentalEvidenceTotalPoints'] = tempPoints < MAX_SCORE_CONSTANTS.EXPERIMENTAL_EVIDENCE ? this.classificationMathRound(tempPoints) : MAX_SCORE_CONSTANTS.EXPERIMENTAL_EVIDENCE;
 
-        let totalScore = parseFloat(scoreTableValues['geneticEvidenceTotalPoints']) + parseFloat(scoreTableValues['experimentalEvidenceTotalPoints']);
+        let totalScore = scoreTableValues['geneticEvidenceTotalPoints'] + scoreTableValues['experimentalEvidenceTotalPoints'];
 
         // set scoreTabValues state
-        this.setState({totalScore: parseFloat(totalScore).toFixed(2), contradictingEvidence: contradictingEvidence, scoreTableValues: scoreTableValues});
+        this.setState({totalScore: this.classificationMathRound(totalScore), contradictingEvidence: contradictingEvidence, scoreTableValues: scoreTableValues});
 
         // set classification
         this.calculateClassifications(totalScore, this.state.replicatedOverTime);
@@ -647,6 +652,25 @@ var ProvisionalCuration = createReactClass({
                 });
             }
         });
+    },
+
+    /**
+     * Simple Math.round method
+     */
+    classificationMathRound(number) {
+        return Math.round((number + 0.00001) * 100) / 100;
+    },
+
+    /**
+     * Precision Math.round method
+     * Example: this.precisionMathRound(0.30000000004, 2) // Result: 0.3
+     * Example: this.precisionMathRound(0.35000000004, 2) // Result: 0.35
+     */
+    precisionMathRound(number, precision) {
+        let factor = Math.pow(10, precision);
+        let tempNumber = number * factor;
+        let roundedTempNumber = Math.round(tempNumber);
+        return roundedTempNumber / factor;
     },
 
     render: function() {

--- a/src/clincoded/static/components/score/experimental_score.js
+++ b/src/clincoded/static/components/score/experimental_score.js
@@ -132,7 +132,7 @@ var ScoreExperimental = module.exports.ScoreExperimental = createReactClass({
                             scoreExplanation: scoreExplanation ? scoreExplanation : null
                         }, () => {
                             this.refs.scoreStatus.setValue(scoreStatus ? scoreStatus : 'none');
-                            this.refs.scoreExplanation.setValue(scoreExplanation ? scoreExplanation : '');
+                            if (this.refs.scoreExplanation) this.refs.scoreExplanation.setValue(scoreExplanation ? scoreExplanation : '');
                             this.updateUserScoreObj();
                         });
                     }

--- a/src/clincoded/static/components/score/individual_score.js
+++ b/src/clincoded/static/components/score/individual_score.js
@@ -11,7 +11,7 @@ import { defaultScore } from './helpers/default_score';
 import { scoreRange } from './helpers/score_range';
 import { userScore } from './helpers/user_score';
 import { affiliationScore } from './helpers/affiliation_score';
-import { getPathogenicityFromVariant } from '../curator'
+import { getPathogenicityFromVariant } from '../curator';
 
 // Render scoring panel in Gene Curation Interface
 const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
@@ -32,7 +32,7 @@ const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
         scoreError: PropTypes.bool, // TRUE if no explanation is given for modified score or no case info type
         scoreErrorMsg: PropTypes.string, // Text string in response to the type of score error
         affiliation: PropTypes.object, // Affiliation object passed from parent
-        gdmUuid: PropTypes.string,
+        gdm: PropTypes.object,
         pmid: PropTypes.string
     },
 
@@ -500,7 +500,8 @@ const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
     },
 
     renderVariantCurationLinks(variants) {
-        let gdmUuid = this.props.gdmUuid ? this.props.gdmUuid : '';
+        const gdm = this.props.gdm;
+        let gdmUuid = gdm && gdm.uuid ? gdm.uuid : '';
         let pmid = this.props.pmid;
         let affiliation = this.props.affiliation;
         let userUuid = this.props.session && this.props.session.user_properties ? this.props.session.user_properties.uuid : '';
@@ -509,13 +510,13 @@ const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
                 <strong>Curate Variant's Gene Impact:</strong>
                 {variants.map((variant, i) => {
                     // See if the variant has a pathogenicity curated in the current GDM
-                    let userPathogenicity = null, matchingPathogenicity;
+                    let userPathogenicity = null;
                     let inCurrentGdm = _(variant.associatedPathogenicities).find(function(pathogenicity) {
-                        let matchingGdm = _(pathogenicity.associatedGdm).find(function(associatedGdm) {
-                            return associatedGdm.uuid === gdmUuid;
-                        });
-                        if (matchingGdm) {
-                            matchingPathogenicity = pathogenicity;
+                        let matchingGdm = false;
+                        if (gdm && gdm.variantPathogenicity && gdm.variantPathogenicity.length) {
+                            matchingGdm = _(gdm.variantPathogenicity).find(function(item) {
+                                return item['@id'] === pathogenicity;
+                            });
                         }
                         return !!matchingGdm;
                     });
@@ -523,7 +524,6 @@ const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
                     if (inCurrentGdm) {
                         userPathogenicity = getPathogenicityFromVariant(gdm, userUuid, variant.uuid, affiliation);
                     }
-                    inCurrentGdm = userPathogenicity ? true : false;
 
                     let variantCurationUrl = '/variant-curation/?all&gdm=' + gdmUuid + (pmid ? '&pmid=' + pmid : '') + '&variant=' + variant.uuid;
                     variantCurationUrl += affiliation ? '&affiliation=' + affiliation.affiliation_id : (userUuid ? '&user=' + userUuid : '');

--- a/src/clincoded/static/components/score/individual_score.js
+++ b/src/clincoded/static/components/score/individual_score.js
@@ -169,7 +169,7 @@ const ScoreIndividual = module.exports.ScoreIndividual = createReactClass({
                             scoreExplanation: scoreExplanation ? scoreExplanation : null
                         }, () => {
                             this.refs.scoreStatus.setValue(scoreStatus ? scoreStatus : 'none');
-                            this.refs.scoreExplanation.setValue(scoreExplanation ? scoreExplanation : '');
+                            if (this.refs.scoreExplanation) this.refs.scoreExplanation.setValue(scoreExplanation ? scoreExplanation : '');
                             this.updateUserScoreObj();
                         });
                     }


### PR DESCRIPTION
**Steps to test #1626:**
1. Login as part of an affiliation, and curate 3 proband evidence with 3 different variants in a GDM.
2. At the top of the gene-disease record page, click on the individual variant link buttons to curate each variant.
3. Upon curating the variants, click on each of the variant link buttons to go back into each of the curated variants. Expect to see each of the different variants retaining their own curation info.
4. Return to the Dashboard page and change to a different affiliation.
5. Go to the same GDM and curate the same 3 variants.
6. Expect to see each of the different variants retaining their own curation info, as well as showing the correct curations from the prior affiliation.

**Steps to test #1628:**
1. In a GDM, curate and score a proband evidence.
2. Then edit the scored proband evidence by removing the score.
3. Click the **View/Score** link for the proband evidence in the Curation Palette.
4. Expect to see the view-only evidence page to be rendered properly.
5. Removing the score can also be tested from the view-only page.
6. Repeat the testing steps for Case-Control and Experimental evidence and expect to see the same behaviors.

**Steps to test #1629:**
1. Curate and score 3 proband evidence in a GDM with various gene impact types and points involving 0.1 scores.
2. Click on the blue Classification Matrix button at the upper right of the gene-disease record page.
3. In the Classification Matrix table, expect to see the evidence total points and points counted to be rounded to 1 or 2 decimals (e.g. **0.3** or **0.45**) rather than **0.300000000000004**.