### PR TITLE
Connects to #1326. Connects to #1808. Connects to #1866. Copy NOT Phenotypes information from Groups to Families and Individuals.

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -3,7 +3,7 @@
 # Instance
 
 apt_sources:
-- source: "ppa:webupd8team/java"
+- source: "ppa:openjdk-r/ppa"
 - source: "deb http://packages.elasticsearch.org/elasticsearch/1.7/debian stable main"
   key: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -39,7 +39,6 @@ apt_sources:
     -----END PGP PUBLIC KEY BLOCK-----
 bootcmd:
 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/users_ca.pub" >> /etc/ssh/sshd_config
-- cloud-init-per once accepted-oracle-license-v1-1 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 - cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
 - cloud-init-per once chmod-swapfile chmod 600 /swapfile
 - cloud-init-per once mkswap-swapfile mkswap /swapfile
@@ -68,8 +67,7 @@ packages:
 - libxslt1-dev
 - lzop
 - ntp
-- oracle-java8-installer
-- oracle-java8-set-default
+- openjdk-8-jdk
 - pv
 - python2.7-dev
 - python3.4-dev

--- a/src/clincoded/static/components/curator.js
+++ b/src/clincoded/static/components/curator.js
@@ -2449,10 +2449,14 @@ var renderPhenotype = module.exports.renderPhenotype = function(objList, title, 
                         return (
                             <div key={obj.uuid} className="form-group">
                                 <div className="col-sm-5">
-                                    <strong className="pull-right">Phenotype(s) Associated with {parentObjName ? parentObjName : title}
-                                    {type === 'hpo' ? <span style={{fontWeight: 'normal'}}> (<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span> : null}
-                                    {type === 'ft' ? <span style={{fontWeight: 'normal'}}> (free text)</span> : null}
-                                    :</strong>
+                                    { (type === 'hpo' || type === 'ft') ? <strong className="pull-right">Phenotype(s) Associated with {parentObjName ? parentObjName : title}
+                                        {type === 'hpo' ? <span style={{fontWeight: 'normal'}}> (<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span> : null}
+                                        {type === 'ft' ? <span style={{fontWeight: 'normal'}}> (free text)</span> : null}
+                                    :</strong> : null}
+                                    { (type === 'nothpo' || type === 'notft') ? <strong className="pull-right">NOT Phenotype(s) Associated with {parentObjName ? parentObjName : title}
+                                        {type === 'nothpo' ? <span style={{fontWeight: 'normal'}}> (<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span> : null}
+                                        {type === 'notft' ? <span style={{fontWeight: 'normal'}}> (free text)</span> : null}
+                                    :</strong> : null}
                                 </div>
                                 <div className="col-sm-7">
                                     { (type === 'hpo' || type === '') && (obj.hpoIdInDiagnosis && obj.hpoIdInDiagnosis.length > 0) ?
@@ -2467,8 +2471,25 @@ var renderPhenotype = module.exports.renderPhenotype = function(objList, title, 
                                         })
                                         : null
                                     }
+                                    { (type === 'nothpo' || type === '') && (obj.hpoIdInElimination && obj.hpoIdInElimination.length > 0) ?
+                                        obj.hpoIdInElimination.map(function(nothpoid, i) {
+                                            return (
+                                                <span key={nothpoid}>
+                                                    {nothpoid}
+                                                    {i < obj.hpoIdInElimination.length-1 ? ', ' : ''}
+                                                    {i === obj.hpoIdInElimination.length-1 && obj.termsInElimination && type === '' ? '; ' : null}
+                                                </span>
+                                            );
+                                        })
+                                        : null
+                                    }
                                     { type === 'ft' && obj.termsInDiagnosis ?
                                         <span>{obj.termsInDiagnosis}</span>
+                                        :
+                                        null
+                                    }
+                                    { type === 'notft' && obj.termsInElimination ?
+                                        <span>{obj.termsInElimination}</span>
                                         :
                                         null
                                     }

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1590,9 +1590,15 @@ function FamilyCommonDiseases() {
                     title="Copy all Phenotype(s) from Associated Group" clickHandler={this.handleCopyGroupPhenotypes} />
                 : null}
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Family</em> if they are specifically noted in the paper.</p>
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                curator.renderPhenotype(associatedGroups, 'Family', 'nothpo', 'Group') : curator.renderPhenotype(null, 'Family', 'nothpo')
+            }   
             <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : curator.renderPhenotype(null, 'Family', 'notft')
+            }    
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2" value={family && family.termsInElimination ? family.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1591,14 +1591,12 @@ function FamilyCommonDiseases() {
                 : null}
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Family</em> if they are specifically noted in the paper.</p>
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
-                curator.renderPhenotype(associatedGroups, 'Family', 'nothpo', 'Group') : curator.renderPhenotype(null, 'Family', 'nothpo')
-            }   
+                curator.renderPhenotype(associatedGroups, 'Family', 'nothpo', 'Group') : null}
             <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
-                curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : curator.renderPhenotype(null, 'Family', 'notft')
-            }    
+                curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : null}    
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2" value={family && family.termsInElimination ? family.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -265,6 +265,43 @@ var FamilyCuration = createReactClass({
         }
     },
 
+    handleCopyGroupNotPhenotypes(e) {
+        e.preventDefault(); e.stopPropagation();
+        var associatedGroups;
+        var hpoInElim = '';
+        var hpoElimFreeText = '';
+        if (this.state.group) {
+            // We have a group, so get the disease array from it.
+            associatedGroups = [this.state.group];
+        } else if (this.state.family && this.state.family.associatedGroups && this.state.family.associatedGroups.length) {
+            // We have a family with associated groups. Combine the diseases from all groups.
+            associatedGroups = this.state.family.associatedGroups;
+        }
+        if (associatedGroups && associatedGroups.length > 0) {
+            hpoInElim = associatedGroups.map(function(associatedGroup, i) {
+                if (associatedGroup.hpoIdInElimination && associatedGroup.hpoIdInElimination.length) {
+                    return (
+                        associatedGroup.hpoIdInElimination.map(function(elimHpoId, i) {
+                            return (elimHpoId);
+                        }).join(', ')
+                    );
+                }
+            });
+            if (hpoInElim.length) {
+                this.refs['nothpoid'].setValue(hpoInElim.join(', '));
+            }
+            hpoElimFreeText = associatedGroups.map(function(associatedGroup, i) {
+                if (associatedGroup.termsInElimination) {
+                    return associatedGroup.termsInElimination;
+                }
+            });
+            if (hpoElimFreeText !== '') {
+                this.refs['notphenoterms'].setValue(hpoElimFreeText.join(', '));
+            }
+        }
+
+    },
+
     // Handle a click on a copy demographics button
     handleCopyGroupDemographics(e) {
         e.preventDefault(); e.stopPropagation();
@@ -1558,6 +1595,10 @@ function FamilyCommonDiseases() {
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2" value={family && family.termsInElimination ? family.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                <Input type="button" ref={(button) => { this.notphenotypecopygroup = button; }} wrapperClassName="col-sm-7 col-sm-offset-5 orphanet-copy" inputClassName="btn-copy btn-last btn-sm"
+                    title="Copy all NOT Phenotype(s) from Associated Group" clickHandler={this.handleCopyGroupNotPhenotypes} />
+                : null}
         </div>
     );
 }

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2020,7 +2020,7 @@ const FamilyViewer = createReactClass({
             this.setState({submitBusy: true});
             var family = data;
 
-            // Write the assessment to the DB, if there was one.
+            // Write the assessment to the DB, if there was one
             return this.saveAssessment(this.cv.assessmentTracker, this.cv.gdmUuid, this.props.context.uuid).then(assessmentInfo => {
                 // If we're assessing a family segregation, write that to history
                 this.saveAssessmentHistory(assessmentInfo.assessment, null, family, assessmentInfo.update);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1247,7 +1247,7 @@ function IndividualCommonDiseases() {
                 curator.renderPhenotype(associatedGroups, 'Individual', 'nothpo', 'Group') 
                 :
                 (associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
-                    curator.renderPhenotype(associatedFamilies, 'Individual', 'nothpo', 'Family') : curator.renderPhenotype(null, 'Individual', 'nothpo')
+                    curator.renderPhenotype(associatedFamilies, 'Individual', 'nothpo', 'Family') : null
                 ) 
             }  
             <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
@@ -1257,7 +1257,7 @@ function IndividualCommonDiseases() {
                 curator.renderPhenotype(associatedGroups, 'Individual', 'notft', 'Group') 
                 :
                 (associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
-                    curator.renderPhenotype(associatedFamilies, 'Individual', 'notft', 'Family') : curator.renderPhenotype(null, 'Individual', 'notft')
+                    curator.renderPhenotype(associatedFamilies, 'Individual', 'notft', 'Family') : null
                 )
             }       
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2"

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1243,9 +1243,23 @@ function IndividualCommonDiseases() {
                     clickHandler={this.handleClick.bind(this, associatedFamilies[0], 'phenotype')} />
                 : null}
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Individual</em> if they are specifically noted in the paper.</p>
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                curator.renderPhenotype(associatedGroups, 'Individual', 'nothpo', 'Group') 
+                :
+                (associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
+                    curator.renderPhenotype(associatedFamilies, 'Individual', 'nothpo', 'Family') : curator.renderPhenotype(null, 'Individual', 'nothpo')
+                ) 
+            }  
             <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
                 error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                curator.renderPhenotype(associatedGroups, 'Individual', 'notft', 'Group') 
+                :
+                (associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
+                    curator.renderPhenotype(associatedFamilies, 'Individual', 'notft', 'Family') : curator.renderPhenotype(null, 'Individual', 'notft')
+                )
+            }       
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2"
                 value={individual && individual.termsInElimination ? individual.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -114,6 +114,7 @@ const IndividualCuration = createReactClass({
     handleClick: function(obj, item, e) {
         e.preventDefault(); e.stopPropagation();
         var hpoIds = '';
+        var hpoElimIds = '';
 
         if (item === 'phenotype') {
             if (obj.hpoIdInDiagnosis && obj.hpoIdInDiagnosis.length) {
@@ -136,6 +137,16 @@ const IndividualCuration = createReactClass({
 
             if (obj.race) {
                 this.refs['race'].setValue(obj.race);
+            }
+        } else if (item === 'notphenotype') {
+            if (obj.hpoIdInElimination && obj.hpoIdInElimination.length) {
+                hpoElimIds = obj.hpoIdInElimination.map(function(elimhpo, i) {
+                    return (elimhpo);
+                }).join(', ');
+                this.refs['nothpoid'].setValue(hpoElimIds);
+            }
+            if (obj.termsInElimination) {
+                this.refs['notphenoterms'].setValue(obj.termsInElimination);
             }
         }
     },
@@ -1238,6 +1249,14 @@ function IndividualCommonDiseases() {
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2"
                 value={individual && individual.termsInElimination ? individual.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
+            {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
+                <Input type="button" ref="notphenotypecopygroup" wrapperClassName="col-sm-7 col-sm-offset-5 orphanet-copy" inputClassName="btn-copy btn-last btn-sm" title="Copy NOT Phenotype from Associated Group"
+                    clickHandler={this.handleClick.bind(this, associatedGroups[0], 'notphenotype')} />
+                : null}
+            {associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
+                <Input type="button" ref="notphenotypecopygroup" wrapperClassName="col-sm-7 col-sm-offset-5 orphanet-copy" inputClassName="btn-copy btn-last btn-sm" title="Copy NOT Phenotype from Associated Family"
+                    clickHandler={this.handleClick.bind(this, associatedFamilies[0], 'notphenotype')} />
+                : null}    
         </div>
     );
 }


### PR DESCRIPTION
Issue #1326, #1808 - Allow copying of "not" phenotype information from Groups to Families and Individuals.

In GCI, Curation Central => Genetic Evidence sidebar.

- Can copy NOT Phenotype from (Group > Family), (Group > Individual), (Family > Individual)
- Displays NOT Phenotype information (HP ID, Free Text) associated with Group/Family that will be copied

Connects to issue #1866 - 
Typo under the Family-Segregation section was fixed. "UNAFFECTED" sentence: "biallelic" previously read "bialleltic". 