### PR TITLE
Updated Parsing of ClinVar E-utilities XML (to support VCV format)

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -597,7 +597,7 @@ function clinvarQueryResource() {
     // for pinging and parsing data from ClinVar
     this.saveFormValue('resourceId', this.state.inputValue);
     if (clinvarValidateForm.call(this)) {
-        var url = external_url_map['ClinVarEutils'];
+        var url = external_url_map['ClinVarEutilsVCV'];
         var data;
         var id = this.state.inputValue;
         this.getRestDataXml(url + id).then(xml => {
@@ -760,7 +760,7 @@ function carQueryResource() {
             data = parseCAR(json);
             if (data.clinvarVariantId) {
                 // if the CAR result has a ClinVar variant ID, query ClinVar with it, and use its data
-                url = external_url_map['ClinVarEutils'];
+                url = external_url_map['ClinVarEutilsVCV'];
                 this.getRestDataXml(url + data.clinvarVariantId).then(xml => {
                     var data_cv = parseClinvar(xml);
                     if (data_cv.clinvarVariantId) {

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -178,6 +178,7 @@ module.exports.external_url_map = {
     'ClinVarSearch': 'https://www.ncbi.nlm.nih.gov/clinvar/variation/',
     'ClinVarEfetch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=986bd80f43a3ba6ec1bc7a50e7bda60c1b09&db=clinvar',
     'ClinVarEutils': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=986bd80f43a3ba6ec1bc7a50e7bda60c1b09&db=clinvar&rettype=variation&id=',
+    'ClinVarEutilsVCV': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?api_key=986bd80f43a3ba6ec1bc7a50e7bda60c1b09&db=clinvar&rettype=vcv&is_variationid&from_esearch=true&id=',
     'ClinVarEsearch': 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?api_key=986bd80f43a3ba6ec1bc7a50e7bda60c1b09&',
     'HPO': 'http://compbio.charite.de/hpoweb/showterm?id=',
     'HPOBrowser': 'http://compbio.charite.de/hpoweb/showterm?id=HP:0000118',

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -195,21 +195,15 @@ var VariantCurationHub = createReactClass({
             if (variant.clinvarVariantId) {
                 this.setState({clinvar_id: variant.clinvarVariantId});
                 // Get ClinVar data via the parseClinvar method defined in parse-resources.js
-                this.getRestDataXml(external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xml => {
+                this.getRestDataXml(external_url_map['ClinVarEutilsVCV'] + variant.clinvarVariantId).then(xmlClinVarVCV => {
                     // Passing 'true' option to invoke 'mixin' function
                     // To extract more ClinVar data for 'Basic Information' tab
-                    var variantData = parseClinvar(xml, true);
+                    var variantData = parseClinvar(xmlClinVarVCV, true);
                     // Won't show population/predictor data if variation type is 'Haplotype'
                     if (variantData.clinvarVariationType && variantData.clinvarVariationType === 'Haplotype') {
                         this.setState({ext_singleNucleotide: false});
                     }
-                    this.setState({
-                        ext_clinvarEutils: variantData,
-                        ext_clinvarInterpretationSummary: getClinvarInterpretations(xml),
-                        ext_clinVarSCV: parseClinvarSCVs(xml),
-                        loading_clinvarEutils: false,
-                        loading_clinvarSCV: false
-                    });
+                    this.setState({ext_clinvarEutils: variantData});
                     // Last alternative to get gene id and symbol from ClinVar
                     // for API call to mygene.info to retreive gene related data
                     if (variantData.gene && variantData.gene.id) {
@@ -221,13 +215,29 @@ var VariantCurationHub = createReactClass({
                         this.setState({loading_myGeneInfo: false});
                     }
                     this.handleCodonEsearch(variantData);
+                    // Retrieve data (in non-VCV format) for interpretations submitted to ClinVar
+                    this.getRestDataXml(external_url_map['ClinVarEutils'] + variant.clinvarVariantId).then(xmlClinVar => {
+                        this.setState({
+                            ext_clinvarInterpretationSummary: getClinvarInterpretations(xmlClinVar),
+                            ext_clinVarSCV: parseClinvarSCVs(xmlClinVar),
+                            loading_clinvarEutils: false,
+                            loading_clinvarSCV: false
+                        });
+                    }).catch(err => {
+                        this.setState({
+                            loading_clinvarEutils: false,
+                            loading_clinvarSCV: false,
+                            loading_clinvarEsearch: false
+                        });
+                        console.log('ClinVarEutils Fetch Error=: %o', err);
+                    });
                 }).catch(err => {
                     this.setState({
                         loading_clinvarEutils: false,
                         loading_clinvarSCV: false,
                         loading_clinvarEsearch: false
                     });
-                    console.log('ClinVarEutils Fetch Error=: %o', err);
+                    console.log('ClinVarEutilsVCV Fetch Error=: %o', err);
                 });
             } else {
                 this.setState({

--- a/src/clincoded/static/components/variant_central/index.js
+++ b/src/clincoded/static/components/variant_central/index.js
@@ -461,9 +461,9 @@ var VariantCurationHub = createReactClass({
         const hostname = this.props.href_url && this.props.href_url.hostname;
         if (variant && (hostname && hostname !== 'localhost')) {
             let hgvs_notation = getHgvsNotation(variant, 'GRCh37', true);
-            let hgvsParts = hgvs_notation.split(':');
-            let position = hgvsParts[1].replace(/[^\d]/g, '');
-            let pageDataVariantId = hgvsParts[0] + ':' + position;
+            let hgvsParts = hgvs_notation ? hgvs_notation.split(':') : [];
+            let position = hgvsParts[1] ? hgvsParts[1].replace(/[^\d]/g, '') : '';
+            let pageDataVariantId = hgvsParts[0] && position ? hgvsParts[0] + ':' + position : '';
             if (pageDataVariantId) {
                 this.getRestData(external_url_map['PAGE'] + pageDataVariantId).then(response => {
                     this.setState({ext_pageData: response, loading_pageData: false});

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -238,10 +238,16 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     // Because myvariant.info doesn't always return ExAC allele frequency data
     parseAlleleFrequencyData: function(response) {
         let populationObj = this.state.populationObj;
+        const colocatedVariants = response && response[0] && response[0].colocated_variants && response[0].colocated_variants[0] ?
+            response[0].colocated_variants[0] : null;
         populationStatic.exac._order.map(key => {
-            populationObj.exac[key].af = typeof populationObj.exac[key].af !== 'undefined' ? (isNaN(populationObj.exac[key].af) ? null : populationObj.exac[key].af) : parseFloat(response[0].colocated_variants[0]['exac_' + key + '_maf']);
+            populationObj.exac[key].af = typeof populationObj.exac[key].af !== 'undefined' ?
+                (isNaN(populationObj.exac[key].af) ? null : populationObj.exac[key].af) :
+                (colocatedVariants ? parseFloat(colocatedVariants['exac_' + key + '_maf']) : NaN);
         });
-        populationObj.exac._tot.af = typeof populationObj.exac._tot.af !== 'undefined' ? (isNaN(populationObj.exac._tot.af) ? null : populationObj.exac._tot.af) : parseFloat(response[0].colocated_variants[0].exac_adj_maf);
+        populationObj.exac._tot.af = typeof populationObj.exac._tot.af !== 'undefined' ?
+            (isNaN(populationObj.exac._tot.af) ? null : populationObj.exac._tot.af) :
+            (colocatedVariants ? parseFloat(colocatedVariants.exac_adj_maf) : NaN);
 
         this.setState({populationObj: populationObj});
     },

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -489,12 +489,18 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
     parseTGenomesData: function(response) {
         // not all variants are SNPs. Do nothing if variant is not a SNP
         if (response.var_class && response.var_class == 'SNP') {
-            // FIXME: this GRCh vs gRCh needs to be reconciled in the data model and data import
-            // update off of this.props.data as it is more stable, and this.state.data does not contain relevant updates
-            let hgvs_GRCh37 = this.props.data.hgvsNames.GRCh37 ? this.props.data.hgvsNames.GRCh37 : this.props.data.hgvsNames.gRCh37;
-            let hgvs_GRCh38 = this.props.data.hgvsNames.GRCh38 ? this.props.data.hgvsNames.GRCh38 : this.props.data.hgvsNames.gRCh38;
+            let hgvs_GRCh37 = '';
+            let hgvs_GRCh38 = '';
             let populationObj = this.state.populationObj;
             let updated1000GData = false;
+            // FIXME: this GRCh vs gRCh needs to be reconciled in the data model and data import
+            // update off of this.props.data as it is more stable, and this.state.data does not contain relevant updates
+            if (this.props.data && this.props.data.hgvsNames) {
+                hgvs_GRCh37 = this.props.data.hgvsNames.GRCh37 ? this.props.data.hgvsNames.GRCh37 :
+                    (this.props.data.hgvsNames.gRCh37 ? this.props.data.hgvsNames.gRCh37 : '');
+                hgvs_GRCh38 = this.props.data.hgvsNames.GRCh38 ? this.props.data.hgvsNames.GRCh38 :
+                    (this.props.data.hgvsNames.gRCh38 ? this.props.data.hgvsNames.gRCh38 : '');
+            }
             // get extra 1000Genome information
             populationObj.tGenomes._extra.name = response.name;
             populationObj.tGenomes._extra.var_class = response.var_class;

--- a/src/clincoded/static/components/variant_central/interpretation/population.js
+++ b/src/clincoded/static/components/variant_central/interpretation/population.js
@@ -674,7 +674,8 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
 
     // Method to render external ExAC/gnomAD linkout when no relevant population data is found
     renderExacGnomadLinkout: function(response, datasetName) {
-        let datasetCheck, datasetHomeURLKey, datasetLink, datasetRegionURLKey, linkText;
+        let datasetCheck, datasetLink, datasetRegionURLKey;
+        let linkText = 'Search ' + datasetName;
         // If no ExAC/gnomAD population data, construct external linkout for one of the following:
         // 1) clinvar/cadd data found & the variant type is substitution
         // 2) clinvar/cadd data found & the variant type is NOT substitution
@@ -682,30 +683,30 @@ var CurationInterpretationPopulation = module.exports.CurationInterpretationPopu
         switch (datasetName) {
             case 'ExAC':
                 datasetCheck = this.state.hasExacData;
-                datasetHomeURLKey = 'EXACHome';
+                datasetLink = external_url_map['EXACHome'];
                 datasetRegionURLKey = 'ExACRegion';
             break;
             case 'gnomAD':
                 datasetCheck = this.state.hasGnomadData;
-                datasetHomeURLKey = 'gnomADHome';
+                datasetLink = external_url_map['gnomADHome'];
                 datasetRegionURLKey = 'gnomADRegion';
             break;
         }
         if (response) {
             let chrom = response.chrom;
-            let pos = response.hg19 ? response.hg19.start : (response.clinvar.hg19 ? response.clinvar.hg19.start : response.cadd.hg19.start);
-            let regionStart = response.hg19 ? parseInt(response.hg19.start) - 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.start) - 30 : parseInt(response.cadd.hg19.start) - 30);
-            let regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 : (response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 : parseInt(response.cadd.hg19.end) + 30);
+            const regionStart = response.hg19 ? parseInt(response.hg19.start) - 30 :
+                (response.clinvar && response.clinvar.hg19 ? parseInt(response.clinvar.hg19.start) - 30 :
+                    (response.cadd && response.cadd.hg19 ? parseInt(response.cadd.hg19.start) - 30 : ''));
+            const regionEnd = response.hg19 ? parseInt(response.hg19.end) + 30 :
+                (response.clinvar && response.clinvar.hg19 ? parseInt(response.clinvar.hg19.end) + 30 :
+                    (response.cadd && response.cadd.hg19 ? parseInt(response.cadd.hg19.end) + 30 : ''));
+
             // Applies to 'Duplication', 'Deletion', 'Insertion', 'Indel' (deletion + insertion)
             // Or there is no ExAC/gnomAD data object in the returned myvariant.info JSON response
-            if (!this.state.ext_gnomadExac || !datasetCheck) {
+            if ((!this.state.ext_gnomadExac || !datasetCheck) && chrom && regionStart && regionEnd) {
                 datasetLink = external_url_map[datasetRegionURLKey] + chrom + '-' + regionStart + '-' + regionEnd;
                 linkText = 'View the coverage of this region (+/- 30 bp) in ' + datasetName;
             }
-        } else {
-            // 404 response from myvariant.info
-            datasetLink = external_url_map[datasetHomeURLKey];
-            linkText = 'Search ' + datasetName;
         }
         return (
             <span>

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -286,9 +286,10 @@ export function parseClinvar(xml, extended) {
                         if (elementsXRef[i].getAttribute('DB') === 'dbSNP') {
                             variant.dbSNPIds.push(elementsXRef[i].getAttribute('ID'));
                         }
-                    }
-                    if ($XRef[j].getAttribute('DB') === 'ClinGen') {
-                        variant.carId = $XRef[j].getAttribute('ID');
+
+                        if (elementsXRef[i].getAttribute('DB') === 'ClinGen') {
+                            variant.carId = elementsXRef[i].getAttribute('ID');
+                        }
                     }
                 }
 

--- a/src/clincoded/static/libs/parse-resources.js
+++ b/src/clincoded/static/libs/parse-resources.js
@@ -235,7 +235,7 @@ export function parseClinvar(xml, extended) {
 
                             if (attributeAssembly) {
                                 variant.hgvsNames[attributeAssembly] = textNEExpression;
-                            } else {
+                            } else if (variant.hgvsNames.others.indexOf(textNEExpression) === -1) {
                                 variant.hgvsNames.others.push(textNEExpression);
                             }
 
@@ -253,7 +253,10 @@ export function parseClinvar(xml, extended) {
                         if (elementProteinExpression) {
                             const elementPEExpression = elementProteinExpression.getElementsByTagName('Expression')[0];
                             const textPEExpression = elementPEExpression ? elementPEExpression.textContent : '';
-                            variant.hgvsNames.others.push(textPEExpression);
+
+                            if (variant.hgvsNames.others.indexOf(textPEExpression) === -1) {
+                                variant.hgvsNames.others.push(textPEExpression);
+                            }
 
                             // Save protein change transcript data (for possible extended parsing)
                             if (attributeHGVSType === 'protein') {


### PR DESCRIPTION
Steps to test #2034:
1. Start a new variant curation (based on ClinVar ID).
2. Upon retrieving the variant from ClinVar, check that the **HGVS terms** list includes items identified as GRCh37 and/or GRCh38 (in parenthesis after the term). If such items aren't included, it likely means the data isn't present in ClinVar's E-utilities XML (and a new variant should be selected).
3. Upon saving the variant and being taken to the evidence view, confirm that the "variant is not associated with a GRCh37 genomic representation" warning does not appear.
4. Start the interpretation and confirm there are no problems with existing functionality (adding a disease, inheritance, criteria evaluations, PMID evidence, etc.). If curating as an affiliation, use the approval process to approve the interpretation and then generate ClinVar submission data.