### PR TITLE
add platform/OS to Travis tests otherwise Sauce Labs runs as Windows NT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
         --browser-arg-int build  "$TRAVIS_BUILD_NUMBER" \
         --browser-arg-int idleTimeout 600 \
         --browser-arg name "$TRAVIS_REPO_SLUG $TRAVIS_BRANCH $TRAVIS_COMMIT" \
-        --browser-arg browser "$BROWSER"
+        --browser-arg browser "$BROWSER" \
         --browser-arg platform "Linux"
     fi
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
         --pidfile $SC_PIDFILE \
         --tunnel-identifier $TRAVIS_JOB_NUMBER \
         --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY > /dev/null &
-      while test -f "$SC_PIDFILE" && test ! -f "$SC_READYFILE"; do 
+      while test -f "$SC_PIDFILE" && test ! -f "$SC_READYFILE"; do
         sleep 0.5
       done
     fi
@@ -74,6 +74,7 @@ script:
         --browser-arg-int idleTimeout 600 \
         --browser-arg name "$TRAVIS_REPO_SLUG $TRAVIS_BRANCH $TRAVIS_COMMIT" \
         --browser-arg browser "$BROWSER"
+        --browser-arg platform "Linux"
     fi
 after_script:
   - >


### PR DESCRIPTION
Apparently Travis is now defaulting to using Windows NT if no OS/platform is specified, and as a result the tests on Sauce Labs fail when platform is not specified.

This change just directs Travis to use Linux as the platform for Sauce Labs to run the browser on (and also removed one non-significant whitespace at the end of a line elsewhere in the file).


- Sauce Labs:
  https://app.saucelabs.com/builds/e7fb05f1f71648b68964090dcaa7f868

  <img width="1065" alt="image" src="https://user-images.githubusercontent.com/1878194/49681277-ccccbf00-fa53-11e8-8cf1-bf168c524fe0.png">


- Travis:
https://travis-ci.org/ClinGen/clincoded/jobs/465228236



-----
### *NOTE*: Recommendations for future work:
 - add `dist: trusty`
 (precise is being discontinued, as seen on https://blog.travis-ci.com/2017-08-31-trusty-as-default-status)

 - upgrade Sauce Connect version from 4.4.2 to 4.5.2

- test against Windows or Mac in Sauce Labs


