### PR TITLE
Connects to #1932. Updated to Sauce Connect 4.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 before_script:
   - >
     if test -n "$BROWSER"; then
-      CONNECT_URL=https://saucelabs.com/downloads/sc-4.4.2-linux.tar.gz
+      CONNECT_URL=https://saucelabs.com/downloads/sc-4.5.3-linux.tar.gz
       CONNECT_DOWNLOAD=sc.tar.gz
       SC_READYFILE=$HOME/sauce-connect-ready-$RANDOM
       SC_LOGFILE=$HOME/sauce-connect.log


### PR DESCRIPTION
Several Travis builds have completed successfully, and the corresponding logs have looked ok,  running the latest version of Sauce Connect (4.5.3), so I think it's safe to merge this change.