### PR TITLE
Updated buildout.cfg and ez_setup.py for setuptools Connects to #1653

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,6 +5,8 @@ extends = versions.cfg
 include-site-packages = false
 # XXX https://bitbucket.org/pypa/setuptools/issue/133/find-links-should-override-allow-hosts
 allow-hosts =
+    pypi.org
+    files.pythonhosted.org
     *.python.org
     github.com
 find-links =

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -30,8 +30,8 @@ try:
 except ImportError:
     USER_SITE = None
 
-DEFAULT_VERSION = "14.3"
-DEFAULT_URL = "https://pypi.python.org/packages/source/s/setuptools/"
+DEFAULT_VERSION = "15.2"
+DEFAULT_URL = "https://files.pythonhosted.org/packages/28/17/f1b300eeec0405388bfffc51a1efb37c45ad713c978b231f2c24e1a7cee4/"
 DEFAULT_SAVE_DIR = os.curdir
 
 


### PR DESCRIPTION
I have added two other hosts in our buildout.cfg: pypi.org and files.pythonhosted.org.
Also, I have updated our ez_setup with the correct default version and default URL.
Thank you @forresttanaka and @jimmyzhen for finding these corrections.

To test these changes I ran the make clean for my local environment and then ran the buildout script `python3.4 bootstrap.py -v 2.9.5 --setuptools-version 15.2`.

- If the changes did not work I should see an error saying that the file for setuptools downloaded is not a .zip file.
- The changes did work and I saw the build out script run and complete successfully. 