### PR TITLE
Generate ClinVar Submission Data from Approved Interpretations

### DIFF
--- a/src/clincoded/static/components/provisional_classification/snapshots.js
+++ b/src/clincoded/static/components/provisional_classification/snapshots.js
@@ -11,6 +11,7 @@ import DayPickerInput from 'react-day-picker/DayPickerInput';
 import MomentLocaleUtils, { formatDate, parseDate } from 'react-day-picker/moment';
 import { renderSimpleStatusLabel } from '../../libs/render_simple_status_label';
 import AlertMessage from '../../libs/bootstrap/alert';
+import { ClinVarSubmissionData } from '../variant_central/clinvar_submission';
 
 class CurationSnapshots extends Component {
     constructor(props) {
@@ -265,8 +266,10 @@ class CurationSnapshots extends Component {
     renderSnapshot(snapshot, isApprovalActive, classificationStatus, currentApprovedSnapshotID, index) {
         const type = snapshot.resourceType;
         const snapshotUUID = snapshot.uuid ? snapshot.uuid : snapshot['@id'].split('/', 3)[2];
+        const affiliationID = snapshot.resource && snapshot.resource.affiliation ? snapshot.resource.affiliation : '';
         const isPublishEventActive = this.props.isPublishEventActive;
         let resourceParent, isSnapshotOnCurrentSOP;
+        let allowClinVarSubmission = false;
         if (snapshot.resourceType === 'classification' && snapshot.resourceParent.gdm) {
             resourceParent = snapshot.resourceParent.gdm;
 
@@ -274,8 +277,8 @@ class CurationSnapshots extends Component {
             isSnapshotOnCurrentSOP = snapshot.resource ? isScoringForCurrentSOP(snapshot.resource.classificationPoints) : false;
         } else if (snapshot.resourceType === 'interpretation' && snapshot.resourceParent.interpretation) {
             resourceParent = snapshot.resourceParent.interpretation;
-
             isSnapshotOnCurrentSOP = true;
+            allowClinVarSubmission = snapshot['@id'] === currentApprovedSnapshotID;
         }
 
         // Special criteria to render a publish link (above a "View Approved Summary" button):
@@ -290,10 +293,10 @@ class CurationSnapshots extends Component {
                         <tbody>
                             <tr>
                                 <td className="snapshot-content">
-                                    {snapshot.resource && snapshot.resource.affiliation ?
+                                    {affiliationID ?
                                         <dl className="inline-dl clearfix">
                                             <dt><span>ClinGen Affiliation:</span></dt>
-                                            <dd>{getAffiliationName(snapshot.resource.affiliation)}</dd>
+                                            <dd>{getAffiliationName(affiliationID)}</dd>
                                         </dl>
                                         : null}
                                     <dl className="inline-dl clearfix snapshot-provisional-approval-submitter">
@@ -350,10 +353,10 @@ class CurationSnapshots extends Component {
                         <tbody>
                             <tr>
                                 <td className="snapshot-content">
-                                    {snapshot.resource && snapshot.resource.affiliation ?
+                                    {affiliationID ?
                                         <dl className="inline-dl clearfix">
                                             <dt><span>ClinGen Affiliation:</span></dt>
-                                            <dd>{getAffiliationName(snapshot.resource.affiliation)}</dd>
+                                            <dd>{getAffiliationName(affiliationID)}</dd>
                                         </dl>
                                         : null}
                                     <dl className="inline-dl clearfix snapshot-final-approval-submitter">
@@ -397,6 +400,10 @@ class CurationSnapshots extends Component {
                                 </td>
                                 <td className="approval-snapshot-buttons">
                                     {this.renderSnapshotStatusIcon(snapshot, 'Approved')}
+                                    {allowClinVarSubmission ?
+                                        <ClinVarSubmissionData affiliationID={affiliationID} isApprovalActive={isApprovalActive}
+                                            isPublishEventActive={isPublishEventActive} resourceUUID={snapshotUUID} />
+                                        : null}
                                     {allowSnapshotPublish ? this.renderPublishLink(resourceParent, snapshot.resourceType, snapshotUUID, false) : null}
                                     <Input type="button" inputClassName={this.renderSnapshotViewSummaryBtn(snapshot, 'Approved')} title="View Approved Summary"
                                         clickHandler={this.viewSnapshotSummary.bind(this, snapshot['@id'], type)} />

--- a/src/clincoded/static/components/variant_central/clinvar_submission.js
+++ b/src/clincoded/static/components/variant_central/clinvar_submission.js
@@ -1,0 +1,226 @@
+'use strict';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { RestMixin } from '../rest';
+import { Input } from '../../libs/bootstrap/form';
+import ModalComponent from '../../libs/bootstrap/modal';
+import { showActivityIndicator } from '../activity_indicator';
+
+const ClinVarSubmissionData = module.exports.ClinVarSubmissionData = createReactClass({
+    mixins: [RestMixin],
+
+    propTypes: {
+        affiliationID: PropTypes.string,
+        isApprovalActive: PropTypes.string,
+        isPublishEventActive: PropTypes.bool,
+        resourceUUID: PropTypes.string
+    },
+
+    /**
+     * Method to initialize component state
+     */
+    getInitialState: function() {
+        return {
+            isClinVarSubmissionActive: false,
+            generatedClinVarSubmissionData: null,
+            failureMessage: null,
+            elementIDToCopy: null
+        };
+    },
+
+    /**
+     * Method to handle user's response (Copy/Close) to ClinVar Submission Data modal
+     * @param {object} e - The submitted event object
+     * @param {string} buttonSelected - String value of the button/response selected by the user
+     */
+    handleClinVarSubmissionDataResponse: function(e, buttonSelected) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (buttonSelected === 'Copy') {
+            try {
+                const dataElement = document.getElementById(this.state.elementIDToCopy);
+
+                // Highlight and copy (to clipboard) ClinVar submission data
+                dataElement.contentEditable = 'true';
+                window.getSelection().selectAllChildren(dataElement);
+                document.execCommand('copy');
+            } catch (error) {
+                console.log('Copying data to clipboard failed');
+            }
+        }
+
+        this.child.closeModal();
+    },
+
+    /**
+     * Method to generate ClinVar submission data (for a submission spreadsheet)
+     * @param {string} resourceType - The type of the data's source object (e.g. snapshot)
+     * @param {string} resourceUUID - The UUID of the data's source object
+     */
+    generateClinVarSubmissionData: function(resourceType, resourceUUID) {
+        return new Promise((resolve, reject) => {
+            if (resourceType && resourceUUID) {
+                this.getRestData('/generate-clinvar-data?type=' + resourceType + '&uuid=' + resourceUUID, null, false).then(result => {
+                    if (result.status === 'Success') {
+                        resolve(result);
+                    } else {
+                        console.log('Data generation failure: %s', result.message);
+                        reject(result);
+                    }
+                }).catch(error => {
+                    console.log('Internal data retrieval error: %o', error);
+                    if (error && !error.message) {
+                        error.message = 'Internal data retrieval error';
+                    }
+                    reject(error);
+                });
+            } else {
+                reject({'message': 'Missing expected parameters'});
+            }
+        });
+    },
+
+    /**
+     * Method to store (as state) ClinVar submission data
+     * @param {string} resourceType - The type of the data's source object (e.g. snapshot)
+     * @param {string} resourceUUID - The UUID of the data's source object
+     */
+    storeClinVarSubmissionData: function(resourceType, resourceUUID) {
+        const isClinVarSubmissionActive = this.state.isClinVarSubmissionActive;
+
+        if (!isClinVarSubmissionActive && resourceType && resourceUUID) {
+            this.setState({isClinVarSubmissionActive: true}, () => {
+                this.generateClinVarSubmissionData(resourceType, resourceUUID).then(response => {
+                    if (response && response.message) {
+                        const elementIDToCopy = response.message.status && response.message.status.errorCount > 0 ?
+                            '' : 'generated-clinvar-submission-data';
+
+                        this.setState({isClinVarSubmissionActive: false, generatedClinVarSubmissionData: response.message,
+                            failureMessage: null, elementIDToCopy: elementIDToCopy});
+                    } else {
+                        this.setState({isClinVarSubmissionActive: false, failureMessage: 'Error generating data.'});
+                    }
+                }).catch(error => {
+                    const failureMessage = 'Error generating data' + (error && error.message ? ': ' + error.message : '.');
+                    console.log('Data generation error: %o', error);
+                    this.setState({isClinVarSubmissionActive: false, failureMessage: failureMessage});
+                });
+            });
+        }
+    },
+
+    /**
+     * Method to check if (prop) affiliation is allowed to generate ClinVar submission data
+     * The allowedAffiliationIDs constant contains the IDs of affiliations that have ClinGen-approved guidelines
+     */
+    isAffiliationAllowedtoGenerate: function() {
+        const affiliationID = this.props.affiliationID;
+        const allowedAffiliationIDs = {'10002': true, '10007': true, '10012': true, '10014': true, '10015': true, '10021': true};
+
+        return (affiliationID in allowedAffiliationIDs);
+    },
+
+    /**
+     * Method to render ClinVar submission data
+     */
+    renderClinVarSubmissionData: function() {
+        const generatedClinVarSubmissionData = this.state.generatedClinVarSubmissionData ? this.state.generatedClinVarSubmissionData : {};
+
+        if (generatedClinVarSubmissionData.status && generatedClinVarSubmissionData.status.totalRecords > 0 &&
+            generatedClinVarSubmissionData.variants && Array.isArray(generatedClinVarSubmissionData.variants)) {
+            return (
+                <table>
+                    <tbody>
+                        {generatedClinVarSubmissionData.variants.map((variant, variantIndex) => {
+                            let submissionErrors = {};
+
+                            // If record/variant has errors, save them (at a key that corresponds to the matching index within the data)
+                            if (variant.errors && Array.isArray(variant.errors) && variant.errors.length > 0 &&
+                                variant.submission && Array.isArray(variant.submission) && variant.submission.length > 0) {
+                                variant.errors.forEach(error => {
+                                    if (error.errorCode && typeof error.errorCode === 'string' &&
+                                        error.errorMessage && typeof error.errorMessage === 'string') {
+                                        variant.submission.forEach((data, dataIndex) => {
+                                            if (typeof data === 'string' && data.indexOf(error.errorCode) > -1) {
+                                                submissionErrors[dataIndex] = error.errorMessage;
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+
+                            return (
+                                <tr key={'submission-data-row-' + variantIndex}>
+                                    {variant.submission && Array.isArray(variant.submission) ?
+                                        variant.submission.map((column, columnIndex) => {
+                                            if (submissionErrors[columnIndex]) {
+                                                return (
+                                                    <td key={'submission-data-row-' + variantIndex + '-column-' + columnIndex}
+                                                        className="error-column">{column}
+                                                        <span data-toggle="tooltip" data-placement="top" data-tooltip={submissionErrors[columnIndex]}>
+                                                            <i className="icon icon-info-circle"></i>
+                                                        </span>
+                                                    </td>
+                                                );
+                                            } else {
+                                                return (<td key={'submission-data-row-' + variantIndex + '-column-' + columnIndex}>{column}</td>);
+                                            }
+                                        })
+                                        :
+                                        <td colSpan="96"></td>
+                                    }
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            );
+        } else {
+            return null;
+        }
+    },
+
+    /**
+     * Method to render the component
+     */
+    render: function() {
+        const isClinVarSubmissionActive = this.state.isClinVarSubmissionActive;
+        const generatedClinVarSubmissionData = this.state.generatedClinVarSubmissionData;
+        const failureMessage = this.state.failureMessage;
+        const disableCopyButton = this.state.elementIDToCopy ? false : true;
+        const isPublishEventActive = this.props.isPublishEventActive;
+        const isApprovalActive = this.props.isApprovalActive;
+        const resourceUUID = this.props.resourceUUID;
+
+        if (this.isAffiliationAllowedtoGenerate() && !isPublishEventActive && !isApprovalActive) {
+            return (
+                <ModalComponent modalTitle="ClinVar Submission Data" modalClass="modal-clinvar" modalWrapperClass="clinvar-submission-modal"
+                    bootstrapBtnClass="btn btn-default clinvar-submission-link-item" actuatorClass="" actuatorTitle="ClinVar Submission Data"
+                    onRef={ref => (this.child = ref)}>
+                    <div className="modal-body" id="generated-clinvar-submission-data">
+                        {generatedClinVarSubmissionData ?
+                            this.renderClinVarSubmissionData()
+                            : isClinVarSubmissionActive ?
+                                showActivityIndicator('Generating... ')
+                                :
+                                <Input type="button" inputClassName="btn-default btn-inline-spacer"
+                                    clickHandler={this.storeClinVarSubmissionData.bind(null, 'snapshot', resourceUUID)} title="Generate" />
+                        }{failureMessage ?
+                            <div className="clinvar-submission-failure">{failureMessage}</div>
+                            : null}
+                    </div>
+                    <div className="modal-footer">
+                        <Input type="button" inputClassName="btn-default btn-inline-spacer clinvar-submission" inputDisabled={disableCopyButton}
+                            clickHandler={(e) => this.handleClinVarSubmissionDataResponse(e, 'Copy')} title="Copy (to clipboard)" />
+                        <Input type="button" inputClassName="btn-default btn-inline-spacer clinvar-submission"
+                            clickHandler={(e) => this.handleClinVarSubmissionDataResponse(e, 'Close')} title="Close" />
+                    </div>
+                </ModalComponent>
+            );
+        } else {
+            return null;
+        }
+    }
+});

--- a/src/clincoded/static/scss/clincoded/modules/_approval.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_approval.scss
@@ -133,7 +133,7 @@
         vertical-align: bottom;
         width: 20%;
 
-        input[type="button"] {
+        input[type="button"] :not(.clinvar-submission) {
             margin: 8px 0;
         }
 
@@ -152,10 +152,19 @@
         }
 
         .btn.approve-provisional-link-item,
+        .btn.clinvar-submission-link-item,
         .btn.publish-link-item {
             font-size: 91%;
             margin-bottom: 5px;
             padding: 6px 8px;
+        }
+
+        .btn.clinvar-submission-link-item {
+            background-color: #d4af37;
+
+            &:hover {
+                background-color: #a98c2c;
+            }
         }
 
         .btn.btn-default.publish-link-item {

--- a/src/clincoded/static/scss/clincoded/modules/_modal_clinvar_submission.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_modal_clinvar_submission.scss
@@ -1,0 +1,43 @@
+.clinvar-submission-modal {
+    .modal-clinvar {
+        background-color: #d4af37;
+    }
+
+    .modal-body {
+        overflow-x: scroll;
+        overflow-wrap: break-word;
+
+        .activity-indicator.overlay-wrapper {
+            text-align: center;
+            position: relative;
+        }
+
+        table {
+            margin: 20px 0px;
+
+            td {
+                padding: 3px;
+                white-space: pre;
+
+                &.error-column {
+                    color: #f00;
+
+                    span[data-tooltip] {
+                        padding-left: 5px;
+                    }
+
+                    [data-tooltip]:before {
+                        margin-left: -200px;
+                        padding: 3px;
+                        width: 400px;
+                    }
+                }
+            }
+        }
+
+        .clinvar-submission-failure {
+            color: #f00;
+            padding-top: 10px;
+        }
+    }
+}

--- a/src/clincoded/static/scss/style.scss
+++ b/src/clincoded/static/scss/style.scss
@@ -70,6 +70,7 @@
 @import "clincoded/modules/approval";
 @import "clincoded/modules/variant_interpretation_summary";
 @import "clincoded/modules/admin";
+@import "clincoded/modules/modal_clinvar_submission";
 
 // Utility classes - Bootstrap 3, keep last
 @import "bootstrap/utilities";


### PR DESCRIPTION
Steps to test #1967:
1. Choose to curate as one of ClinGen's approved VCEPs (e.g. Cardiomyopathy).
2. Via the VCI's approval process, save, provision and approve an interpretation.
3. In order to see the **ClinVar Submission Data** button, the approval process can't be "active" (displaying a panel to approve or publish). So, if the button isn't present, either publish the approved interpretation (the default next step after approving) or click the **Return to Interpretation** button (to exit the approval process) and then click the **View Summary** button (to return to the approval process).
4. Click the **ClinVar Submission Data** button, which should open a **ClinVar Submission Data** modal.
5. Click the **Generate** button in the modal. If the generation process is successful, a single row of data, pulled from the interpretation, should be displayed and the **Copy (to clipboard)** button should be enabled.