### PR TITLE
Connects to #1701. Updating Auth0 lock to version 11.7.2.

### DIFF
--- a/src/clincoded/static/components/app.js
+++ b/src/clincoded/static/components/app.js
@@ -262,7 +262,7 @@ var App = module.exports = createReactClass({
                     <title>ClinGen</title>
                     <link rel="canonical" href={canonical} />
                     <script async src='//www.google-analytics.com/analytics.js'></script>
-                    <script src="https://cdn.auth0.com/js/lock/10.17.0/lock.min.js"></script>
+                    <script src="https://cdn.auth0.com/js/lock/11.7.2/lock.min.js"></script>
                     <script data-prop-name="inline" dangerouslySetInnerHTML={{__html: this.props.inline}}></script>
                     <link rel="stylesheet" href="@@cssFile" />
                     <link rel="stylesheet" href="https://unpkg.com/react-day-picker/lib/style.css" />


### PR DESCRIPTION
I have added the latest version of Auth0 to app.js for install.
I have also added the correct URLs to Auth0 for allowed origins and callbacks.

I tested this from a demo instance:
- Install the latest Auth0 version
- Verify that I could log in via google
- Verify I could log in without google
- Be sure the curators could log in with both Google and text box.

Completion of testing showed that both I and the curators could log in with both Google and text box successfully. 