### PR TITLE
Connects to #1689. Upgrade script changes.

### DIFF
--- a/src/clincoded/upgrade/interpretation.py
+++ b/src/clincoded/upgrade/interpretation.py
@@ -169,3 +169,10 @@ def interpretation_4_5(value, system):
     # Add affiliation property and update schema version
     return
 
+
+@upgrade_step('interpretation', '5', '6')
+def interpretation_5_6(value, system):
+    # https://github.com/ClinGen/clincoded/issues/1600
+    # Add canonical transcript title property and update schema version
+    return
+

--- a/src/clincoded/upgrade/variant.py
+++ b/src/clincoded/upgrade/variant.py
@@ -109,3 +109,9 @@ def variant_2_3(value, system):
     if 'hgvsNames' in value and value['hgvsNames'] == []:
         value['hgvsNames'] = {}
 
+
+@upgrade_step('variant', '3', '4')
+def variant_3_4(value, system):
+    # https://github.com/ClinGen/clincoded/issues/1600
+    # Add canonical transcript title property and update schema version
+    return


### PR DESCRIPTION
**Steps to test:**
1. Spin up an instance with a backup copy of the production data prior to 2018-05-22.
2. Run the `batchupgrade` script on the instance.
3. Expect to see no errors incurred by the script.
4. Reindex the ElasticSearch data.
5. Go to ^/interpretation/ and check the JSON data of individual `interpretation` objects.
6. Expect to see the `schema_version` property value being `6` instead of `5`.
7. Go to ^/variant/ and check the JSON data of individual `variant` objects.
8. Expect to see the `schema_version` property value being `4` instead of `3`.