### PR TITLE
Connects to #1715, Return gnomAD/ExAC data for indel variants in the VCI (Population Tab)

### DIFF
--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -82,7 +82,7 @@ var SelectVariant = createReactClass({
                                 </div>
                                 <div className="row">
                                     <div className="alert alert-danger">
-                                        Note: <strong>This version of the interface currently returns evidence for SNVs (single nucleotide variants) only.</strong> We are currently working to optimize the evidence returned for non-SNVs. However, the interface supports the evaluation/interpretation of any variant.
+                                        Note: <strong>This version of the interface currently returns evidence for SNVs (single nucleotide variants) and Indels (Insertions/Deletions) only.</strong> We are currently working to optimize the evidence returned for non-SNVs. However, the interface supports the evaluation/interpretation of any variant.
                                     </div>
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -83,7 +83,7 @@ var SelectVariant = createReactClass({
                                 <div className="row">
                                     <div className="alert alert-danger">
                                         Note: <strong>This version of the interface returns evidence for SNVs (single nucleotide variants) 
-                                        and for some small duplications, insertions, and deletions.</strong> 
+                                        and for some small duplications, insertions, and deletions. </strong> 
                                         We are currently working to optimize the evidence returned for other variant types. 
                                         However, the interface supports the evaluation/interpretation of any variant.
                                     </div>

--- a/src/clincoded/static/components/select_variant.js
+++ b/src/clincoded/static/components/select_variant.js
@@ -82,7 +82,10 @@ var SelectVariant = createReactClass({
                                 </div>
                                 <div className="row">
                                     <div className="alert alert-danger">
-                                        Note: <strong>This version of the interface currently returns evidence for SNVs (single nucleotide variants) and Indels (Insertions/Deletions) only.</strong> We are currently working to optimize the evidence returned for non-SNVs. However, the interface supports the evaluation/interpretation of any variant.
+                                        Note: <strong>This version of the interface returns evidence for SNVs (single nucleotide variants) 
+                                        and for some small duplications, insertions, and deletions.</strong> 
+                                        We are currently working to optimize the evidence returned for other variant types. 
+                                        However, the interface supports the evaluation/interpretation of any variant.
                                     </div>
                                     <div className="alert alert-info">
                                         Instructions (please follow this order to determine correct ID for variant)<br /><br />

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -55,7 +55,7 @@ var VariantCurationHub = createReactClass({
             ext_ensemblGeneId: null,
             ext_geneSynonyms: null,
             ext_singleNucleotide: true,
-            ext_indelVariant: true,
+            ext_gnomadExac: false,
             loading_clinvarEutils: true,
             loading_clinvarEsearch: true,
             loading_clinvarSCV: true,
@@ -288,6 +288,7 @@ var VariantCurationHub = createReactClass({
     parseVariantType: function(variant) {
         if (variant) {
             // Reference to http://www.hgvs.org/mutnomen/recs-DNA.html
+            const popVariantTypes = ['single nucleotide variant', 'deletion', 'insertion', 'duplication']
             let seqChangeTypes = ['del', 'dup', 'ins', 'indels', 'inv', 'con'];
             let genomicHGVS, ncGenomic;
 
@@ -299,10 +300,13 @@ var VariantCurationHub = createReactClass({
             // Filter variant by its change type
             // Look for the <VariantType> node value in first pass
             // Then look into HGVS term for non-SNV type patterns
+            if (variant.variationType && variant.variationType) {
+                if (popVariantTypes.indexOf(variant.variationType.toLowerCase()) > -1) {
+                    this.setState({ext_gnomadExac: true })
+                }
+            }
             if (variant.variationType && variant.variationType !== 'single nucleotide variant') {
                 this.setState({ext_singleNucleotide: false});
-            } else if (variant.variationType && variant.variationType !== 'Deletion' && variant.variationType && variant.variationType !== 'Duplication' && variant.variationType && variant.variationType !== 'Insertion') {
-                this.setState({ext_indelVariant: false})
             } else if (genomicHGVS) {
                 ncGenomic = genomicHGVS.substring(genomicHGVS.indexOf(':'));
                 seqChangeTypes.forEach(type => {
@@ -546,7 +550,7 @@ var VariantCurationHub = createReactClass({
                             ext_ensemblGeneId={this.state.ext_ensemblGeneId}
                             ext_geneSynonyms={this.state.ext_geneSynonyms}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
-                            ext_indelVariant={this.state.ext_indelVariant}
+                            ext_gnomadExac={this.state.ext_gnomadExac}
                             loading_clinvarEutils={this.state.loading_clinvarEutils}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                             loading_clinvarSCV={this.state.loading_clinvarSCV}

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -300,7 +300,7 @@ var VariantCurationHub = createReactClass({
             // Filter variant by its change type
             // Look for the <VariantType> node value in first pass
             // Then look into HGVS term for non-SNV type patterns
-            if (variant.variationType && variant.variationType) {
+            if (variant.variationType) {
                 if (popVariantTypes.indexOf(variant.variationType.toLowerCase()) > -1) {
                     this.setState({ext_gnomadExac: true })
                 }

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -301,7 +301,7 @@ var VariantCurationHub = createReactClass({
             // Then look into HGVS term for non-SNV type patterns
             if (variant.variationType && variant.variationType !== 'single nucleotide variant') {
                 this.setState({ext_singleNucleotide: false});
-            } else if (variant.variationType && variant.variationType !== 'Deletion' && variant.variationType && variant.variationType !== 'Duplication') {
+            } else if (variant.variationType && variant.variationType !== 'Deletion' && variant.variationType && variant.variationType !== 'Duplication' && variant.variationType && variant.variationType !== 'Insertion') {
                 this.setState({ext_indelVariant: false})
             } else if (genomicHGVS) {
                 ncGenomic = genomicHGVS.substring(genomicHGVS.indexOf(':'));

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -55,6 +55,7 @@ var VariantCurationHub = createReactClass({
             ext_ensemblGeneId: null,
             ext_geneSynonyms: null,
             ext_singleNucleotide: true,
+            ext_indelVariant: true,
             loading_clinvarEutils: true,
             loading_clinvarEsearch: true,
             loading_clinvarSCV: true,
@@ -283,7 +284,7 @@ var VariantCurationHub = createReactClass({
     },
 
     // Method to parse variant type
-    // Won't show population/predictor data if subject is not single nucleotide variant
+    // Won't show population/predictor data if subject is not single nucleotide variant or indel
     parseVariantType: function(variant) {
         if (variant) {
             // Reference to http://www.hgvs.org/mutnomen/recs-DNA.html
@@ -300,6 +301,8 @@ var VariantCurationHub = createReactClass({
             // Then look into HGVS term for non-SNV type patterns
             if (variant.variationType && variant.variationType !== 'single nucleotide variant') {
                 this.setState({ext_singleNucleotide: false});
+            } else if (variant.variationType && variant.variationType !== 'Deletion' && variant.variationType && variant.variationType !== 'Duplication') {
+                this.setState({ext_indelVariant: false})
             } else if (genomicHGVS) {
                 ncGenomic = genomicHGVS.substring(genomicHGVS.indexOf(':'));
                 seqChangeTypes.forEach(type => {
@@ -543,6 +546,7 @@ var VariantCurationHub = createReactClass({
                             ext_ensemblGeneId={this.state.ext_ensemblGeneId}
                             ext_geneSynonyms={this.state.ext_geneSynonyms}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
+                            ext_indelVariant={this.state.ext_indelVariant}
                             loading_clinvarEutils={this.state.loading_clinvarEutils}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                             loading_clinvarSCV={this.state.loading_clinvarSCV}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -44,6 +44,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_ensemblGeneId: PropTypes.string,
         ext_geneSynonyms: PropTypes.array,
         ext_singleNucleotide: PropTypes.bool,
+        ext_indelVariant: PropTypes.bool,
         loading_clinvarEutils: PropTypes.bool,
         loading_clinvarEsearch: PropTypes.bool,
         loading_clinvarSCV: PropTypes.bool,
@@ -75,6 +76,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
+            ext_indelVariant: this.props.ext_indelVariant,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch,
             loading_clinvarSCV: this.props.loading_clinvarSCV,
@@ -138,6 +140,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
+            ext_indelVariant: nextProps.ext_indelVariant,
             loading_myGeneInfo: nextProps.loading_myGeneInfo,
             loading_pageData: nextProps.loading_pageData,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
@@ -209,6 +212,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_ensemblVariation={this.state.ext_ensemblVariation}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
+                            ext_indelVariant={this.state.ext_indelVariant}
                             loading_pageData={this.state.pageData}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_ensemblVariation={this.state.loading_ensemblVariation}
@@ -224,6 +228,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
+                            ext_indelVariant={this.state.ext_indelVariant}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                             affiliation={this.props.affiliation}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -228,7 +228,6 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
-                            ext_gnomadExac={this.state.ext_gnomadExac}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                             affiliation={this.props.affiliation}

--- a/src/clincoded/static/components/variant_central/interpretation.js
+++ b/src/clincoded/static/components/variant_central/interpretation.js
@@ -44,7 +44,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         ext_ensemblGeneId: PropTypes.string,
         ext_geneSynonyms: PropTypes.array,
         ext_singleNucleotide: PropTypes.bool,
-        ext_indelVariant: PropTypes.bool,
+        ext_gnomadExac: PropTypes.bool,
         loading_clinvarEutils: PropTypes.bool,
         loading_clinvarEsearch: PropTypes.bool,
         loading_clinvarSCV: PropTypes.bool,
@@ -76,7 +76,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
             ext_ensemblGeneId: this.props.ext_ensemblGeneId,
             ext_geneSynonyms: this.props.ext_geneSynonyms,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
-            ext_indelVariant: this.props.ext_indelVariant,
+            ext_gnomadExac: this.props.ext_gnomadExac,
             loading_clinvarEutils: this.props.loading_clinvarEutils,
             loading_clinvarEsearch: this.props.loading_clinvarEsearch,
             loading_clinvarSCV: this.props.loading_clinvarSCV,
@@ -140,7 +140,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
-            ext_indelVariant: nextProps.ext_indelVariant,
+            ext_gnomadExac: nextProps.ext_gnomadExac,
             loading_myGeneInfo: nextProps.loading_myGeneInfo,
             loading_pageData: nextProps.loading_pageData,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
@@ -212,7 +212,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_ensemblHgvsVEP={this.state.ext_ensemblHgvsVEP}
                             ext_ensemblVariation={this.state.ext_ensemblVariation}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
-                            ext_indelVariant={this.state.ext_indelVariant}
+                            ext_gnomadExac={this.state.ext_gnomadExac}
                             loading_pageData={this.state.pageData}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_ensemblVariation={this.state.loading_ensemblVariation}
@@ -228,7 +228,7 @@ var VariantCurationInterpretation = module.exports.VariantCurationInterpretation
                             ext_clinvarEutils={this.state.ext_clinvarEutils}
                             ext_clinVarEsearch={this.state.ext_clinVarEsearch}
                             ext_singleNucleotide={this.state.ext_singleNucleotide}
-                            ext_indelVariant={this.state.ext_indelVariant}
+                            ext_gnomadExac={this.state.ext_gnomadExac}
                             loading_myVariantInfo={this.state.loading_myVariantInfo}
                             loading_clinvarEsearch={this.state.loading_clinvarEsearch}
                             affiliation={this.props.affiliation}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -62,7 +62,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         ext_ensemblHgvsVEP: PropTypes.array,
         ext_ensemblVariation: PropTypes.object,
         ext_singleNucleotide: PropTypes.bool,
-        ext_indelVariant: PropTypes.bool,
+        ext_gnomadExac: PropTypes.bool,
         loading_pageData: PropTypes.bool,
         loading_myVariantInfo: PropTypes.bool,
         loading_ensemblVariation: PropTypes.bool,
@@ -118,7 +118,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             populationObjDiff: null,
             populationObjDiffFlag: false,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
-            ext_indelVariant: this.props.ext_indelVariant,
+            ext_gnomadExac: this.props.ext_gnomadExac,
             loading_pageData: this.props.loading_pageData,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_ensemblVariation: this.props.loading_ensemblVariation,
@@ -192,7 +192,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
-            ext_indelVariant: nextProps.ext_indelVariant,
+            ext_gnomadExac: nextProps.ext_gnomadExac,
             loading_ensemblVariation: nextProps.loading_ensemblVariation,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
             loading_pageData: nextProps.loading_pageData
@@ -687,7 +687,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
             // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
             // Or there is no ExAC/gnomAD data object in the returned myvariant.info JSON response
-            if (!this.state.ext_indelVariant || !this.state.ext_singleNucleotide || !datasetCheck) {
+            if (!this.state.ext_gnomadExac || !this.state.ext_singleNucleotide || !datasetCheck) {
                 datasetLink = external_url_map[datasetRegionURLKey] + chrom + '-' + regionStart + '-' + regionEnd;
                 linkText = 'View the coverage of this region (+/- 30 bp) in ' + datasetName;
             }
@@ -1124,7 +1124,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         var desiredCI = this.state.populationObj && this.state.populationObj.desiredCI ? this.state.populationObj.desiredCI : CI_DEFAULT;
         var populationObjDiffFlag = this.state.populationObjDiffFlag;
         var singleNucleotide = this.state.ext_singleNucleotide;
-        var indelVariant = this.state.ext_indelVariant;
+        var gnomadExac = this.state.ext_gnomadExac;
         let exacSortedAlleleFrequency = this.sortObjKeys(exac);
         let gnomADSortedAlleleFrequency = this.sortObjKeys(gnomAD);
         const affiliation = this.props.affiliation, session = this.props.session;
@@ -1192,7 +1192,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {!singleNucleotide && !indelVariant ?
+                            {!gnomadExac ?
                                 <div className="panel-body">
                                     <span>Data is currently only returned for single nucleotide variants and for some small duplications, insertions, and deletions. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'gnomAD')}</span>
                                 </div>
@@ -1236,7 +1236,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {!singleNucleotide && !indelVariant ?
+                            {!gnomadExac ?
                                 <div className="panel-body">
                                     <span>Data is currently only returned for single nucleotide variants and for some small duplications, insertions, and deletions. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'ExAC')}</span>
                                 </div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -933,7 +933,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     },
 
     // Method to render ExAC/gnomAD population table header content
-    renderExacGnomadHeader: function(datasetCheck, loading_myVariantInfo, dataset, singleNucleotide, response, datasetName) {
+    renderExacGnomadHeader: function(datasetCheck, loading_myVariantInfo, dataset, gnomadExac, response, datasetName) {
         let datasetVariant = '';
         let datasetLink;
 
@@ -947,7 +947,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             }
         }
 
-        if (datasetCheck && !loading_myVariantInfo && singleNucleotide) {
+        if (datasetCheck && !loading_myVariantInfo && gnomadExac) {
             const datasetVariantURLKey = (datasetName === 'ExAC') ? 'EXAC' : (datasetName === 'gnomAD') ? 'gnomAD' : null;
             const datasetURL = 'http:' + external_url_map[datasetVariantURLKey] + dataset._extra.chrom + '-' + dataset._extra.pos + '-' + dataset._extra.ref + '-' + dataset._extra.alt;
             datasetLink = <a className="panel-subtitle pull-right" href={datasetURL} target="_blank">See data in {datasetName}</a>
@@ -1188,7 +1188,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </div>
                     <div className="panel panel-info datasource-gnomAD">
                         <div className="panel-heading">
-                            {this.renderExacGnomadHeader(this.state.hasGnomadData, this.state.loading_myVariantInfo, gnomAD, singleNucleotide, this.props.ext_myVariantInfo, 'gnomAD')}
+                            {this.renderExacGnomadHeader(this.state.hasGnomadData, this.state.loading_myVariantInfo, gnomAD, gnomadExac, this.props.ext_myVariantInfo, 'gnomAD')}
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
@@ -1232,7 +1232,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                     </div>
                     <div className="panel panel-info datasource-ExAC">
                         <div className="panel-heading">
-                            {this.renderExacGnomadHeader(this.state.hasExacData, this.state.loading_myVariantInfo, exac, singleNucleotide, this.props.ext_myVariantInfo, 'ExAC')}
+                            {this.renderExacGnomadHeader(this.state.hasExacData, this.state.loading_myVariantInfo, exac, gnomadExac, this.props.ext_myVariantInfo, 'ExAC')}
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -687,7 +687,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
             // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
             // Or there is no ExAC/gnomAD data object in the returned myvariant.info JSON response
-            if (!this.state.ext_gnomadExac || !this.state.ext_singleNucleotide || !datasetCheck) {
+            if (!this.state.ext_gnomadExac || !datasetCheck) {
                 datasetLink = external_url_map[datasetRegionURLKey] + chrom + '-' + regionStart + '-' + regionEnd;
                 linkText = 'View the coverage of this region (+/- 30 bp) in ' + datasetName;
             }

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -62,6 +62,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         ext_ensemblHgvsVEP: PropTypes.array,
         ext_ensemblVariation: PropTypes.object,
         ext_singleNucleotide: PropTypes.bool,
+        ext_indelVariant: PropTypes.bool,
         loading_pageData: PropTypes.bool,
         loading_myVariantInfo: PropTypes.bool,
         loading_ensemblVariation: PropTypes.bool,
@@ -117,6 +118,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             populationObjDiff: null,
             populationObjDiffFlag: false,
             ext_singleNucleotide: this.props.ext_singleNucleotide,
+            ext_indelVariant: this.props.ext_indelVariant,
             loading_pageData: this.props.loading_pageData,
             loading_myVariantInfo: this.props.loading_myVariantInfo,
             loading_ensemblVariation: this.props.loading_ensemblVariation,
@@ -190,6 +192,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         }
         this.setState({
             ext_singleNucleotide: nextProps.ext_singleNucleotide,
+            ext_indelVariant: nextProps.ext_indelVariant,
             loading_ensemblVariation: nextProps.loading_ensemblVariation,
             loading_myVariantInfo: nextProps.loading_myVariantInfo,
             loading_pageData: nextProps.loading_pageData
@@ -684,7 +687,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
             let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
             // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
             // Or there is no ExAC/gnomAD data object in the returned myvariant.info JSON response
-            if (!this.state.ext_singleNucleotide || !datasetCheck) {
+            if (!this.state.ext_indelVariant || !this.state.ext_singleNucleotide || !datasetCheck) {
                 datasetLink = external_url_map[datasetRegionURLKey] + chrom + '-' + regionStart + '-' + regionEnd;
                 linkText = 'View the coverage of this region (+/- 30 bp) in ' + datasetName;
             }
@@ -1121,6 +1124,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         var desiredCI = this.state.populationObj && this.state.populationObj.desiredCI ? this.state.populationObj.desiredCI : CI_DEFAULT;
         var populationObjDiffFlag = this.state.populationObjDiffFlag;
         var singleNucleotide = this.state.ext_singleNucleotide;
+        var indelVariant = this.state.ext_indelVariant;
         let exacSortedAlleleFrequency = this.sortObjKeys(exac);
         let gnomADSortedAlleleFrequency = this.sortObjKeys(gnomAD);
         const affiliation = this.props.affiliation, session = this.props.session;
@@ -1188,9 +1192,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {!singleNucleotide ?
+                            {!singleNucleotide && !indelVariant ?
                                 <div className="panel-body">
-                                    <span>Data is currently only returned for single nucleotide variants. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'gnomAD')}</span>
+                                    <span>Data is currently only returned for single nucleotide variants and indels. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'gnomAD')}</span>
                                 </div>
                                 :
                                 <div>
@@ -1232,9 +1236,9 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                         </div>
                         <div className="panel-content-wrapper">
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
-                            {!singleNucleotide ?
+                            {!singleNucleotide && !indelVariant ?
                                 <div className="panel-body">
-                                    <span>Data is currently only returned for single nucleotide variants. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'ExAC')}</span>
+                                    <span>Data is currently only returned for single nucleotide variants and indels. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'ExAC')}</span>
                                 </div>
                                 :
                                 <div>

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -1194,7 +1194,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                             {!singleNucleotide && !indelVariant ?
                                 <div className="panel-body">
-                                    <span>Data is currently only returned for single nucleotide variants and indels. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'gnomAD')}</span>
+                                    <span>Data is currently only returned for single nucleotide variants and for some small duplications, insertions, and deletions. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'gnomAD')}</span>
                                 </div>
                                 :
                                 <div>
@@ -1238,7 +1238,7 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
                             {this.state.loading_myVariantInfo ? showActivityIndicator('Retrieving data... ') : null}
                             {!singleNucleotide && !indelVariant ?
                                 <div className="panel-body">
-                                    <span>Data is currently only returned for single nucleotide variants and indels. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'ExAC')}</span>
+                                    <span>Data is currently only returned for single nucleotide variants and for some small duplications, insertions, and deletions. {this.renderExacGnomadLinkout(this.props.ext_myVariantInfo, 'ExAC')}</span>
                                 </div>
                                 :
                                 <div>


### PR DESCRIPTION
Steps to test #1715 

1. New Variant Curation, Search and Select Variant for the following:
 - (ClinVar VariationID: 18000) represents a SNV (single nucleotide variant)
 - (ClinVar VariationID: 372075) represents a 4bp deletion (indel variant)

2. Confirm red info card on Search/Select Variant reads "This version of the interface returns evidence for SNVs (single nucleotide variants) and for some small duplications, insertions, and deletions." 

3. Confirm that gnomAD/ExAC data for both variants renders in Population tab, along with their respective "link-outs" in header ("See data in gnomAD/ExAC")