### PR TITLE
Connects to #1466: Allow query via DOIs when adding a new Article

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -3,7 +3,7 @@
 # Instance
 
 apt_sources:
-- source: "ppa:webupd8team/java"
+- source: "ppa:openjdk-r/ppa"
 - source: "deb http://packages.elasticsearch.org/elasticsearch/1.7/debian stable main"
   key: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -39,7 +39,6 @@ apt_sources:
     -----END PGP PUBLIC KEY BLOCK-----
 bootcmd:
 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/users_ca.pub" >> /etc/ssh/sshd_config
-- cloud-init-per once accepted-oracle-license-v1-1 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 - cloud-init-per once fallocate-swapfile fallocate -l 4G /swapfile
 - cloud-init-per once chmod-swapfile chmod 600 /swapfile
 - cloud-init-per once mkswap-swapfile mkswap /swapfile
@@ -68,8 +67,7 @@ packages:
 - libxslt1-dev
 - lzop
 - ntp
-- oracle-java8-installer
-- oracle-java8-set-default
+- openjdk-8-jdk
 - pv
 - python2.7-dev
 - python3.4-dev

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -373,7 +373,7 @@ function pubmedTxt(field, extra) {
             txt = 'Add new PubMed Article';
             break;
         case 'inputLabel':
-            txt = 'Enter a PMID';
+            txt = 'Enter a PMID or DOI';
             break;
         case 'editLabel':
             txt = 'Edit PMID';

--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -370,19 +370,19 @@ function pubmedTxt(field, extra) {
     }
     switch(field) {
         case 'modalTitle':
-            txt = 'Add new PubMed Article';
+            txt = 'Add new Article';
             break;
         case 'inputLabel':
             txt = 'Enter a PMID or DOI';
             break;
         case 'editLabel':
-            txt = 'Edit PMID';
+            txt = 'Edit PMID/DOI';
             break;
         case 'inputButton':
-            txt = 'Retrieve PubMed Article';
+            txt = 'Retrieve Article';
             break;
         case 'resourceResponse':
-            txt = "Select \"" + extra + "\" (below) if the following citation is correct; otherwise, edit the PMID (above) to retrieve a different article.";
+            txt = "Select \"" + extra + "\" (below) if the following citation is correct; otherwise, edit the PMID/DOI (above) to retrieve a different article.";
             break;
     }
     return txt;

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -269,7 +269,7 @@ var PmidSelectionList = createReactClass({
             <div className="pmid-selection-wrapper">
                 <div className="pmid-selection-add">
                     <AddResourceId resourceType="pubmed" wrapperClass="inline-button-wrapper-fullwidth" buttonWrapperClass="inline-button-wrapper-fullwidth" buttonClass="btn btn-primary pmid-selection-add-btn"
-                        protocol={this.props.protocol} parentObj={this.props.currGdm} buttonText="Add New PMID" modalButtonText="Add Article" updateParentForm={this.props.updateGdmArticles} buttonOnly={true} />
+                        protocol={this.props.protocol} parentObj={this.props.currGdm} buttonText="Add New Article" modalButtonText="Add Article" updateParentForm={this.props.updateGdmArticles} buttonOnly={true} />
                 </div>
                 {annotations ?
                     <div className="pmid-selection-list" id="user-pmid-list">
@@ -283,6 +283,7 @@ var PmidSelectionList = createReactClass({
                                         <PmidSummary article={annotation.article} />
                                     </div>
                                     <div className="pmid-selection-list-pmid"><a href={external_url_map['PubMed'] + annotation.article.pmid} target="_blank">PMID: {annotation.article.pmid}</a></div>
+                                    <div className="pmid-selection-list-pmid"><span>DOI: {annotation.article.doi}</span></div>
                                 </div>
                             );
                         })}
@@ -290,7 +291,7 @@ var PmidSelectionList = createReactClass({
                 : null}
                 {annotations.length === 0 ?
                     <div className="pmid-selection-help">
-                        <i>Add papers to this Gene-Disease Record using the <strong>Add New PMID(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</i>
+                        <i>Add papers to this Gene-Disease Record using the <strong>Add New Article(s)</strong> button; click on any added paper to view its abstract and begin curating evidence from that paper.</i>
                     </div>
                 :null }
             </div>

--- a/src/clincoded/static/components/curation_central.js
+++ b/src/clincoded/static/components/curation_central.js
@@ -283,7 +283,7 @@ var PmidSelectionList = createReactClass({
                                         <PmidSummary article={annotation.article} />
                                     </div>
                                     <div className="pmid-selection-list-pmid"><a href={external_url_map['PubMed'] + annotation.article.pmid} target="_blank">PMID: {annotation.article.pmid}</a></div>
-                                    <div className="pmid-selection-list-pmid"><span>DOI: {annotation.article.doi}</span></div>
+                                    { annotation.article.doi ? <div className="pmid-selection-list-pmid"><a href={external_url_map['PubMed'] + annotation.article.pmid} target="_blank">DOI: {annotation.article.doi}</a></div> : null}
                                 </div>
                             );
                         })}

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -164,6 +164,7 @@ module.exports.dbxref_prefix_map = {
 
 module.exports.external_url_map = {
     'PubMedSearch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=986bd80f43a3ba6ec1bc7a50e7bda60c1b09&db=PubMed&retmode=xml&id=',
+    'DoiToPubMed': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=',
     'PubMed': 'https://www.ncbi.nlm.nih.gov/pubmed/',
     'OrphaNet': 'http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=',
     'OrphanetHome': 'http://www.orpha.net/',

--- a/src/clincoded/static/libs/parse-pubmed.js
+++ b/src/clincoded/static/libs/parse-pubmed.js
@@ -13,14 +13,27 @@ function parsePubmed(xml){
     var article = {};
     var doc = new DOMParser().parseFromString(xml, 'text/xml');
 
+    // Get PMID from DOI XML
+    var $DOIResult = doc.getElementsByTagName('eSearchResult')[0];
+    if($DOIResult) {
+        var $PMID = $DOIResult.getElementsByTagName('Id')[0];
+        if($PMID) {
+            article.pmid = $PMID.textContent;
+        }
+    }
+
     var $PubmedArticle = doc.getElementsByTagName('PubmedArticle')[0];
     if($PubmedArticle){
         var publicationData = '';
 
-        // Get the PMID
+        // Get the PMID and DOI
         var $PMID = $PubmedArticle.getElementsByTagName('PMID')[0];
+        var $DOI = $PubmedArticle.querySelector('[IdType="doi"]')
         if($PMID) {
             article.pmid = $PMID.textContent;
+        }
+        if($DOI) {
+            article.doi = $DOI.textContent;
         }
 
         // Get the journal name

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -271,12 +271,13 @@
 
     &:hover div,
     &.curr-pmid div {
+        overflow: hidden;
         opacity: 1;
     }
 }
 
 .pmid-selection-list-pmid {
-    font-weight: bold;
+    font-weight: bold;        
 }
 
 .pmid-selection-help {

--- a/src/clincoded/tests/features/curation_central.feature
+++ b/src/clincoded/tests/features/curation_central.feature
@@ -37,19 +37,19 @@ Feature: Curation Central
         Then I should see "Any user may explore the demo version of the ClinGen interfaces"
 
 
-    Scenario: Test PMID modal in Curation-central
+    Scenario: Test Article modal in Curation-central
         When I visit "/logout"
         Then I should see "Demo Login"
         When I press "Demo Login"
         And I wait for 10 seconds
         Then I should see "Logout ClinGen Test Curator"
         When I go to "/curation-central/?gdm=9ffd7c1e-16d9-11e5-b283-60f81dc5b05a/"
-        Then I should see "Add New PMID" within 5 seconds
-        When I press "Add New PMID"
+        Then I should see "Add New Article" within 5 seconds
+        When I press "Add New Article"
         Then I should see an element with the css selector ".modal-dialog" within 5 seconds
-        Then I should see "Enter a PMID"
+        Then I should see "Enter a PMID or DOI"
         When I fill in the css element field "input.form-control" with "123456"
-        When I press the button "Retrieve PubMed Article"
+        When I press the button "Retrieve Article"
         Then I should see "Grados OB. " within 10 seconds
         When I press the button "Add Article"
         Then I should not see an element with the css selector ".modal-open"


### PR DESCRIPTION
- GCI => New Gene Curation => Add Article
- Search via DOI (some example DOIs)
  - 10.1093/jnci/djq238
  - 10.1016/j.ijantimicag.2014.01.019
  - 10.1016/j.fsigen.2014.02.002
- Form validation when searching by a DOI/PMID already associated with an article
- Validation to recognize a "bad" DOI/PMID
- UI changes in modal reflect the addition of DOIs (Add Article, Edit PMID/DOI, Add New Article)
- Left hand side of Curation Central - Article "cards" - Long DOI should not overflow past length of card, should be hidden
- Tests associated with Add Article modal have updated text and pass