### PR TITLE
Allow All Affiliations to Generate ClinVar Submission Data + Affiliation Updates

### DIFF
--- a/src/clincoded/static/components/affiliation/affiliations.json
+++ b/src/clincoded/static/components/affiliation/affiliations.json
@@ -674,5 +674,32 @@
                 "fullname": "Peroxisomal Disorders GCEP"
             }
         }
+    },
+    {
+        "affiliation_id": "10050",
+        "affiliation_fullname": "DICER1 and miRNA-Processing Gene",
+        "publish_approval": true,
+        "subgroups": {
+            "vcep": {
+                "id": "50050",
+                "fullname": "DICER1 and miRNA-Processing Gene VCEP"
+            }
+        }
+    },
+    {
+        "affiliation_id": "10051",
+        "affiliation_fullname": "Von Willebrand"
+    },
+    {
+        "affiliation_id": "10052",
+        "affiliation_fullname": "Hemoglobinopathies"
+    },
+    {
+        "affiliation_id": "10053",
+        "affiliation_fullname": "Glaucoma"
+    },
+    {
+        "affiliation_id": "10054",
+        "affiliation_fullname": "Myopathies"
     }
 ]

--- a/src/clincoded/static/components/affiliation/affiliations.json
+++ b/src/clincoded/static/components/affiliation/affiliations.json
@@ -475,7 +475,9 @@
         "subgroups": {
             "vcep": {
                 "id": "50034",
-                "fullname": "Myeloid Malignancy VCEP"
+                "fullname": "Myeloid Malignancy VCEP",
+                "guidelines_name": "ClinGen Myeloid Malignancy Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines Version 1",
+                "guidelines_url": "https://www.clinicalgenome.org/affiliation/50034/docs/assertion-criteria"
             }
         },
         "approver": [

--- a/src/clincoded/static/components/variant_central/clinvar_submission.js
+++ b/src/clincoded/static/components/variant_central/clinvar_submission.js
@@ -112,17 +112,6 @@ const ClinVarSubmissionData = module.exports.ClinVarSubmissionData = createReact
     },
 
     /**
-     * Method to check if (prop) affiliation is allowed to generate ClinVar submission data
-     * The allowedAffiliationIDs constant contains the IDs of affiliations that have ClinGen-approved guidelines
-     */
-    isAffiliationAllowedtoGenerate: function() {
-        const affiliationID = this.props.affiliationID;
-        const allowedAffiliationIDs = {'10002': true, '10007': true, '10012': true, '10014': true, '10015': true, '10021': true};
-
-        return (affiliationID in allowedAffiliationIDs);
-    },
-
-    /**
      * Method to render ClinVar submission data
      */
     renderClinVarSubmissionData: function() {
@@ -190,11 +179,14 @@ const ClinVarSubmissionData = module.exports.ClinVarSubmissionData = createReact
         const generatedClinVarSubmissionData = this.state.generatedClinVarSubmissionData;
         const failureMessage = this.state.failureMessage;
         const disableCopyButton = this.state.elementIDToCopy ? false : true;
+        const affiliationID = this.props.affiliationID;
         const isPublishEventActive = this.props.isPublishEventActive;
         const isApprovalActive = this.props.isApprovalActive;
         const resourceUUID = this.props.resourceUUID;
 
-        if (this.isAffiliationAllowedtoGenerate() && !isPublishEventActive && !isApprovalActive) {
+        // Criteria to render ClinVar submission button/modal: affiliation has been provided (affiliationID) and neither a publish
+        //  event (!isPublishEventActive) nor the approval process (!isApprovalActive) is currently in progress
+        if (affiliationID && !isPublishEventActive && !isApprovalActive) {
             return (
                 <ModalComponent modalTitle="ClinVar Submission Data" modalClass="modal-clinvar" modalWrapperClass="clinvar-submission-modal"
                     bootstrapBtnClass="btn btn-default clinvar-submission-link-item" actuatorClass="" actuatorTitle="ClinVar Submission Data"


### PR DESCRIPTION
Steps to test #1982:
1. Choose to curate as an affiliation.
2. Via the VCI's approval process, save, provision and approve an interpretation.
3. In order to see the **ClinVar Submission Data** button, the approval process can't be "active" (displaying a panel to approve or publish). So, if the button isn't present, click the **Return to Interpretation** button (to exit the approval process) and then click the **View Summary** button (to return to the approval process).
4. Click the **ClinVar Submission Data** button, which should open a **ClinVar Submission Data** modal.
5. Click the **Generate** button in the modal. If the generation process is successful, a single row of data, pulled from the interpretation, should be displayed and the **Copy (to clipboard)** button should be enabled.

Steps to test #1990:
1. Choose to curate as the **Myeloid Malignancy** affiliation.
2. Via the VCI's approval process, save, provision, approve and publish an interpretation.

Steps to test #1993:
1. Choose to curate as any of the following affiliations (to confirm they now exist): **DICER1 and miRNA-Processing Gene**, **Von Willebrand**, **Hemoglobinopathies**, **Glaucoma**, **Myopathies**