### PR TITLE
1627 ct update travis tests

### DIFF
--- a/src/clincoded/tests/features/create_gene_disease.feature
+++ b/src/clincoded/tests/features/create_gene_disease.feature
@@ -76,4 +76,4 @@ Feature: Create Gene Disease
         Then I should see an element with the css selector ".pmid-selection-add-btn" within 5 seconds
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"

--- a/src/clincoded/tests/features/curation_central.feature
+++ b/src/clincoded/tests/features/curation_central.feature
@@ -34,7 +34,7 @@ Feature: Curation Central
         Then I should see "123456" within 5 seconds
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: Test PMID modal in Curation-central
@@ -55,4 +55,4 @@ Feature: Curation Central
         Then I should not see an element with the css selector ".modal-open"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"

--- a/src/clincoded/tests/features/curation_central.feature
+++ b/src/clincoded/tests/features/curation_central.feature
@@ -14,7 +14,7 @@ Feature: Curation Central
         Then I should see "Abstract" within 10 seconds
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: Test OMIM modal in Curation-central

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -32,7 +32,7 @@ Feature: Select Variant
         Then I should see "Variant Interpretation Record"
         When I press "Logout ClinGen Test Curator"
         And I wait for 10 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: VCI select-variant modal CAR functionality

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -59,6 +59,6 @@ Feature: Select Variant
         Then I should see " rs566967979"
         When I press "Logout ClinGen Test Curator"
         And I wait for 10 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 

--- a/src/clincoded/tests/features/variant_curation_tabs.feature
+++ b/src/clincoded/tests/features/variant_curation_tabs.feature
@@ -86,7 +86,7 @@ Feature: Variant Curation Tabs
         Then I should see "criteria provided, single submitter"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: Testing VCI tab functionality on non-SNV variant (Type: Insertion)
@@ -130,7 +130,7 @@ Feature: Variant Curation Tabs
         Then I should see "no assertion criteria provided"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: Testing VCI tab functionality on non-SNV variant (Type: Indel)
@@ -174,4 +174,4 @@ Feature: Variant Curation Tabs
         Then I should see "criteria provided, single submitter"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"

--- a/src/clincoded/tests/features/variant_curation_tabs.feature
+++ b/src/clincoded/tests/features/variant_curation_tabs.feature
@@ -42,7 +42,7 @@ Feature: Variant Curation Tabs
         Then I should see "reviewed by expert panel"
         When I press "Logout ClinGen Test Curator"
         And I wait for 5 seconds
-        Then I should see "All users may register for our demo version of the ClinGen interfaces"
+        Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
     Scenario: Testing VCI tab functionality on non-SNV variant (Type: Deletion)


### PR DESCRIPTION
Merge this second to last, before PR #1635 this updates the tests to read the new wording on the home screen. 

The current Travis tests are for the current wording for the homepage, I have corrected the wording for these tests to reflect what we will now have displayed. See PR #1635 to see what text has been changed.
