### PR TITLE
Connects to #1865: View JSON in VCI/GCI Evidence Summaries (Preview, Provisional, Approved)

### DIFF
--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -10,6 +10,7 @@ import GeneDiseaseEvidenceSummarySegregation from './case_level_segregation';
 import GeneDiseaseEvidenceSummaryCaseControl from './case_control';
 import GeneDiseaseEvidenceSummaryExperimental from './experimental';
 import GeneDiseaseEvidenceSummaryClassificationMatrix from './classification_matrix';
+import ViewJson from '../view_json';
 import CASE_INFO_TYPES from '../score/constants/case_info_types';
 
 const GeneDiseaseEvidenceSummary = createReactClass({
@@ -36,6 +37,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
             caseControlEvidenceList: [],
             experimentalEvidenceList: [],
             preview: queryKeyValue('preview', this.props.href),
+            displayJson: false,
             hpoTermsCollection: {
                 caseLevel: {},
                 segregation: {},
@@ -656,15 +658,24 @@ const GeneDiseaseEvidenceSummary = createReactClass({
     },
 
     /**
-     * Method to genetate PDF from HTML
+     * Method to generate PDF from HTML
      * @param {*} e - Window event
      */
     handlePrintPDF(e) {
         window.print();
     },
 
+    /**
+     * Method to toggle JSON from gdm state
+     * @param {*} e
+     */
+    handleViewJSON(e) {
+        this.setState({displayJson: !this.state.displayJson})
+    },
+
     render() {
         const gdm = this.state.gdm;
+        const json = JSON.stringify(gdm, null, 4);
         const provisional = this.state.provisional;
         const snapshotPublishDate = this.state.snapshotPublishDate;
         const hpoTermsCollection = this.state.hpoTermsCollection;
@@ -692,7 +703,13 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                 </p>
                 <div className="pdf-download-wrapper">
                     <button className="btn btn-default btn-inline-spacer" onClick={this.handleWindowClose}><i className="icon icon-close"></i> Close</button>
+                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>View JSON</button>
                     <button className="btn btn-primary btn-inline-spacer pull-right" onClick={this.handlePrintPDF}>Print PDF</button>
+                </div>
+                <div>
+                    {this.state.displayJson ? 
+                        <ViewJson data={json} />
+                    : null}
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { curator_page, queryKeyValue, external_url_map } from '../globals';
 import { RestMixin } from '../rest';
+import omit from 'lodash/omit';
 import GeneDiseaseEvidenceSummaryHeader from './header';
 import GeneDiseaseEvidenceSummaryCaseLevel from './case_level';
 import GeneDiseaseEvidenceSummarySegregation from './case_level_segregation';
@@ -678,7 +679,8 @@ const GeneDiseaseEvidenceSummary = createReactClass({
 
     render() {
         const gdm = this.state.gdm;
-        const json = JSON.stringify(gdm, null, 4);
+        const parsedJson = omit(gdm, ['@id', '@type', 'actions', 'active']);
+        const json = JSON.stringify(parsedJson, null, 4);
         const provisional = this.state.provisional;
         const snapshotPublishDate = this.state.snapshotPublishDate;
         const hpoTermsCollection = this.state.hpoTermsCollection;

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -58,6 +58,9 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         if (affiliationUtilityBar) {
             affiliationUtilityBar.setAttribute('style', 'display:none');
         }
+        if (this.jsonView) {
+            this.jsonView.scrollIntoView({ behavior: "smooth" });
+        }
     },
 
     loadData() {
@@ -670,7 +673,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
      * @param {*} e
      */
     handleViewJSON(e) {
-        this.setState({displayJson: !this.state.displayJson})
+        this.setState({displayJson: !this.state.displayJson});
     },
 
     render() {
@@ -679,6 +682,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         const provisional = this.state.provisional;
         const snapshotPublishDate = this.state.snapshotPublishDate;
         const hpoTermsCollection = this.state.hpoTermsCollection;
+        let jsonButtonText = this.state.displayJson ? 'Hide JSON' : 'View JSON';
 
         return (
             <div className="gene-disease-evidence-summary-wrapper">
@@ -698,18 +702,18 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     <GeneDiseaseEvidenceSummaryCaseControl caseControlEvidenceList={this.state.caseControlEvidenceList} hpoTerms={hpoTermsCollection.caseControl} />
                     <GeneDiseaseEvidenceSummaryExperimental experimentalEvidenceList={this.state.experimentalEvidenceList} />
                 </div>
+                {this.state.displayJson ? 
+                    <div ref={(ref) => this.jsonView = ref}>
+                        <ViewJson data={json} />
+                    </div>
+                : null}
                 <p className="print-info-note">
                     <i className="icon icon-info-circle"></i> For best printing, choose "Landscape" for layout, 50% for Scale, "Minimum" for Margins, and select "Background graphics".
                 </p>
                 <div className="pdf-download-wrapper">
                     <button className="btn btn-default btn-inline-spacer" onClick={this.handleWindowClose}><i className="icon icon-close"></i> Close</button>
-                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>View JSON</button>
+                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>{jsonButtonText}</button>
                     <button className="btn btn-primary btn-inline-spacer pull-right" onClick={this.handlePrintPDF}>Print PDF</button>
-                </div>
-                <div>
-                    {this.state.displayJson ? 
-                        <ViewJson data={json} />
-                    : null}
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/variant_interpretation_summary/index.js
+++ b/src/clincoded/static/components/variant_interpretation_summary/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { curator_page, userMatch, queryKeyValue, external_url_map } from '../globals';
 import { RestMixin } from '../rest';
+import omit from 'lodash/omit';
 import ViewJson from '../view_json';
 import VariantInterpretationSummaryHeader from './header';
 import VariantInterpretationSummaryEvaluation from './evaluations';
@@ -87,7 +88,8 @@ const VariantInterpretationSummary = createReactClass({
     render() {
         const interpretation = this.state.interpretation;
         const classification = this.state.classification;
-        const json = JSON.stringify(interpretation, null, 4);
+        const parsedJson = omit(interpretation, ['@id', '@type', 'actions', 'active']);
+        const json = JSON.stringify(parsedJson, null, 4);
         let jsonButtonText = this.state.displayJson ? 'Hide JSON' : 'View JSON';
 
 

--- a/src/clincoded/static/components/variant_interpretation_summary/index.js
+++ b/src/clincoded/static/components/variant_interpretation_summary/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { curator_page, userMatch, queryKeyValue, external_url_map } from '../globals';
 import { RestMixin } from '../rest';
+import ViewJson from '../view_json';
 import VariantInterpretationSummaryHeader from './header';
 import VariantInterpretationSummaryEvaluation from './evaluations';
 
@@ -21,7 +22,8 @@ const VariantInterpretationSummary = createReactClass({
             user: null, // Logged-in user uuid
             interpretation: null, // The parent interpretation object associated with the classification
             classification: {}, // Logged-in user's existing classification object
-            preview: queryKeyValue('preview', this.props.href)
+            preview: queryKeyValue('preview', this.props.href),
+            displayJson: false,
         };
     },
 
@@ -71,9 +73,18 @@ const VariantInterpretationSummary = createReactClass({
         window.print();
     },
 
+    /**
+     * Method to toggle JSON from interpretation state
+     * @param {*} e - Window event
+     */
+    handleViewJSON(e) {
+        this.setState({displayJson: !this.state.displayJson})
+    },
+
     render() {
         const interpretation = this.state.interpretation;
         const classification = this.state.classification;
+        const json = JSON.stringify(interpretation, null, 4);
 
         return (
             <div className="container variant-interprertation-summary-wrapper">
@@ -90,7 +101,13 @@ const VariantInterpretationSummary = createReactClass({
                 </p>
                 <div className="pdf-download-wrapper">
                     <button className="btn btn-default btn-inline-spacer" onClick={this.handleWindowClose}><i className="icon icon-close"></i> Close</button>
+                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>View JSON</button>
                     <button className="btn btn-primary btn-inline-spacer pull-right" onClick={this.handlePrintPDF}>Print PDF</button>
+                </div>
+                <div>
+                    {this.state.displayJson ? 
+                        <ViewJson data={json} />
+                    : null}
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/variant_interpretation_summary/index.js
+++ b/src/clincoded/static/components/variant_interpretation_summary/index.js
@@ -39,6 +39,9 @@ const VariantInterpretationSummary = createReactClass({
         if (affiliationUtilityBar) {
             affiliationUtilityBar.setAttribute('style', 'display:none');
         }
+        if (this.jsonView) {
+            this.jsonView.scrollIntoView({ behavior: "smooth" });
+        }
     },
 
     loadData() {
@@ -85,6 +88,8 @@ const VariantInterpretationSummary = createReactClass({
         const interpretation = this.state.interpretation;
         const classification = this.state.classification;
         const json = JSON.stringify(interpretation, null, 4);
+        let jsonButtonText = this.state.displayJson ? 'Hide JSON' : 'View JSON';
+
 
         return (
             <div className="container variant-interprertation-summary-wrapper">
@@ -96,18 +101,18 @@ const VariantInterpretationSummary = createReactClass({
                     <VariantInterpretationSummaryHeader interpretation={interpretation} classification={classification} />
                     <VariantInterpretationSummaryEvaluation interpretation={interpretation} classification={classification} />
                 </div>
+                {this.state.displayJson ? 
+                    <div ref={(ref) => this.jsonView = ref}>
+                        <ViewJson data={json} />
+                    </div>
+                : null}
                 <p className="print-info-note">
                     <i className="icon icon-info-circle"></i> For best printing, choose "Landscape" for layout, 50% for Scale, "Minimum" for Margins, and select "Background graphics".
                 </p>
                 <div className="pdf-download-wrapper">
                     <button className="btn btn-default btn-inline-spacer" onClick={this.handleWindowClose}><i className="icon icon-close"></i> Close</button>
-                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>View JSON</button>
+                    <button className="btn btn-primary btn-inline-spacer" onClick={this.handleViewJSON}>{jsonButtonText}</button>
                     <button className="btn btn-primary btn-inline-spacer pull-right" onClick={this.handlePrintPDF}>Print PDF</button>
-                </div>
-                <div>
-                    {this.state.displayJson ? 
-                        <ViewJson data={json} />
-                    : null}
                 </div>
             </div>
         );

--- a/src/clincoded/static/components/view_json.js
+++ b/src/clincoded/static/components/view_json.js
@@ -7,7 +7,6 @@ const divStyle = {
   userSelect: 'all',
   overflowY: 'scroll', 
   maxHeight: '500px',
-  marginBottom: '2rem'
 }
 
 const ViewJson = props => {

--- a/src/clincoded/static/components/view_json.js
+++ b/src/clincoded/static/components/view_json.js
@@ -1,0 +1,23 @@
+'use strict';
+import React from 'react';
+
+const divStyle = {
+  WebkitUserSelect: 'all',
+  MozUserSelect: 'all',
+  userSelect: 'all',
+  overflowY: 'scroll', 
+  maxHeight: '500px',
+  marginBottom: '2rem'
+}
+
+const ViewJson = props => {
+  return (
+    <div style={divStyle}>
+      <pre>
+        <code>{props.data}</code>
+      </pre>
+    </div>
+  )
+}
+
+export default ViewJson;


### PR DESCRIPTION
- In GCI, JSON in "view box" is the GDM state object, with an omission of `@id`, `@type`, `actions`, `active` properties.
- In VCI, JSON in view box is the Interpretation state object, with an omission of `@id`, `@type`, `actions`, `active` properties.

Upon click of "View JSON" button, button text should change to "Hide JSON". JSON view window should smooth scroll open from above the buttons. Single-clicking inside the JSON box highlights all text inside box. Scrollbar inside JSON box.