### PR TITLE
Connects to #1658. Upgrade script bug.

### DIFF
--- a/src/clincoded/upgrade/provisionalClassification.py
+++ b/src/clincoded/upgrade/provisionalClassification.py
@@ -34,8 +34,10 @@ def provisionalClassification_4_5(value, system):
     # https://github.com/ClinGen/clincoded/issues/1417
     # Add various points properties and update schema version
     if 'totalScore' in value:
-        value['classificationPoints']['evidencePointsTotal'] = value['totalScore']
-        value.pop('totalScore', None)
+        if 'classificationPoints' not in value:
+            value['classificationPoints'] = {}
+            value['classificationPoints']['evidencePointsTotal'] = value['totalScore']
+            value.pop('totalScore', None)
 
     if 'classificationStatus' in value:
         if value['classificationStatus'] == 'Provisional':


### PR DESCRIPTION
**Steps to test:**
1. Spin up an instance with a backup copy of the production data prior to 2018-04-18.
2. Run the `batchupgrade` script on the instance.
3. Expect to see no errors incurred by the script.
4. Reindex the ElasticSearch data.
5. Go to ^/provisional/ and check the JSON data of individual `provisionalClassification` objects.
6. Expect to see the `totalScore` property being replaced by the `classificationPoints.evidencePointsTotal` property.