### PR TITLE
Connects to #1827. R23rc1 bugs.

### DIFF
--- a/src/clincoded/static/components/admin/reports/index.js
+++ b/src/clincoded/static/components/admin/reports/index.js
@@ -128,7 +128,7 @@ const AdminReports = createReactClass({
                     const classifications = gdm.provisionalClassifications;
                     const affiliatedClassification = this.findAffiliatedClassification(classifications, affiliation.affiliation_id);
                     // Get the most recently published snapshot
-                    const snapshots = affiliatedClassification.associatedClassificationSnapshots;
+                    const snapshots = affiliatedClassification && affiliatedClassification.associatedClassificationSnapshots ? affiliatedClassification.associatedClassificationSnapshots : null;
                     const sortedSnapshots = snapshots && snapshots.length ? sortListByDate(snapshots, 'date_created') : [];
                     const publishedSnapshot = sortedSnapshots.find(snapshot => snapshot.approvalStatus === 'Approved' && snapshot.publishStatus);
                     return typeof publishedSnapshot === 'object' && Object.keys(publishedSnapshot).length;


### PR DESCRIPTION
**Technical notes:**
1. Production data is required for testing this PR.
2. Have the Chrome DevTools console open while testing.

**Steps to test:**
1. Sign in as admin and go to `^/admin`.
2. On the landing page, select the **Gene-Disease Record Stats for Expert Panels** option from the reports selection dropdown.
![image](https://user-images.githubusercontent.com/6956310/48382985-ac018b80-e698-11e8-831b-ac5e8f49c281.png)
3. Click the **Submit** button and expect to the stats table to be rendered without any Javascript errors.