### PR TITLE
Connects to #1713. Adding config for apache-error logs to also be sent to AWS.

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -236,6 +236,13 @@ write_files:
       initial_position = end_of_file
       log_group_name = Apache2-prod
 
+      [/var/log/apache2]
+      file = /var/log/apache2/error.log
+      buffer_duration = 5000
+      log_stream_name = {hostname}
+      initial_position = end_of_file
+      log_group_name = Apache2-error-log-prod
+
       [/var/log/postgresql]
       file = /var/log/postgresql/postgresql-9.4-main.log
       buffer_duration = 5000


### PR DESCRIPTION
This will add the apache error logs to the awslogs. It was left out and had been added manually during a release. Now it has been added to the cloud-config so it will be added as the release is built.