### PR TITLE
Connects to #1624. Page Study data patch.

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -680,8 +680,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             <tr key={key} className="page-data-item">
                 <td>{populationStatic.page._labels[popKey]}</td>
                 <td>{pageObj['nobs']}</td>
-                <td>{this.parseFloatShort(pageObj['alleles'][1]) + ': ' + this.parseFloatShort(pageObj['freq'][1])}</td>
-                <td>{this.parseFloatShort(pageObj['alleles'][0]) + ': ' + this.parseFloatShort(pageObj['freq'][0])}</td>
+                <td>{this.parseFloatShort(pageObj['alleles'][1]) + ': ' + this.parseFloatShort(1 - Number(pageObj['rawfreq']))}</td>
+                <td>{this.parseFloatShort(pageObj['alleles'][0]) + ': ' + this.parseFloatShort(pageObj['rawfreq'])}</td>
             </tr>
         );
     },

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -680,8 +680,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             <tr key={key} className="page-data-item">
                 <td>{populationStatic.page._labels[popKey]}</td>
                 <td>{pageObj['nobs']}</td>
-                <td>{this.parseFloatShort(pageObj['alleles'][1]) + ': ' + this.parseFloatShort(1 - Number(pageObj['rawfreq']))}</td>
-                <td>{this.parseFloatShort(pageObj['alleles'][0]) + ': ' + this.parseFloatShort(pageObj['rawfreq'])}</td>
+                <td>{pageObj['alleles'][1] + ': ' + this.parseFloatShort(1 - parseFloat(pageObj['rawfreq']))}</td>
+                <td>{pageObj['alleles'][0] + ': ' + this.parseFloatShort(pageObj['rawfreq'])}</td>
             </tr>
         );
     },


### PR DESCRIPTION
**Steps to test:**
1. In the VCI, select ClinVar ID **6762** and proceed to the Evidence View.
2. Click on the Population tab and scroll to the PAGE Study table.
3. Expect to see the **African American** population has a **C: 0.00012** allele frequency instead of **C: 0.12300**. 
4. And expect to see the **Cuban** population has a **C: 0.00024** allele frequency instead of **0.23640**.