### PR TITLE
Update to Prevent (and Remove Existing) Provisional/Snapshot Data Nesting

### DIFF
--- a/src/clincoded/schemas/provisionalClassification.json
+++ b/src/clincoded/schemas/provisionalClassification.json
@@ -14,7 +14,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "9"
+            "default": "10"
         },
         "classificationPoints": {
             "title": "Calculated scores and points from the scored evidence",

--- a/src/clincoded/schemas/provisional_variant.json
+++ b/src/clincoded/schemas/provisional_variant.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "4"
+            "default": "5"
         },
         "autoClassification": {
             "title": "Classification",

--- a/src/clincoded/schemas/resourceHistory.json
+++ b/src/clincoded/schemas/resourceHistory.json
@@ -14,7 +14,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "resourceId": {
             "title": "Resource ID",

--- a/src/clincoded/static/components/provisional_classification/approval.js
+++ b/src/clincoded/static/components/provisional_classification/approval.js
@@ -345,6 +345,14 @@ const ClassificationApproval = module.exports.ClassificationApproval = createRea
                 // this.recordHistory('modify', provisionalClassification, meta);
                 return Promise.resolve(provisionalClassification);
             }).then(result => {
+                let previousSnapshots;
+
+                // To avoid provisional/snapshot data nesting, remove old snapshots from provisional that will be added to the new snapshot
+                if (result && result.associatedClassificationSnapshots) {
+                    previousSnapshots = result.associatedClassificationSnapshots;
+                    delete result['associatedClassificationSnapshots'];
+                }
+
                 // get a fresh copy of the gdm object
                 this.getRestData('/gdm/' + this.props.gdm.uuid).then(newGdm => {
                     // Send approval data to Data Exchange
@@ -364,6 +372,11 @@ const ClassificationApproval = module.exports.ClassificationApproval = createRea
                         this.props.updateSnapshotList(approvalSnapshot['@id'], true);
                         return Promise.resolve(approvalSnapshot);
                     }).then(snapshot => {
+                        // Return old snapshots to provisional before adding latest snapshot
+                        if (previousSnapshots) {
+                            result.associatedClassificationSnapshots = previousSnapshots;
+                        }
+
                         let newClassification = curator.flatten(result);
                         let newSnapshot = curator.flatten(snapshot);
                         if ('associatedClassificationSnapshots' in newClassification) {
@@ -398,6 +411,14 @@ const ClassificationApproval = module.exports.ClassificationApproval = createRea
                 // this.recordHistory('modify', provisionalClassification, meta);
                 return Promise.resolve(provisionalClassification);
             }).then(result => {
+                let previousSnapshots;
+
+                // To avoid provisional/snapshot data nesting, remove old snapshots from provisional that will be added to the new snapshot
+                if (result && result.associatedInterpretationSnapshots) {
+                    previousSnapshots = result.associatedInterpretationSnapshots;
+                    delete result['associatedInterpretationSnapshots'];
+                }
+
                 // get a fresh copy of the interpretation object
                 this.getRestData('/interpretation/' + this.props.interpretation.uuid).then(newInterpretation => {
                     let parentSnapshot = { interpretation: newInterpretation };
@@ -414,6 +435,11 @@ const ClassificationApproval = module.exports.ClassificationApproval = createRea
                         this.props.updateSnapshotList(approvalSnapshot['@id'], true);
                         return Promise.resolve(approvalSnapshot);
                     }).then(snapshot => {
+                        // Return old snapshots to provisional before adding latest snapshot
+                        if (previousSnapshots) {
+                            result.associatedInterpretationSnapshots = previousSnapshots;
+                        }
+
                         let newClassification = curator.flatten(result);
                         let newSnapshot = curator.flatten(snapshot);
                         if ('associatedInterpretationSnapshots' in newClassification) {

--- a/src/clincoded/static/components/provisional_classification/provisional.js
+++ b/src/clincoded/static/components/provisional_classification/provisional.js
@@ -176,6 +176,14 @@ const ProvisionalApproval = module.exports.ProvisionalApproval = createReactClas
                 // this.recordHistory('modify', provisionalClassification, meta);
                 return Promise.resolve(provisionalClassification);
             }).then(result => {
+                let previousSnapshots;
+
+                // To avoid provisional/snapshot data nesting, remove old snapshots from provisional that will be added to the new snapshot
+                if (result && result.associatedClassificationSnapshots) {
+                    previousSnapshots = result.associatedClassificationSnapshots;
+                    delete result['associatedClassificationSnapshots'];
+                }
+
                 // get a fresh copy of the gdm object
                 this.getRestData('/gdm/' + this.props.gdm.uuid).then(newGdm => {
                     // Send provisional data to Data Exchange
@@ -194,6 +202,11 @@ const ProvisionalApproval = module.exports.ProvisionalApproval = createReactClas
                         this.props.updateSnapshotList(provisionalSnapshot['@id']);
                         return Promise.resolve(provisionalSnapshot);
                     }).then(snapshot => {
+                        // Return old snapshots to provisional before adding latest snapshot
+                        if (previousSnapshots) {
+                            result.associatedClassificationSnapshots = previousSnapshots;
+                        }
+
                         let newClassification = curator.flatten(result);
                         let newSnapshot = curator.flatten(snapshot);
                         if ('associatedClassificationSnapshots' in newClassification) {
@@ -229,6 +242,14 @@ const ProvisionalApproval = module.exports.ProvisionalApproval = createReactClas
                 // this.recordHistory('modify', provisionalClassification, meta);
                 return Promise.resolve(provisionalClassification);
             }).then(result => {
+                let previousSnapshots;
+
+                // To avoid provisional/snapshot data nesting, remove old snapshots from provisional that will be added to the new snapshot
+                if (result && result.associatedInterpretationSnapshots) {
+                    previousSnapshots = result.associatedInterpretationSnapshots;
+                    delete result['associatedInterpretationSnapshots'];
+                }
+
                 // get a fresh copy of the interpretation object
                 this.getRestData('/interpretation/' + this.props.interpretation.uuid).then(newInterpretation => {
                     let parentSnapshot = {interpretation: newInterpretation};
@@ -244,6 +265,11 @@ const ProvisionalApproval = module.exports.ProvisionalApproval = createReactClas
                         this.props.updateSnapshotList(provisionalSnapshot['@id']);
                         return Promise.resolve(provisionalSnapshot);
                     }).then(snapshot => {
+                        // Return old snapshots to provisional before adding latest snapshot
+                        if (previousSnapshots) {
+                            result.associatedInterpretationSnapshots = previousSnapshots;
+                        }
+
                         let newClassification = curator.flatten(result);
                         let newSnapshot = curator.flatten(snapshot);
                         if ('associatedInterpretationSnapshots' in newClassification) {

--- a/src/clincoded/upgrade/provisionalClassification.py
+++ b/src/clincoded/upgrade/provisionalClassification.py
@@ -72,3 +72,21 @@ def provisionalClassification_8_9(value, system):
     # https://github.com/ClinGen/clincoded/issues/1796
     # Add several properties for the secondary approvers
     return
+
+@upgrade_step('provisionalClassification', '9', '10')
+def provisionalClassification_9_10(value, system):
+    # https://github.com/ClinGen/clincoded/issues/2132
+    # Remove existing provisional/snapshot nested data
+
+    try:
+        for snapshot in value['associatedClassificationSnapshots']:
+            try:
+                del snapshot['resource']['associatedClassificationSnapshots']
+
+            except KeyError:
+                pass
+
+    except KeyError:
+        pass
+
+    return

--- a/src/clincoded/upgrade/provisional_variant.py
+++ b/src/clincoded/upgrade/provisional_variant.py
@@ -20,3 +20,20 @@ def provisional_variant_3_4(value, system):
     # Add publication properties and update schema version
     return
 
+@upgrade_step('provisional_variant', '4', '5')
+def provisional_variant_4_5(value, system):
+    # https://github.com/ClinGen/clincoded/issues/2132
+    # Remove existing provisional/snapshot nested data
+
+    try:
+        for snapshot in value['associatedInterpretationSnapshots']:
+            try:
+                del snapshot['resource']['associatedInterpretationSnapshots']
+
+            except KeyError:
+                pass
+
+    except KeyError:
+        pass
+
+    return

--- a/src/clincoded/upgrade/resourceHistory.py
+++ b/src/clincoded/upgrade/resourceHistory.py
@@ -1,0 +1,41 @@
+from contentbase.upgrader import upgrade_step
+
+@upgrade_step('snapshot', '1', '2')
+def snapshot_1_2(value, system):
+    # https://github.com/ClinGen/clincoded/issues/2132
+    # Remove existing provisional/snapshot nested data
+
+    try:
+        if (value['resourceType'] == 'classification'):
+            curation_object_name = 'gdm'
+            provisional_array_name = 'provisionalClassifications'
+            snapshot_array_name = 'associatedClassificationSnapshots'
+        elif (value['resourceType'] == 'interpretation'):
+            curation_object_name = 'interpretation'
+            provisional_array_name = 'provisional_variant'
+            snapshot_array_name = 'associatedInterpretationSnapshots'
+        else:
+            raise KeyError
+
+        del value['resource'][snapshot_array_name]
+
+        try:
+            for provisional in value['resourceParent'][curation_object_name][provisional_array_name]:
+                try:
+                    for snapshot in provisional[snapshot_array_name]:
+                        try:
+                            del snapshot['resource'][snapshot_array_name]
+
+                        except KeyError:
+                            pass
+
+                except KeyError:
+                    pass
+
+        except KeyError:
+            pass
+
+    except KeyError:
+        pass
+
+    return


### PR DESCRIPTION
Steps to test #2132:
1. Start a new curation (gene or variant).
2. Run through the approval process (save, provision and approve) multiple times.
3. Check the resulting provisional and latest snapshot objects to confirm there's, at most, one snapshot array reference (`associatedClassificationSnapshots` for gene curation, `associatedInterpretationSnapshots` for variant curation).