### PR TITLE
1641 elasticsearch oom error

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -204,12 +204,10 @@ write_files:
   content: |
     #TEMP changed to 2g for testing
     #ES_HEAP_SIZE=4g
-    
     if test "%(BACKUPDB)s" = "s3_data"
     then
      ES_HEAP_SIZE=8g
     fi
-
     ES_HEAP_SIZE=2g
 
 - path: /etc/postgresql/9.4/main/custom.conf

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -204,6 +204,12 @@ write_files:
   content: |
     #TEMP changed to 2g for testing
     #ES_HEAP_SIZE=4g
+    
+    if test "%(BACKUPDB)s" = "s3_data"
+    then
+     ES_HEAP_SIZE=8g
+    fi
+
     ES_HEAP_SIZE=2g
 
 - path: /etc/postgresql/9.4/main/custom.conf

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -207,8 +207,9 @@ write_files:
     if test "%(BACKUPDB)s" = "s3_data"
     then
      ES_HEAP_SIZE=8g
+    else
+     ES_HEAP_SIZE=2g
     fi
-    ES_HEAP_SIZE=2g
 
 - path: /etc/postgresql/9.4/main/custom.conf
   content: |


### PR DESCRIPTION
Updated cloud-config.yml to use 8g of memory if production data is used for instance creation, else it will use 2g for demo data.