### PR TITLE
Update to Display Logic of Add Variant Modal (to fix automated tests)

### DIFF
--- a/src/clincoded/static/components/add_external_resource.js
+++ b/src/clincoded/static/components/add_external_resource.js
@@ -826,7 +826,7 @@ function clinvarAndCarRenderResourceResult() {
     return(
         <div className="resource-metadata">
             <span className="p-break">{this.state.tempResource.clinvarVariantTitle}</span>
-            {this.state.tempResource && this.state.tempResource.hgvsNames ?
+            {this.state.tempResource ?
                 <div className="row">
                     {this.state.tempResource.carId ?
                         <div className="row">


### PR DESCRIPTION
Steps to test #2115:
1. Start the application and run the browser (bdd) test locally (to confirm no failures).

To see how the update impacts the display of the "add variant" modal, compare the results of retrieving variants by ClinVar ID, such as 224885, both locally and on the demo site.
