### PR TITLE
Connects to 1832. Added PHI disclaimer/warning to VCI.

### DIFF
--- a/src/clincoded/static/components/variant_central/actions.js
+++ b/src/clincoded/static/components/variant_central/actions.js
@@ -101,6 +101,21 @@ var VariantCurationActions = module.exports.VariantCurationActions = createReact
     },
 
     /**
+     * Method to handle user's response (Agree/Disagree) to PHI Disclaimer modal (presented when user attempts to start a new interpretation)
+     * @param {object} e - The submitted event object
+     * @param {string} buttonSelected - String value of the button/response selected by the user
+     */
+    handlePHIDisclaimerResponse: function(e, buttonSelected) {
+        this.child.closeModal();
+
+        if (buttonSelected === 'Agree') {
+            this.handleInterpretationEvent(e);
+        } else {
+            e.preventDefault(); e.stopPropagation();
+        }
+    },
+
+    /**
      * Update the 'diseaseObj' state used to save data upon form submission
      */
     updateDiseaseObj(diseaseObj) {
@@ -143,9 +158,17 @@ var VariantCurationActions = module.exports.VariantCurationActions = createReact
                         <h2><span>Evidence View</span></h2>
                         <div className="btn-group">
                             {!hasExistingInterpretation ?
-                                <button className="btn btn-primary pull-right" onClick={this.handleInterpretationEvent}>
-                                    Interpretation <i className="icon icon-plus-circle"></i>
-                                </button>
+                                <ModalComponent modalTitle="PHI Disclaimer" modalClass="modal-warning" modalWrapperClass="phi-disclaimer-modal" bootstrapBtnClass="btn btn-primary pull-right"
+                                    actuatorClass="" actuatorTitle={<span>Interpretation <i className="icon icon-plus-circle"></i></span>} onRef={ref => (this.child = ref)}>
+                                    <div className="modal-body">Users should not enter unique or sensitive information that is likely to identify an individual. Users
+                                        should not publish data found in this interface without permission from the individual(s) who entered the data. For publication
+                                        of aggregate information, please contact ClinGen at <a href="mailto:clingen@clinicalgenome.org">clingen@clinicalgenome.org</a>.
+                                        <br /><br />Do you agree to these terms?</div>
+                                    <div className="modal-footer">
+                                        <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={(e) => this.handlePHIDisclaimerResponse(e, 'Agree')} title="Agree" />
+                                        <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={(e) => this.handlePHIDisclaimerResponse(e, 'Disagree')} title="Disagree" />
+                                    </div>
+                                </ModalComponent>
                                 : null}
                         </div>
                     </div>

--- a/src/clincoded/static/components/variant_central/interpretation/segregation.js
+++ b/src/clincoded/static/components/variant_central/interpretation/segregation.js
@@ -68,6 +68,11 @@ var CurationInterpretationSegregation = module.exports.CurationInterpretationSeg
 
         return (
             <div className="variant-interpretation segregation">
+                {this.state.interpretation ?
+                    <p className="alert alert-warning">Users should not enter unique or sensitive information that is likely to identify an individual.
+                        Users should not publish data found in this interface without permission from the individual(s) who entered the data. For publication
+                        of aggregate information, please contact ClinGen at <a href="mailto:clingen@clinicalgenome.org">clingen@clinicalgenome.org</a>.</p>
+                    : null }
                 <PanelGroup accordion><Panel title="Observed in healthy adult(s)" panelBodyClassName="panel-wide-content"
                     panelClassName="tab-segegration-panel-observed-in-healthy" open>
                     {(this.state.data && this.state.interpretation) ?

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -29,6 +29,15 @@ Feature: Select Variant
         Then I should see "criteria provided, multiple submitters, no conflicts"
         When I press the button "Interpretation "
         And I wait for 1 seconds
+        Then I should see "PHI Disclaimer"
+        When I press the button "Disagree"
+        And I wait for 1 seconds
+        Then I should see "criteria provided, multiple submitters, no conflicts"
+        When I press the button "Interpretation "
+        And I wait for 1 seconds
+        Then I should see "PHI Disclaimer"
+        When I press the button "Agree"
+        And I wait for 1 seconds
         Then I should see "Variant Interpretation Record"
         When I press "Logout ClinGen Test Curator"
         And I wait for 10 seconds


### PR DESCRIPTION
Steps to test #1832:
1. Add a new variant or select one which does not have an interpretation.
2. Click the "Interpretation +" button to start an interpretation.
3. From the "PHI Disclaimer" modal that appears:
a) Clicking "Disagree" closes the modal and doesn't allow curation to continue.
b) Clicking "Agree" closes the modal and allows curation to continue (interpretation is created).
4. Within an interpretation, select the "Case/Segregation" tab to see a warning regarding PHI.