### PR TITLE
Issue #1585 Display human-readable HPO terms in gene curations

### DIFF
--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -1715,7 +1715,8 @@ var CaseControlViewer = createReactClass({
                                         <div>
                                             <dt>HPO IDs</dt>
                                             <dd>{caseCohort.hpoIdInDiagnosis && caseCohort.hpoIdInDiagnosis.map(function(hpo, i) {
-                                                return <span key={hpo + '_' + i}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                                let id = hpo.match(/\HP:\d{7}/g);
+                                                return <span key={hpo + '_' + i}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                             })}</dd>
                                         </div>
 
@@ -1727,7 +1728,8 @@ var CaseControlViewer = createReactClass({
                                         <div>
                                             <dt>NOT HPO IDs</dt>
                                             <dd>{caseCohort.hpoIdInElimination && caseCohort.hpoIdInElimination.map(function(hpo, i) {
-                                                return <span key={hpo + '_' + i}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                                let id = hpo.match(/\HP:\d{7}/g);
+                                                return <span key={hpo + '_' + i}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                             })}</dd>
                                         </div>
 

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -15,7 +15,7 @@ import * as CaseControlEvalScore from './case_control/evaluation_score';
 import * as CuratorHistory from './curator_history';
 import { ScoreCaseControl } from './score/case_control_score';
 import { ScoreViewer } from './score/viewer';
-import ModalComponent from '../libs/bootstrap/modal';
+import HpoTermModal from './hpo_term_modal';
 import { GroupDisease } from './disease';
 import * as curator from './curator';
 const CurationMixin = curator.CurationMixin;
@@ -66,7 +66,9 @@ const CaseControlCuration = createReactClass({
             diseaseObj: {},
             diseaseUuid: null,
             diseaseError: null,
-            diseaseRequired: false
+            diseaseRequired: false,
+            hpoWithTerms: [],
+            hpoElimWithTerms: []
         };
     },
 
@@ -81,6 +83,18 @@ const CaseControlCuration = createReactClass({
     // done from unmounted components.
     componentDidMount: function() {
         this.loadData();
+    },
+
+    passHpoToParent: function(hpoWithTerms) {
+        if (hpoWithTerms) {
+            this.setState({ hpoWithTerms });
+        }
+    },
+
+    passElimHpoToParent: function(hpoElimWithTerms) {
+        if (hpoElimWithTerms) {
+            this.setState({ hpoElimWithTerms });
+        }
     },
 
     // Load objects from query string into the state variables. Must have already parsed the query string
@@ -148,6 +162,12 @@ const CaseControlCuration = createReactClass({
                 this.setState({caseGroupName: stateObj.caseGroup.label});
                 if (stateObj.caseGroup['commonDiagnosis'] && stateObj.caseGroup['commonDiagnosis'].length > 0) {
                     this.setState({diseaseObj: stateObj.caseGroup['commonDiagnosis'][0]});
+                }
+                if (stateObj.caseGroup['hpoIdInDiagnosis'] && stateObj.caseGroup['hpoIdInDiagnosis'].length > 0) {
+                    this.setState({ hpoWithTerms: stateObj.caseGroup['hpoIdInDiagnosis'] });
+                }
+                if (stateObj.caseGroup['hpoIdInElimination'] && stateObj.caseGroup['hpoIdInElimination'].length > 0) {
+                    this.setState({ hpoElimWithTerms: stateObj.caseGroup['hpoIdInElimination'] });
                 }
                 this.setState({caseNumWithVariant: stateObj.caseGroup.numberWithVariant});
                 this.setState({caseNumAllGenotyped: stateObj.caseGroup.numberAllGenotypedSequenced});
@@ -239,9 +259,9 @@ const CaseControlCuration = createReactClass({
             /**********************************/
             /* Only applicable to Case Cohort */
             /**********************************/
-            let hpoids = curator.capture.hpoids(this.getFormValue('caseCohort_hpoId'));
+            let hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
             let hpotext = curator.capture.hpoids(this.getFormValue('caseCohort_phenoTerms'));
-            let nothpoids = curator.capture.hpoids(this.getFormValue('caseCohort_nothpoId'));
+            let nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
 
             let valid_disease = false;
             if (!this.state.diseaseObj || (this.state.diseaseObj && !this.state.diseaseObj['term'])) {
@@ -250,18 +270,8 @@ const CaseControlCuration = createReactClass({
                 valid_disease = true;
             }
 
-            let valid_phoId = false;
-            // Check HPO ID format
-            if (hpoids && hpoids.length && _(hpoids).any(function(id) { return id === null; })) {
-                // HPOID list is bad
-                formError = true;
-                this.setFormErrors('caseCohort_hpoId', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
-            } else if (hpoids && hpoids.length && !_(hpoids).any(function(id) { return id === null; })) {
-                valid_phoId = true;
-            }
-
             // Check disease, HPO ID and HPO text
-            if (!formError && !valid_disease && !valid_phoId && (!hpotext || !hpotext.length)) {
+            if (!formError && !valid_disease && (!hpotext || !hpotext.length)) {
                 // Can not empty at all of them
                 formError = true;
                 this.setState({diseaseError: 'Required', diseaseRequired: true}, () => {
@@ -269,13 +279,6 @@ const CaseControlCuration = createReactClass({
                 });
                 this.setFormErrors('caseCohort_hpoId', 'Enter disease term and/or HPO Id(s) and/or Phenotype free text.');
                 this.setFormErrors('caseCohort_phenoTerms', 'Enter disease term and/or HPO Id(s) and/or Phenotype free text.');
-            }
-
-            // Check 'NOT Phenotype(s)' HPO ID format
-            if (nothpoids && nothpoids.length && _(nothpoids).any(function(id) { return id === null; })) {
-                // NOT HPOID list is bad
-                formError = true;
-                this.setFormErrors('caseCohort_nothpoId', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
             }
 
             /*****************************************************/
@@ -1180,26 +1183,26 @@ function GroupName(groupType) {
 // as the calling component.
 function GroupCommonDiseases(groupType) {
     let inputDisabled = (groupType === 'control-cohort') ? true : false;
-    let hpoId, phenoTerms, nothpoId, notphenoTerms, group, cohortLabel;
+    let phenoTerms, notphenoTerms, group, cohortLabel;
     if (groupType === 'case-cohort') {
-        hpoId = 'caseCohort_hpoId';
         phenoTerms = 'caseCohort_phenoTerms';
-        nothpoId = 'caseCohort_nothpoId';
         notphenoTerms = 'caseCohort_notphenoTerms';
         cohortLabel = 'Case Cohort';
         group = this.state.caseGroup;
     }
     if (groupType === 'control-cohort') {
-        hpoId = 'controlCohort_hpoId';
         phenoTerms = 'controlCohort_phenoTerms';
-        nothpoId = 'controlCohort_nothpoId';
         notphenoTerms = 'controlCohort_notphenoTerms';
         cohortLabel = 'Control Cohort';
         group = this.state.controlGroup;
     }
 
-    let hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis.join(', ') : '';
-    let nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination.join(', ') : '';
+    let hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
+    let nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
+    const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+    const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     return (
         <div className="row section section-disease">
@@ -1210,39 +1213,53 @@ function GroupCommonDiseases(groupType) {
             </div>
             <GroupDisease gdm={this.state.gdm} group={group} updateDiseaseObj={this.updateDiseaseObj} diseaseObj={this.state.diseaseObj} required={this.state.diseaseRequired}
                 error={this.state.diseaseError} clearErrorInParent={this.clearErrorInParent} session={this.props.session} inputDisabled={inputDisabled} />
-            <Input type="textarea" ref={hpoId} label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
-                error={this.getFormError(hpoId)} clearError={this.clrMultiFormErrors.bind(null, [hpoId, phenoTerms])}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label>Phenotype(s) in Common&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>    
+            <div className="form-group hpo-term-container">
+                {hpoWithTerms.length ?
+                    <ul>
+                        {hpoWithTerms.map((term, i) => {
+                            return (
+                                <li className="hpo-term" key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                    : null}
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+            </div>
             <Input type="textarea" ref={phenoTerms} label={<LabelPhenoTerms />} rows="2" inputDisabled={inputDisabled}
                 value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
-                error={this.getFormError(phenoTerms)} clearError={this.clrMultiFormErrors.bind(null, [hpoId, phenoTerms])}
+                error={this.getFormError(phenoTerms)} clearError={this.clrMultiFormErrors.bind(null, phenoTerms)}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in {cohortLabel}</em> if they are specifically noted in the paper.</p>
-            <Input type="textarea" ref={nothpoId} label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300" inputDisabled={inputDisabled}
-                error={this.getFormError(nothpoId)} clearError={this.clrFormErrors.bind(null, nothpoId)}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label className="emphasis">NOT Phenotype(s)&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container">
+                {hpoElimWithTerms.length ?
+                    <ul>
+                        {hpoElimWithTerms.map((term, i) => {
+                            return (
+                                <li className="hpo-term" key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                    : null}
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+            </div>
             <Input type="textarea" ref={notphenoTerms} label={<LabelPhenoTerms not />} rows="2" inputDisabled={inputDisabled}
                 value={group && group.termsInElimination ? group.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );
 }
-
-// HTML labels for inputs follow.
-var LabelHpoId = createReactClass({
-    propTypes: {
-        not: PropTypes.bool // T to show 'NOT' version of label
-    },
-
-    render: function() {
-        return (
-            <span>
-                {this.props.not ? <span className="emphasis">NOT Phenotype(s)&nbsp;</span> : <span>Phenotype(s) in Common&nbsp;</span>}
-                <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
-            </span>
-        );
-    }
-});
 
 // HTML labels for inputs follow.
 var LabelPhenoTerms = createReactClass({

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -547,6 +547,9 @@ const CaseControlCuration = createReactClass({
                     if (nothpoids && nothpoids.length) {
                         newCaseGroup.hpoIdInElimination = nothpoids;
                     }
+                    else if (newCaseGroup.hpoIdInElimination) {
+                        delete newCaseGroup.hpoIdInElimination;
+                    }
                     phenoterms = this.getFormValue(prefix + 'notphenoTerms');
                     if (phenoterms) {
                         newCaseGroup.termsInElimination = phenoterms;
@@ -1197,12 +1200,12 @@ function GroupCommonDiseases(groupType) {
         group = this.state.controlGroup;
     }
 
-    let hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
-    let nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
+    const hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
+    const nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
-    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
-    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addHpoTermButton = hpoWithTerms.length  ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = hpoElimWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     return (
         <div className="row section section-disease">
@@ -1233,7 +1236,7 @@ function GroupCommonDiseases(groupType) {
             </div>
             <Input type="textarea" ref={phenoTerms} label={<LabelPhenoTerms />} rows="2" inputDisabled={inputDisabled}
                 value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
-                error={this.getFormError(phenoTerms)} clearError={this.clrMultiFormErrors.bind(null, phenoTerms)}
+                error={this.getFormError(phenoTerms)} clearError={this.clrMultiFormErrors.bind(null, [phenoTerms])}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in {cohortLabel}</em> if they are specifically noted in the paper.</p>
             <div className="col-sm-5 control-label">

--- a/src/clincoded/static/components/case_control_curation.js
+++ b/src/clincoded/static/components/case_control_curation.js
@@ -85,13 +85,13 @@ const CaseControlCuration = createReactClass({
         this.loadData();
     },
 
-    passHpoToParent: function(hpoWithTerms) {
+    updateHpo: function(hpoWithTerms) {
         if (hpoWithTerms) {
             this.setState({ hpoWithTerms });
         }
     },
 
-    passElimHpoToParent: function(hpoElimWithTerms) {
+    updateElimHpo: function(hpoElimWithTerms) {
         if (hpoElimWithTerms) {
             this.setState({ hpoElimWithTerms });
         }
@@ -259,9 +259,9 @@ const CaseControlCuration = createReactClass({
             /**********************************/
             /* Only applicable to Case Cohort */
             /**********************************/
-            let hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+            let hpoIds = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
             let hpotext = curator.capture.hpoids(this.getFormValue('caseCohort_phenoTerms'));
-            let nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+            let notHpoIds = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
 
             let valid_disease = false;
             if (!this.state.diseaseObj || (this.state.diseaseObj && !this.state.diseaseObj['term'])) {
@@ -533,8 +533,8 @@ const CaseControlCuration = createReactClass({
                     } else {
                         delete newCaseGroup.commonDiagnosis;
                     }
-                    if (hpoids && hpoids.length) {
-                        newCaseGroup.hpoIdInDiagnosis = hpoids;
+                    if (hpoIds && hpoIds.length) {
+                        newCaseGroup.hpoIdInDiagnosis = hpoIds;
                     } else if (newCaseGroup.hpoIdInDiagnosis) {
                         delete newCaseGroup.hpoIdInDiagnosis;
                     }
@@ -544,13 +544,13 @@ const CaseControlCuration = createReactClass({
                     } else if (newCaseGroup.termsInDiagnosis) {
                         delete newCaseGroup.termsInDiagnosis;
                     }
-                    if (nothpoids && nothpoids.length) {
-                        newCaseGroup.hpoIdInElimination = nothpoids;
+                    if (notHpoIds && notHpoIds.length) {
+                        newCaseGroup.hpoIdInElimination = notHpoIds;
                     }
                     else if (newCaseGroup.hpoIdInElimination) {
                         delete newCaseGroup.hpoIdInElimination;
                     }
-                    phenoterms = this.getFormValue(prefix + 'notphenoTerms');
+                    phenoterms = this.getFormValue(prefix + 'notPhenoTerms');
                     if (phenoterms) {
                         newCaseGroup.termsInElimination = phenoterms;
                     }
@@ -1186,22 +1186,22 @@ function GroupName(groupType) {
 // as the calling component.
 function GroupCommonDiseases(groupType) {
     let inputDisabled = (groupType === 'control-cohort') ? true : false;
-    let phenoTerms, notphenoTerms, group, cohortLabel;
+    let phenoTerms, notPhenoTerms, group, cohortLabel;
     if (groupType === 'case-cohort') {
         phenoTerms = 'caseCohort_phenoTerms';
-        notphenoTerms = 'caseCohort_notphenoTerms';
+        notPhenoTerms = 'caseCohort_notPhenoTerms';
         cohortLabel = 'Case Cohort';
         group = this.state.caseGroup;
     }
     if (groupType === 'control-cohort') {
         phenoTerms = 'controlCohort_phenoTerms';
-        notphenoTerms = 'controlCohort_notphenoTerms';
+        notPhenoTerms = 'controlCohort_notPhenoTerms';
         cohortLabel = 'Control Cohort';
         group = this.state.controlGroup;
     }
 
-    const hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
-    const nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
+    const hpoIdVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
+    const notHpoIdVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
     const addHpoTermButton = hpoWithTerms.length  ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
@@ -1232,7 +1232,7 @@ function GroupCommonDiseases(groupType) {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.updateHpo} savedHpo={hpoIdVal} inElim={false} />
             </div>
             <Input type="textarea" ref={phenoTerms} label={<LabelPhenoTerms />} rows="2" inputDisabled={inputDisabled}
                 value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
@@ -1255,9 +1255,9 @@ function GroupCommonDiseases(groupType) {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.updateElimHpo} savedElimHpo={notHpoIdVal} inElim={true} />
             </div>
-            <Input type="textarea" ref={notphenoTerms} label={<LabelPhenoTerms not />} rows="2" inputDisabled={inputDisabled}
+            <Input type="textarea" ref={notPhenoTerms} label={<LabelPhenoTerms not />} rows="2" inputDisabled={inputDisabled}
                 value={group && group.termsInElimination ? group.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -2420,7 +2420,8 @@ const FamilyViewer = createReactClass({
                                 <div>
                                     <dt>HPO IDs</dt>
                                     <dd>{family.hpoIdInDiagnosis && family.hpoIdInDiagnosis.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 
@@ -2432,7 +2433,8 @@ const FamilyViewer = createReactClass({
                                 <div>
                                     <dt>NOT HPO IDs</dt>
                                     <dd>{family.hpoIdInElimination && family.hpoIdInElimination.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -311,7 +311,7 @@ var FamilyCuration = createReactClass({
         if (associatedGroups && associatedGroups.length > 0) {
             hpoIds = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.hpoIdInDiagnosis && associatedGroup.hpoIdInDiagnosis.length) {
-                    const hpoTerm = associatedGroup.hpoIdInDiagnosis ? associatedGroup.hpoIdInDiagnosis : [];
+                    const hpoTerm = associatedGroup.hpoIdInDiagnosis;
                     return hpoTerm;
                 }
             });
@@ -346,7 +346,7 @@ var FamilyCuration = createReactClass({
         if (associatedGroups && associatedGroups.length > 0) {
             hpoInElim = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.hpoIdInElimination && associatedGroup.hpoIdInElimination.length) {
-                    const hpoTerm = associatedGroup.hpoIdInElimination ? associatedGroup.hpoIdInElimination : [];
+                    const hpoTerm = associatedGroup.hpoIdInElimination;
                     return hpoTerm;
                 }
             });
@@ -1276,6 +1276,9 @@ var FamilyCuration = createReactClass({
         if (hpoElimWithTerms) {
             newFamily.hpoIdInElimination = hpoElimWithTerms;
         }
+        else if (newFamily.hpoIdInElimination) {
+            delete newFamily.hpoIdInElimination;
+        }
         phenoterms = this.getFormValue('notphenoterms');
         if (phenoterms) {
             newFamily.termsInElimination = phenoterms;
@@ -1694,8 +1697,8 @@ function FamilyCommonDiseases() {
     const nothpoidVal = family && family.hpoIdInElimination ? family.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
-    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
-    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = hpoElimWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     // Make a list of diseases from the group, either from the given group,
     // or the family if we're editing one that has associated groups.renderPhenotype

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1722,14 +1722,16 @@ function FamilyCommonDiseases() {
                     <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
                 </span>
             </div>
-            <div className="form-group hpo-term-container"> 
-                <ul>
-                    {hpoWithTerms.map((term, i) => {
-                        return (
-                            <li key={i}>{term}</li>
-                        );
-                    })}
-                </ul>
+            <div className="form-group hpo-term-container">
+                {hpoWithTerms.length ?
+                    <ul>
+                        {hpoWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                    : null}
                 <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
             </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
@@ -1751,7 +1753,7 @@ function FamilyCommonDiseases() {
                 </span>
             </div>
             <div className="form-group hpo-term-container">
-                <span>
+                {hpoElimWithTerms.length ?
                     <ul>
                         {hpoElimWithTerms.map((term, i) => {
                             return (
@@ -1759,7 +1761,7 @@ function FamilyCommonDiseases() {
                             );
                         })}
                     </ul>
-                </span>
+                    : null}
                 <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
             </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -1406,13 +1406,13 @@ var FamilyCuration = createReactClass({
         this.loadData();
     },
 
-    passHpoToParent: function(hpoWithTerms) {
+    updateHpo: function(hpoWithTerms) {
         if (hpoWithTerms) {
             this.setState({ hpoWithTerms });
         }
     },
 
-    passElimHpoToParent: function(hpoElimWithTerms) {
+    updateElimHpo: function(hpoElimWithTerms) {
         if (hpoElimWithTerms) {
             this.setState({ hpoElimWithTerms });
         }
@@ -1693,8 +1693,8 @@ function FamilyCommonDiseases() {
     let associatedGroups;
 
     // If we're editing a family, make editable values of the complex properties
-    const hpoidVal = family && family.hpoIdInDiagnosis ? family.hpoIdInDiagnosis : [];
-    const nothpoidVal = family && family.hpoIdInElimination ? family.hpoIdInElimination : [];
+    const hpoIdVal = family && family.hpoIdInDiagnosis ? family.hpoIdInDiagnosis : [];
+    const notHpoIdVal = family && family.hpoIdInElimination ? family.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
     const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
@@ -1735,7 +1735,7 @@ function FamilyCommonDiseases() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.updateHpo} savedHpo={hpoIdVal} inElim={false} />
             </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'ft', 'Group') : curator.renderPhenotype(null, 'Family', 'ft')
@@ -1765,7 +1765,7 @@ function FamilyCommonDiseases() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.updateElimHpo} savedElimHpo={notHpoIdVal} inElim={true} />
             </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : null}

--- a/src/clincoded/static/components/family_curation.js
+++ b/src/clincoded/static/components/family_curation.js
@@ -15,7 +15,7 @@ import { AddResourceId } from './add_external_resource';
 import * as CuratorHistory from './curator_history';
 import * as methods from './methods';
 import { makeStarterIndividual, updateProbandVariants, recordIndividualHistory } from './individual_curation';
-import ModalComponent from '../libs/bootstrap/modal';
+import HpoTermModal from './hpo_term_modal';
 import { FamilyDisease, FamilyProbandDisease } from './disease';
 import { renderVariantLabelAndTitle } from '../libs/render_variant_label_title';
 import * as curator from './curator';
@@ -113,7 +113,9 @@ var FamilyCuration = createReactClass({
             diseaseError: null,
             probandDiseaseObj: {},
             probandDiseaseUuid: null,
-            probandDiseaseError: null
+            probandDiseaseError: null,
+            hpoWithTerms: [],
+            hpoElimWithTerms: []
         };
     },
 
@@ -309,15 +311,14 @@ var FamilyCuration = createReactClass({
         if (associatedGroups && associatedGroups.length > 0) {
             hpoIds = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.hpoIdInDiagnosis && associatedGroup.hpoIdInDiagnosis.length) {
-                    return (
-                        associatedGroup.hpoIdInDiagnosis.map(function(hpoid, i) {
-                            return (hpoid);
-                        }).join(', ')
-                    );
+                    const hpoTerm = associatedGroup.hpoIdInDiagnosis ? associatedGroup.hpoIdInDiagnosis : [];
+                    return hpoTerm;
                 }
             });
             if (hpoIds.length) {
-                this.refs['hpoid'].setValue(hpoIds.join(', '));
+                hpoIds.forEach((hpoArr) => {
+                    this.setState({ hpoWithTerms: hpoArr });
+                });
             }
             hpoFreeText = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.termsInDiagnosis) {
@@ -345,15 +346,14 @@ var FamilyCuration = createReactClass({
         if (associatedGroups && associatedGroups.length > 0) {
             hpoInElim = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.hpoIdInElimination && associatedGroup.hpoIdInElimination.length) {
-                    return (
-                        associatedGroup.hpoIdInElimination.map(function(elimHpoId, i) {
-                            return (elimHpoId);
-                        }).join(', ')
-                    );
+                    const hpoTerm = associatedGroup.hpoIdInElimination ? associatedGroup.hpoIdInElimination : [];
+                    return hpoTerm;
                 }
             });
             if (hpoInElim.length) {
-                this.refs['nothpoid'].setValue(hpoInElim.join(', '));
+                hpoInElim.forEach((hpoArr) => {
+                    this.setState({ hpoElimWithTerms: hpoArr });
+                });
             }
             hpoElimFreeText = associatedGroups.map(function(associatedGroup, i) {
                 if (associatedGroup.termsInElimination) {
@@ -544,6 +544,12 @@ var FamilyCuration = createReactClass({
                 if (stateObj.family.commonDiagnosis && stateObj.family.commonDiagnosis.length > 0) {
                     this.setState({diseaseObj: stateObj.family['commonDiagnosis'][0]});
                 }
+                if (stateObj.family['hpoIdInDiagnosis'] && stateObj.family['hpoIdInDiagnosis'].length > 0) {
+                    this.setState({ hpoWithTerms: stateObj.family['hpoIdInDiagnosis'] });
+                }
+                if (stateObj.family['hpoIdInElimination'] && stateObj.family['hpoIdInElimination'].length > 0) {
+                    this.setState({ hpoElimWithTerms: stateObj.family['hpoIdInElimination'] });
+                }
 
                 // Load the previously stored 'Published Calculated LOD score' if any
                 stateObj.publishedLodScore = stateObj.family.segregation.publishedLodScore ? stateObj.family.segregation.publishedLodScore : null;
@@ -711,8 +717,6 @@ var FamilyCuration = createReactClass({
             var hadvar = false; // T if family had variants before being edited here.
 
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
-            var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
-            var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
             let recessiveZygosity = this.state.recessiveZygosity;
             let gdm = this.state.gdm;
             const semiDom = gdm && gdm.modeInheritance ? gdm.modeInheritance.indexOf('Semidominant') > -1 : false;
@@ -735,19 +739,6 @@ var FamilyCuration = createReactClass({
                 this.setFormErrors('otherpmids', 'Use PubMed IDs (e.g. 12345678) separated by commas');
             }
 
-            // Check that all gene symbols have the proper format (will check for existence later)
-            if (hpoids && hpoids.length && _(hpoids).any(function(id) { return id === null; })) {
-                // HPOID list is bad
-                formError = true;
-                this.setFormErrors('hpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
-            }
-
-            // Check that all gene symbols have the proper format (will check for existence later)
-            if (nothpoids && nothpoids.length && _(nothpoids).any(function(id) { return id === null; })) {
-                // NOT HPOID list is bad
-                formError = true;
-                this.setFormErrors('nothpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
-            }
             // Get variant uuid's if they were added via the modals
             for (var i = 0; i < maxVariants; i++) {
                 // Grab the values from the variant form panel
@@ -1265,9 +1256,9 @@ var FamilyCuration = createReactClass({
         }
 
         // Fill in the group fields from the Common Diseases & Phenotypes panel
-        var hpoTerms = this.getFormValue('hpoid');
+        var hpoTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
         if (hpoTerms) {
-            newFamily.hpoIdInDiagnosis = _.compact(hpoTerms.toUpperCase().split(', '));
+            newFamily.hpoIdInDiagnosis = hpoTerms;
         }
         else if (newFamily.hpoIdInDiagnosis) {
             // allow to delete HPO ids
@@ -1281,9 +1272,9 @@ var FamilyCuration = createReactClass({
             // allow to delete phenotype free text
             delete newFamily.termsInDiagnosis;
         }
-        hpoTerms = this.getFormValue('nothpoid');
-        if (hpoTerms) {
-            newFamily.hpoIdInElimination = _.compact(hpoTerms.toUpperCase().split(', '));
+        var hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+        if (hpoElimWithTerms) {
+            newFamily.hpoIdInElimination = hpoElimWithTerms;
         }
         phenoterms = this.getFormValue('notphenoterms');
         if (phenoterms) {
@@ -1410,6 +1401,18 @@ var FamilyCuration = createReactClass({
     componentDidMount: function() {
         // Get the 'evidence', 'gdm', and 'group' UUIDs from the query string and save them locally.
         this.loadData();
+    },
+
+    passHpoToParent: function(hpoWithTerms) {
+        if (hpoWithTerms) {
+            this.setState({ hpoWithTerms });
+        }
+    },
+
+    passElimHpoToParent: function(hpoElimWithTerms) {
+        if (hpoElimWithTerms) {
+            this.setState({ hpoElimWithTerms });
+        }
     },
 
     componentWillUnmount: function() {
@@ -1687,8 +1690,12 @@ function FamilyCommonDiseases() {
     let associatedGroups;
 
     // If we're editing a family, make editable values of the complex properties
-    let hpoidVal = family && family.hpoIdInDiagnosis ? family.hpoIdInDiagnosis.join(', ') : '';
-    let nothpoidVal = family && family.hpoIdInElimination ? family.hpoIdInElimination.join(', ') : '';
+    const hpoidVal = family && family.hpoIdInDiagnosis ? family.hpoIdInDiagnosis : [];
+    const nothpoidVal = family && family.hpoIdInElimination ? family.hpoIdInElimination : [];
+    const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+    const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     // Make a list of diseases from the group, either from the given group,
     // or the family if we're editing one that has associated groups.renderPhenotype
@@ -1709,9 +1716,22 @@ function FamilyCommonDiseases() {
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'hpo', 'Group') : curator.renderPhenotype(null, 'Family', 'hpo')
             }
-            <Input type="textarea" ref="hpoid" label={LabelHpoId()} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label>Phenotype(s) in Common&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container"> 
+                <ul>
+                    {hpoWithTerms.map((term, i) => {
+                        return (
+                            <li key={i}>{term}</li>
+                        );
+                    })}
+                </ul>
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+            </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'ft', 'Group') : curator.renderPhenotype(null, 'Family', 'ft')
             }
@@ -1724,11 +1744,26 @@ function FamilyCommonDiseases() {
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Family</em> if they are specifically noted in the paper.</p>
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
                 curator.renderPhenotype(associatedGroups, 'Family', 'nothpo', 'Group') : null}
-            <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label className="emphasis">NOT Phenotype(s)&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container">
+                <span>
+                    <ul>
+                        {hpoElimWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                </span>
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+            </div>
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
-                curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : null}    
+                curator.renderPhenotype(associatedGroups, 'Family', 'notft', 'Group') : null}
             <Input type="textarea" ref="notphenoterms" label={LabelPhenoTerms('not')} rows="2" value={family && family.termsInElimination ? family.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
@@ -1738,19 +1773,6 @@ function FamilyCommonDiseases() {
         </div>
     );
 }
-
-/**
- * HTML labels for inputs follow.
- * @param {string} bool - Value of 'not'
- */
-const LabelHpoId = bool => {
-    return (
-        <span>
-            {bool && bool === 'not' ? <span className="emphasis">NOT Phenotype(s)&nbsp;</span> : <span>Phenotype(s) in Common&nbsp;</span>}
-            <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
-        </span>
-    );
-};
 
 /**
  * HTML labels for inputs follow.

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -66,7 +66,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                     {evidence.diseaseId && evidence.diseaseTerm ?
                         <span>{evidence.diseaseTerm}
                             <span> {!evidence.diseaseFreetext ? (<span>({evidence.diseaseId.replace('_', ':')})</span>)
-                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br/><strong>HPO term(s):</strong>{evidence.hpoIdInDiagnosis.join(', ')}</span> : null)
+                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br/><strong>HPO term(s): </strong>{evidence.diseasePhenotypes.join(', ')}</span> : null)
                             }
                             </span>
                         </span>

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
-import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     constructor(props) {
@@ -66,8 +65,8 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                 <td className="evidence-disease">
                     {evidence.diseaseId && evidence.diseaseTerm ?
                         <span>{evidence.diseaseTerm}
-                            <span> {!evidence.diseaseFreetext ? <span>({evidence.diseaseId.replace('_', ':')})</span>
-                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br /><strong>HPO term(s):</strong><HpoTerms hpoIds={evidence.diseasePhenotypes} /></span> : null)
+                            <span> {!evidence.diseaseFreetext ? (<span>({evidence.diseaseId.replace('_', ':')})</span>)
+                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br/><strong>HPO term(s):</strong>{evidence.hpoIdInDiagnosis.join(', ')}</span> : null)
                             }
                             </span>
                         </span>
@@ -75,7 +74,11 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                         <span>
                             {evidence.hpoIdInDiagnosis.length ?
                                 <span><strong>HPO term(s):</strong>
-                                    <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
+                                {evidence.hpoIdInDiagnosis.map((term, i) => {
+                                    return (
+                                        <div key={i}>{term}</div>
+                                    );
+                                })}
                                 </span> 
                                 : null}
                             {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
@@ -229,8 +232,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseControl.propTypes = {
-    caseControlEvidenceList: PropTypes.array,
-    hpoTerms: PropTypes.object
+    caseControlEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummaryCaseControl;

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -76,7 +76,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                                 <span><strong>HPO term(s):</strong>
                                 {evidence.hpoIdInDiagnosis.map((term, i) => {
                                     return (
-                                        <div key={i}>{term}</div>
+                                        <div className="hpo-term-summary" key={i}>{term}</div>
                                     );
                                 })}
                                 </span> 

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -89,7 +89,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                         <span><strong>HPO term(s): </strong>
                             {evidence.hpoIdInDiagnosis.map((term, i) => {
                                 return (
-                                    <div key={i}>{term}</div>
+                                    <div className="hpo-term-summary" key={i}>{term}</div>
                                 );
                             })}
                         </span> 

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
-import HpoTerms from '../../libs/get_hpo_term';
 import { renderVariantTitle } from '../../libs/render_variant_title';
 
 class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
@@ -87,8 +86,12 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                 </td>
                 <td className="evidence-phenotypes">
                     {evidence.hpoIdInDiagnosis.length ?
-                        <span><strong>HPO term(s):</strong>
-                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
+                        <span><strong>HPO term(s): </strong>
+                            {evidence.hpoIdInDiagnosis.map((term, i) => {
+                                return (
+                                    <div key={i}>{term}</div>
+                                );
+                            })}
                         </span> 
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
@@ -257,8 +260,7 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseLevel.propTypes = {
-    caseLevelEvidenceList: PropTypes.array,
-    hpoTerms: PropTypes.object
+    caseLevelEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummaryCaseLevel;

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -70,7 +70,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                         <span><strong>HPO term(s):</strong>
                         {evidence.hpoIdInDiagnosis.map((term, i) => {
                             return (
-                                <div key={i}>{term}</div>
+                                <div className="hpo-term-summary" key={i}>{term}</div>
                             );
                         })}
                         </span> 

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
-import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummarySegregation extends Component {
     constructor(props) {
@@ -69,7 +68,11 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                 <td className="evidence-phenotypes">
                     {evidence.hpoIdInDiagnosis.length ?
                         <span><strong>HPO term(s):</strong>
-                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
+                        {evidence.hpoIdInDiagnosis.map((term, i) => {
+                            return (
+                                <div key={i}>{term}</div>
+                            );
+                        })}
                         </span> 
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
@@ -206,8 +209,7 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
 }
 
 GeneDiseaseEvidenceSummarySegregation.propTypes = {
-    segregationEvidenceList: PropTypes.array,
-    hpoTerms: PropTypes.object
+    segregationEvidenceList: PropTypes.array
 };
 
 export default GeneDiseaseEvidenceSummarySegregation;

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -37,12 +37,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
             caseControlEvidenceList: [],
             experimentalEvidenceList: [],
             nonscorableEvidenceList: [],
-            preview: queryKeyValue('preview', this.props.href),
-            hpoTermsCollection: {
-                caseLevel: {},
-                segregation: {},
-                caseControl: {}
-            }
+            preview: queryKeyValue('preview', this.props.href)
         };
     },
 
@@ -283,11 +278,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                             caseLevelEvidence['sequencingMethod'] = segregation && segregation.sequencingMethod ? segregation.sequencingMethod : null;
                             // Put object into array
                             caseLevelEvidenceList.push(caseLevelEvidence);
-                            this.setState({caseLevelEvidenceList: caseLevelEvidenceList}, () => {
-                                if (this.state.caseLevelEvidenceList.length) {
-                                    this.fetchHpoTerms(this.state.caseLevelEvidenceList, 'caseLevel');
-                                }
-                            });
+                            this.setState({caseLevelEvidenceList: caseLevelEvidenceList});
                         }
                     }
                 });
@@ -388,11 +379,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     segregationEvidence['sequencingMethod'] = segregation && segregation.sequencingMethod ? segregation.sequencingMethod : null;
                     // Put object into array
                     segregationEvidenceList.push(segregationEvidence);
-                    this.setState({segregationEvidenceList: segregationEvidenceList}, () => {
-                        if (this.state.segregationEvidenceList.length) {
-                            this.fetchHpoTerms(this.state.segregationEvidenceList, 'segregation');
-                        }
-                    });
+                    this.setState({segregationEvidenceList: segregationEvidenceList});
                 }
             }
         });
@@ -476,11 +463,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                             caseControlEvidence['hpoIdInDiagnosis'] = caseControl.caseCohort.hpoIdInDiagnosis && caseControl.caseCohort.hpoIdInDiagnosis.length ? caseControl.caseCohort.hpoIdInDiagnosis : [];
                                             // Put object into array
                                             caseControlEvidenceList.push(caseControlEvidence);
-                                            this.setState({caseControlEvidenceList: caseControlEvidenceList}, () => {
-                                                if (this.state.caseControlEvidenceList.length) {
-                                                    this.fetchHpoTerms(this.state.caseControlEvidenceList, 'caseControl');
-                                                }
-                                            });
+                                            this.setState({caseControlEvidenceList: caseControlEvidenceList});
                                         }
                                     }
                                 }
@@ -633,45 +616,6 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         return explanation;
     },
 
-    fetchHpoTerms(evidenceList, evidenceType) {
-        let allHpoIds = [];
-        if (evidenceList && evidenceList.length) {
-            evidenceList.forEach(evidence => {
-                if (evidence.hpoIdInDiagnosis && evidence.hpoIdInDiagnosis.length) {
-                    Array.prototype.push.apply(allHpoIds, evidence.hpoIdInDiagnosis);
-                }
-            });
-        }
-        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
-        let hpoTermsCollection = this.state.hpoTermsCollection;
-        uniqueHpoIds.forEach(id => {
-            let url = external_url_map['HPOApi'] + id.replace(':', '_');
-            // Make the OLS REST API call
-            this.getRestData(url).then(result => {
-                let termLabel = result['_embedded']['terms'][0]['label'];
-                if (evidenceType === 'caseLevel') {
-                    hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                } else if (evidenceType === 'segregation') {
-                    hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                } else if (evidenceType === 'caseControl') {
-                    hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                }
-                this.setState({hpoTermsCollection: hpoTermsCollection});
-            }).catch(err => {
-                // Unsuccessful retrieval
-                console.warn('Error in fetching HPO data =: %o', err);
-                if (evidenceType === 'caseLevel') {
-                    hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
-                } else if (evidenceType === 'segregation') {
-                    hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
-                } else if (evidenceType === 'caseControl') {
-                    hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
-                }
-                this.setState({hpoTermsCollection: hpoTermsCollection});
-            });
-        });
-    },
-
     /**
      * Method to close current window
      * @param {*} e - Window event
@@ -692,7 +636,6 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         const gdm = this.state.gdm;
         const provisional = this.state.provisional;
         const snapshotPublishDate = this.state.snapshotPublishDate;
-        const hpoTermsCollection = this.state.hpoTermsCollection;
 
         return (
             <div className="gene-disease-evidence-summary-wrapper">
@@ -707,9 +650,9 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     {!this.state.preview && provisional && Object.keys(provisional).length ?
                         <GeneDiseaseEvidenceSummaryClassificationMatrix classification={provisional} />
                         : null}
-                    <GeneDiseaseEvidenceSummaryCaseLevel caseLevelEvidenceList={this.state.caseLevelEvidenceList} hpoTerms={hpoTermsCollection.caseLevel} />
-                    <GeneDiseaseEvidenceSummarySegregation segregationEvidenceList={this.state.segregationEvidenceList} hpoTerms={hpoTermsCollection.segregation} />
-                    <GeneDiseaseEvidenceSummaryCaseControl caseControlEvidenceList={this.state.caseControlEvidenceList} hpoTerms={hpoTermsCollection.caseControl} />
+                    <GeneDiseaseEvidenceSummaryCaseLevel caseLevelEvidenceList={this.state.caseLevelEvidenceList} />
+                    <GeneDiseaseEvidenceSummarySegregation segregationEvidenceList={this.state.segregationEvidenceList} />
+                    <GeneDiseaseEvidenceSummaryCaseControl caseControlEvidenceList={this.state.caseControlEvidenceList} />
                     <GeneDiseaseEvidenceSummaryExperimental experimentalEvidenceList={this.state.experimentalEvidenceList} />
                     <GeneDiseaseEvidenceSummaryNonscorableEvidence nonscorableEvidenceList={this.state.nonscorableEvidenceList} />
                 </div>

--- a/src/clincoded/static/components/globals.js
+++ b/src/clincoded/static/components/globals.js
@@ -201,7 +201,7 @@ module.exports.external_url_map = {
     'Mondo': 'https://www.ebi.ac.uk/ols/ontologies/mondo',
     'MondoSearch': 'https://www.ebi.ac.uk/ols/ontologies/mondo/terms?iri=http://purl.obolibrary.org/obo/',
     'MondoApi': 'https://www.ebi.ac.uk/ols/api/ontologies/mondo/terms?iri=http://purl.obolibrary.org/obo/',
-    'HPOApi': 'https://www.ebi.ac.uk/ols/api/ontologies/hp/terms?iri=http://purl.obolibrary.org/obo/',
+    'HPOApi': 'https://hpo.jax.org/api/hpo/term/',
     'dbSNP': 'https://www.ncbi.nlm.nih.gov/snp/',
     'CAR': 'http://reg.genome.network/site/cg-registry',
     'CARallele': '//reg.genome.network/allele/',

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -908,7 +908,8 @@ class GroupViewer extends Component {
                                 <div>
                                     <dt>HPO IDs</dt>
                                     <dd>{context.hpoIdInDiagnosis && context.hpoIdInDiagnosis.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 
@@ -920,7 +921,8 @@ class GroupViewer extends Component {
                                 <div>
                                     <dt>NOT HPO IDs</dt>
                                     <dd>{context.hpoIdInElimination && context.hpoIdInElimination.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -13,7 +13,7 @@ import { parseAndLogError } from './mixins';
 import { parsePubmed } from '../libs/parse-pubmed';
 import * as CuratorHistory from './curator_history';
 import * as methods from './methods';
-import ModalComponent from '../libs/bootstrap/modal';
+import HpoTermModal from './hpo_term_modal';
 import { GroupDisease } from './disease';
 import * as curator from './curator';
 const CurationMixin = curator.CurationMixin;
@@ -45,7 +45,9 @@ var GroupCuration = createReactClass({
             diseaseObj: {},
             diseaseUuid: null,
             diseaseError: null,
-            diseaseRequired: false
+            diseaseRequired: false,
+            hpoWithTerms: [],
+            hpoElimWithTerms: []
         };
     },
 
@@ -113,6 +115,12 @@ var GroupCuration = createReactClass({
                 if (stateObj.group['commonDiagnosis'] && stateObj.group['commonDiagnosis'].length > 0) {
                     this.setState({diseaseObj: stateObj.group['commonDiagnosis'][0]});
                 }
+                if (stateObj.group['hpoIdInDiagnosis'] && stateObj.group['hpoIdInDiagnosis'].length > 0) {
+                    this.setState({ hpoWithTerms: stateObj.group['hpoIdInDiagnosis'] });
+                }
+                if (stateObj.group['hpoIdInElimination'] && stateObj.group['hpoIdInElimination'].length > 0) {
+                    this.setState({ hpoElimWithTerms: stateObj.group['hpoIdInElimination'] });
+                }
             }
 
             // Set all the state variables we've collected
@@ -133,6 +141,18 @@ var GroupCuration = createReactClass({
         this.loadData();
     },
 
+    passHpoToParent: function(hpoWithTerms) {
+        if (hpoWithTerms) {
+            this.setState({ hpoWithTerms });
+        }
+    },
+
+    passElimHpoToParent: function(hpoElimWithTerms) {
+        if (hpoElimWithTerms) {
+            this.setState({ hpoElimWithTerms });
+        }
+    },
+
     submitForm: function(e) {
         e.preventDefault(); e.stopPropagation(); // Don't run through HTML submit handler
 
@@ -148,20 +168,9 @@ var GroupCuration = createReactClass({
             // Parse comma-separated list fields
             var geneSymbols = curator.capture.genes(this.getFormValue('othergenevariants'));
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
-            var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
             var hpotext = curator.capture.hpoids(this.getFormValue('phenoterms'));
-            var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
-
-            var valid_phoId = false;
-            // Check HPO ID format
-            if (hpoids && hpoids.length && _(hpoids).any(function(id) { return id === null; })) {
-                // HPOID list is bad
-                formError = true;
-                this.setFormErrors('hpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
-            }
-            else if (hpoids && hpoids.length && !_(hpoids).any(function(id) { return id === null; })) {
-                valid_phoId = true;
-            }
+            var hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+            var nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
 
             let valid_disease = false;
             if (!this.state.diseaseObj || (this.state.diseaseObj && !this.state.diseaseObj['term'])) {
@@ -171,13 +180,12 @@ var GroupCuration = createReactClass({
             }
 
             // Check HPO ID and HPO text
-            if (!formError && !valid_disease && !valid_phoId && (!hpotext || !hpotext.length)) {
+            if (!formError && !valid_disease && (!hpotext || !hpotext.length)) {
                 // Can not empty at all of them
                 formError = true;
                 this.setState({diseaseError: 'Required', diseaseRequired: true}, () => {
                     this.setFormErrors('diseaseError', 'Enter disease term and/or HPO Id(s) and/or Phenotype free text.');
                 });
-                this.setFormErrors('hpoid', 'Enter disease term and/or HPO Id(s) and/or Phenotype free text.');
                 this.setFormErrors('phenoterms', 'Enter disease term and/or HPO Id(s) and/or Phenotype free text.');
             }
 
@@ -193,13 +201,6 @@ var GroupCuration = createReactClass({
                 // PMID list is bad
                 formError = true;
                 this.setFormErrors('otherpmids', 'Use PubMed IDs (e.g. 12345678) separated by commas');
-            }
-
-            // Check that all gene symbols have the proper format (will check for existence later)
-            if (nothpoids && nothpoids.length && _(nothpoids).any(function(id) { return id === null; })) {
-                // NOT HPOID list is bad
-                formError = true;
-                this.setFormErrors('nothpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
             }
 
             if (!formError) {
@@ -638,8 +639,12 @@ var GroupName = function() {
 // as the calling component.
 var GroupCommonDiseases = function() {
     let group = this.state.group;
-    let hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis.join(', ') : '';
-    let nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination.join(', ') : '';
+    const hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
+    const nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
+    const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+    const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     return (
         <div className="row">
@@ -649,37 +654,49 @@ var GroupCommonDiseases = function() {
             </div>
             <GroupDisease gdm={this.state.gdm} group={group} updateDiseaseObj={this.updateDiseaseObj} diseaseObj={this.state.diseaseObj}
                 error={this.state.diseaseError} clearErrorInParent={this.clearErrorInParent} session={this.props.session} required={this.state.diseaseRequired} />
-            <Input type="textarea" ref="hpoid" label={<LabelHpoId />} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('hpoid')} clearError={this.clrMultiFormErrors.bind(null, ['hpoid', 'phenoterms'])} handleChange={this.handleChange}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label>Phenotype(s) in Common&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container"> 
+                <ul>
+                    {hpoWithTerms.map((term, i) => {
+                        return (
+                            <li key={i}>{term}</li>
+                        );
+                    })}
+                </ul>
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+            </div>
             <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
                 error={this.getFormError('phenoterms')} clearError={this.clrMultiFormErrors.bind(null, ['hpoid', 'phenoterms'])} handleChange={this.handleChange}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Group</em> if they are specifically noted in the paper.</p>
-            <Input type="textarea" ref="nothpoid" label={<LabelHpoId not />} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label className="emphasis">NOT Phenotype(s)&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container">
+                <span>
+                    <ul>
+                        {hpoElimWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                </span>
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+            </div> 
             <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={group && group.termsInElimination ? group.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
         </div>
     );
 };
-
-// HTML labels for inputs follow.
-var LabelHpoId = createReactClass({
-    propTypes: {
-        not: PropTypes.bool // T to show 'NOT' version of label
-    },
-
-    render: function() {
-        return (
-            <span>
-                {this.props.not ? <span className="emphasis">NOT Phenotype(s)&nbsp;</span> : <span>Phenotype(s) in Common&nbsp;</span>}
-                <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
-            </span>
-        );
-    }
-});
 
 // HTML labels for inputs follow.
 var LabelPhenoTerms = createReactClass({

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -660,14 +660,16 @@ var GroupCommonDiseases = function() {
                     <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
                 </span>
             </div>
-            <div className="form-group hpo-term-container"> 
-                <ul>
-                    {hpoWithTerms.map((term, i) => {
-                        return (
-                            <li key={i}>{term}</li>
-                        );
-                    })}
-                </ul>
+            <div className="form-group hpo-term-container">
+                {hpoWithTerms.length ?
+                    <ul>
+                        {hpoWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                    : null}
                 <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
             </div>
             <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
@@ -681,7 +683,7 @@ var GroupCommonDiseases = function() {
                 </span>
             </div>
             <div className="form-group hpo-term-container">
-                <span>
+                {hpoElimWithTerms.length ?
                     <ul>
                         {hpoElimWithTerms.map((term, i) => {
                             return (
@@ -689,7 +691,7 @@ var GroupCommonDiseases = function() {
                             );
                         })}
                     </ul>
-                </span>
+                    : null}
                 <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
             </div> 
             <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={group && group.termsInElimination ? group.termsInElimination : ''}

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -141,13 +141,13 @@ var GroupCuration = createReactClass({
         this.loadData();
     },
 
-    passHpoToParent: function(hpoWithTerms) {
+    updateHpo: function(hpoWithTerms) {
         if (hpoWithTerms) {
             this.setState({ hpoWithTerms });
         }
     },
 
-    passElimHpoToParent: function(hpoElimWithTerms) {
+    updateElimHpo: function(hpoElimWithTerms) {
         if (hpoElimWithTerms) {
             this.setState({ hpoElimWithTerms });
         }
@@ -169,8 +169,8 @@ var GroupCuration = createReactClass({
             var geneSymbols = curator.capture.genes(this.getFormValue('othergenevariants'));
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
             var hpotext = curator.capture.hpoids(this.getFormValue('phenoterms'));
-            var hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
-            var nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+            var hpoIds = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+            var notHpoIds = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
 
             let valid_disease = false;
             if (!this.state.diseaseObj || (this.state.diseaseObj && !this.state.diseaseObj['term'])) {
@@ -340,8 +340,8 @@ var GroupCuration = createReactClass({
                     }
 
                     // Fill in the group fields from the Common Diseases & Phenotypes panel
-                    if (hpoids && hpoids.length) {
-                        newGroup.hpoIdInDiagnosis = hpoids;
+                    if (hpoIds && hpoIds.length) {
+                        newGroup.hpoIdInDiagnosis = hpoIds;
                     }
                     else if (newGroup.hpoIdInDiagnosis) {
                         delete newGroup.hpoIdInDiagnosis;
@@ -353,8 +353,8 @@ var GroupCuration = createReactClass({
                     else if (newGroup.termsInDiagnosis) {
                         delete newGroup.termsInDiagnosis;
                     }
-                    if (nothpoids && nothpoids.length) {
-                        newGroup.hpoIdInElimination = nothpoids;
+                    if (notHpoIds && notHpoIds.length) {
+                        newGroup.hpoIdInElimination = notHpoIds;
                     }
                     else if (newGroup.hpoIdInElimination) {
                         delete newGroup.hpoIdInElimination;
@@ -517,7 +517,7 @@ var GroupCuration = createReactClass({
      */
     updateDiseaseObj(diseaseObj) {
         this.setState({diseaseObj: diseaseObj, diseaseRequired: false}, () => {
-            this.clrMultiFormErrors(['diseaseError', 'hpoid', 'phenoterms']);
+            this.clrMultiFormErrors(['diseaseError', 'phenoterms']);
         });
     },
 
@@ -642,8 +642,8 @@ var GroupName = function() {
 // as the calling component.
 var GroupCommonDiseases = function() {
     let group = this.state.group;
-    const hpoidVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
-    const nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
+    const hpoIdVal = group && group.hpoIdInDiagnosis ? group.hpoIdInDiagnosis : [];
+    const notHpoIdVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
     const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
@@ -673,10 +673,10 @@ var GroupCommonDiseases = function() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.updateHpo} savedHpo={hpoIdVal} inElim={false} />
             </div>
             <Input type="textarea" ref="phenoterms" label={<LabelPhenoTerms />} rows="2" value={group && group.termsInDiagnosis ? group.termsInDiagnosis : ''}
-                error={this.getFormError('phenoterms')} clearError={this.clrMultiFormErrors.bind(null, ['hpoid', 'phenoterms'])} handleChange={this.handleChange}
+                error={this.getFormError('phenoterms')} clearError={this.clrMultiFormErrors.bind(null, ['phenoterms'])} handleChange={this.handleChange}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />
             <p className="col-sm-7 col-sm-offset-5">Enter <em>phenotypes that are NOT present in Group</em> if they are specifically noted in the paper.</p>
             <div className="col-sm-5 control-label">
@@ -695,7 +695,7 @@ var GroupCommonDiseases = function() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.updateElimHpo} savedElimHpo={notHpoIdVal} inElim={true} />
             </div> 
             <Input type="textarea" ref="notphenoterms" label={<LabelPhenoTerms not />} rows="2" value={group && group.termsInElimination ? group.termsInElimination : ''}
                 labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" />

--- a/src/clincoded/static/components/group_curation.js
+++ b/src/clincoded/static/components/group_curation.js
@@ -356,6 +356,9 @@ var GroupCuration = createReactClass({
                     if (nothpoids && nothpoids.length) {
                         newGroup.hpoIdInElimination = nothpoids;
                     }
+                    else if (newGroup.hpoIdInElimination) {
+                        delete newGroup.hpoIdInElimination;
+                    }
                     phenoterms = this.getFormValue('notphenoterms');
                     if (phenoterms) {
                         newGroup.termsInElimination = phenoterms;
@@ -643,8 +646,8 @@ var GroupCommonDiseases = function() {
     const nothpoidVal = group && group.hpoIdInElimination ? group.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
-    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
-    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = hpoElimWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     return (
         <div className="row">

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -148,7 +148,8 @@ var HpoTermModal = createReactClass({
                 <ModalComponent modalTitle="Add HPO Terms" modalClass="modal-default" bootstrapBtnClass="btn btn-primary " 
                     actuatorClass="input-group-hpo" actuatorTitle={this.props.addHpoTermButton} onRef={ref => (this.child = ref)}>
                     <div className="modal-body">
-                        <Input type="textarea" label="HPO ID:" ref="hpoid" placeholder="e.g. HP:0010704, HP:0030300" error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')} />
+                        <strong><span><a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s)</span>:</strong>
+                        <Input type="textarea" ref="hpoid" placeholder="e.g. HP:0010704, HP:0030300" error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')} />
                         <Input type="button" ref="gethpoidterm" inputClassName="btn-copy btn-sm btn-last" title="Add" clickHandler={this.props.inElim === true ? this.fetchHpoInElimName : this.fetchHpoName} />
                         <div>
                             {hpoWithTerms ? 

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -45,17 +45,17 @@ var HpoTermModal = createReactClass({
 
     saveForm(e) {
         e.preventDefault(); e.stopPropagation();
-        let hpoWithTermsList = this.state.hpoWithTerms;
-        let hpoElimWithTermsList = this.state.hpoElimWithTerms;
+        let hpoWithTermsList = _.uniq(this.state.hpoWithTerms);
+        let hpoElimWithTermsList = _.uniq(this.state.hpoElimWithTerms);
         const inElim = this.props.inElim ? this.props.inElim : false;
         // Check if the modal has valid values to save, and if in Elim (NOT Phenotype); Modal has two use-cases
         if (hpoWithTermsList && !inElim) {
-            hpoWithTermsList = [...new Set(hpoWithTermsList)];
             this.props.passHpoToParent(hpoWithTermsList);
+            this.setState({ hpoWithTerms: hpoWithTermsList });
         }
         else if (hpoElimWithTermsList && inElim) {
-            hpoElimWithTermsList = [... new Set(hpoElimWithTermsList)];
             this.props.passElimHpoToParent(hpoElimWithTermsList);
+            this.setState({ hpoElimWithTerms: hpoElimWithTermsList });
         }
         this.child.closeModal();
     },
@@ -78,15 +78,17 @@ var HpoTermModal = createReactClass({
     },
 
     deleteHpo(index) {
-        const hpo = this.state.hpoWithTerms.filter((hpo, hpoIndex) => {
-            return hpoIndex !== index;
+        const term = this.state.hpoWithTerms[index];
+        const hpo = this.state.hpoWithTerms.filter(hpo => {
+            return hpo !== term;
         });
         this.setState({ hpoWithTerms: hpo });
     },
 
     deleteElimHpo(index) {
-        const elimHpo = this.state.hpoElimWithTerms.filter((hpo, hpoIndex) => {
-            return hpoIndex !== index;
+        const term = this.state.hpoElimWithTerms[index];
+        const elimHpo = this.state.hpoElimWithTerms.filter(hpo => {
+            return hpo !== term;
         });
         this.setState({ hpoElimWithTerms: elimHpo });
     },
@@ -140,8 +142,8 @@ var HpoTermModal = createReactClass({
     },
 
     render() {
-        let hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
-        let hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+        let hpoWithTerms = _.uniq(this.state.hpoWithTerms ? this.state.hpoWithTerms : []);
+        let hpoElimWithTerms = _.uniq(this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : []);
 
         return (
             <div>

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -97,7 +97,6 @@ var HpoTermModal = createReactClass({
     fetchHpoName() {
         let hpoIds = this.refs['hpoid'].getValue();
         const hpoidList = this.validateHpo(hpoIds);
-        const hpoWithTerms = [];
         if (hpoidList) {
             hpoidList.forEach(id => {
                 const url = external_url_map['HPOApi'] + id;
@@ -122,7 +121,6 @@ var HpoTermModal = createReactClass({
     fetchHpoInElimName() {
         let hpoIds = this.refs['hpoid'].getValue();
         const hpoidList = this.validateHpo(hpoIds);
-        const hpoElimWithTerms = [];
         if (hpoidList) {
             hpoidList.forEach(id => {
                 const url = external_url_map['HPOApi'] + id;

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -151,8 +151,8 @@ var HpoTermModal = createReactClass({
                     actuatorClass="input-group-hpo" actuatorTitle={this.props.addHpoTermButton} onRef={ref => (this.child = ref)}>
                     <div className="modal-body">
                         <strong><span><a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s)</span>:</strong>
-                        <Input type="textarea" ref="hpoid" placeholder="e.g. HP:0010704, HP:0030300" error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')} />
-                        <Input type="button" ref="gethpoidterm" inputClassName="btn-copy btn-sm btn-last" title="Add" clickHandler={this.props.inElim === true ? this.fetchHpoInElimName : this.fetchHpoName} />
+                        <Input type="textarea" ref="hpoid" inputClassName="hpo-text-area" placeholder="e.g. HP:0010704, HP:0030300" rows="4" error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')} />
+                        <Input type="button" ref="gethpoidterm" inputClassName="btn-copy btn-sm btn-last hpo-add-btn" title="Add" clickHandler={this.props.inElim === true ? this.fetchHpoInElimName : this.fetchHpoName} />
                         <div>
                             {hpoWithTerms ? 
                                 <ul>

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -47,12 +47,14 @@ var HpoTermModal = createReactClass({
         e.preventDefault(); e.stopPropagation();
         let hpoWithTermsList = this.state.hpoWithTerms;
         let hpoElimWithTermsList = this.state.hpoElimWithTerms;
-        let inElim = this.props.inElim ? this.props.inElim : false;
+        const inElim = this.props.inElim ? this.props.inElim : false;
         // Check if the modal has valid values to save, and if in Elim (NOT Phenotype); Modal has two use-cases
         if (hpoWithTermsList && !inElim) {
+            hpoWithTermsList = [...new Set(hpoWithTermsList)];
             this.props.passHpoToParent(hpoWithTermsList);
         }
         else if (hpoElimWithTermsList && inElim) {
+            hpoElimWithTermsList = [... new Set(hpoElimWithTermsList)];
             this.props.passElimHpoToParent(hpoElimWithTermsList);
         }
         this.child.closeModal();

--- a/src/clincoded/static/components/hpo_term_modal.js
+++ b/src/clincoded/static/components/hpo_term_modal.js
@@ -1,0 +1,192 @@
+'use strict';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import _ from 'underscore';
+import * as curator from './curator';
+import { external_url_map } from './globals';
+import { RestMixin } from './rest';
+import { FormMixin, Input } from '../libs/bootstrap/form';
+import ModalComponent from '../libs/bootstrap/modal';
+
+var HpoTermModal = createReactClass({
+    mixins: [RestMixin, FormMixin],
+
+    propTypes: {
+        addHpoTermButton: PropTypes.object.isRequired, // Button to trigger HPO modal
+        inElim: PropTypes.bool, // Used to differentiate between normal and "in elim" modal
+        savedHpo: PropTypes.array, // HPO saved from parent
+        savedElimHpo: PropTypes.array, // HPO in elimination saved from parent
+        passHpoToParent: PropTypes.func, // Function used to pass HPO data to respective parent
+        passElimHpoToParent: PropTypes.func // Function used to pass Elim HPO data to parent
+    },
+
+    getInitialState: function() {
+        return {
+            hpoWithTerms: [],
+            hpoElimWithTerms: []
+        };
+    },
+
+    handleModalClose() {
+        this.child.closeModal();
+    },
+
+    componentDidMount() {
+        const savedHpo = this.props.savedHpo ? this.props.savedHpo : null;
+        const savedElimHpo = this.props.savedElimHpo ? this.props.savedElimHpo : null;
+        if (savedHpo && savedHpo.length) {
+            this.setState({ hpoWithTerms: savedHpo });
+        }
+        if (savedElimHpo && savedElimHpo.length) {
+            this.setState({ hpoElimWithTerms: savedElimHpo });
+        }
+    },
+
+    saveForm(e) {
+        e.preventDefault(); e.stopPropagation();
+        let hpoWithTermsList = this.state.hpoWithTerms;
+        let hpoElimWithTermsList = this.state.hpoElimWithTerms;
+        let inElim = this.props.inElim ? this.props.inElim : false;
+        // Check if the modal has valid values to save, and if in Elim (NOT Phenotype); Modal has two use-cases
+        if (hpoWithTermsList && !inElim) {
+            this.props.passHpoToParent(hpoWithTermsList);
+        }
+        else if (hpoElimWithTermsList && inElim) {
+            this.props.passElimHpoToParent(hpoElimWithTermsList);
+        }
+        this.child.closeModal();
+    },
+
+    cancelForm(e) {
+        this.handleModalClose();
+    },
+
+    validateHpo(hpoids) {
+        const checkIds = curator.capture.hpoids(hpoids);
+        // Check HPO ID format
+        if (checkIds && checkIds.length && _(checkIds).any(function(id) { return id === null; })) {
+            // HPOID list is bad
+            this.setFormErrors('hpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
+        }
+        else if (checkIds && checkIds.length && !_(checkIds).any(function(id) { return id === null; })) {
+            const hpoidList = _.without(checkIds, null);
+            return hpoidList;
+        }
+    },
+
+    deleteHpo(index) {
+        const hpo = this.state.hpoWithTerms.filter((hpo, hpoIndex) => {
+            return hpoIndex !== index;
+        });
+        this.setState({ hpoWithTerms: hpo });
+    },
+
+    deleteElimHpo(index) {
+        const elimHpo = this.state.hpoElimWithTerms.filter((hpo, hpoIndex) => {
+            return hpoIndex !== index;
+        });
+        this.setState({ hpoElimWithTerms: elimHpo });
+    },
+    
+    /**
+     * Method to fetch HPO term names and append them to HPO ids
+    */
+    fetchHpoName() {
+        let hpoIds = this.refs['hpoid'].getValue();
+        const hpoidList = this.validateHpo(hpoIds);
+        const hpoWithTerms = [];
+        if (hpoidList) {
+            hpoidList.forEach(id => {
+                const url = external_url_map['HPOApi'] + id;
+                // Make the OLS REST API call
+                this.getRestData(url).then(response => {
+                    const termLabel = response['details']['name'];
+                    const hpoWithTerm = `${termLabel} (${id})`;
+                    this.setState({ hpoWithTerms: [...this.state.hpoWithTerms, hpoWithTerm] });
+                }).catch(err => {
+                    // Unsuccessful retrieval
+                    console.warn('Error in fetching HPO data =: %o', err);
+                    const hpoWithTerm = id + ' (note: term not found)';
+                    this.setState({ hpoWithTerms: [...this.state.hpoWithTerms, hpoWithTerm] });
+                });
+            });
+        }
+    },
+
+    /**
+     * Method to fetch HPO term names and append them to HPO In Elimination ids
+     */
+    fetchHpoInElimName() {
+        let hpoIds = this.refs['hpoid'].getValue();
+        const hpoidList = this.validateHpo(hpoIds);
+        const hpoElimWithTerms = [];
+        if (hpoidList) {
+            hpoidList.forEach(id => {
+                const url = external_url_map['HPOApi'] + id;
+                // Make the OLS REST API call
+                this.getRestData(url).then(response => {
+                    const termLabel = response['details']['name'];
+                    const hpoWithTerm = `${termLabel} (${id})`;
+                    this.setState({ hpoElimWithTerms: [...this.state.hpoElimWithTerms, hpoWithTerm] });
+                }).catch(err => {
+                    // Unsuccessful retrieval
+                    console.warn('Error in fetching HPO data =: %o', err);
+                    const hpoWithTerm = id + ' (note: term not found)';
+                    this.setState({ hpoElimWithTerms: [...this.state.hpoElimWithTerms, hpoWithTerm] });
+                });
+            });
+        }
+    },
+
+    render() {
+        let hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+        let hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+
+        return (
+            <div>
+                <ModalComponent modalTitle="Add HPO Terms" modalClass="modal-default" bootstrapBtnClass="btn btn-primary " 
+                    actuatorClass="input-group-hpo" actuatorTitle={this.props.addHpoTermButton} onRef={ref => (this.child = ref)}>
+                    <div className="modal-body">
+                        <Input type="textarea" label="HPO ID:" ref="hpoid" placeholder="e.g. HP:0010704, HP:0030300" error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')} />
+                        <Input type="button" ref="gethpoidterm" inputClassName="btn-copy btn-sm btn-last" title="Add" clickHandler={this.props.inElim === true ? this.fetchHpoInElimName : this.fetchHpoName} />
+                        <div>
+                            {hpoWithTerms ? 
+                                <ul>
+                                    {hpoWithTerms.map((term, i) => {
+                                        return (
+                                            <div key={i}>
+                                                <li className="hpo-term-list">{term}</li>
+                                                <a className="delete-hpo" role="button" onClick={() => this.deleteHpo(i)}><i className="icon icon-trash-o"></i></a>
+                                            </div>
+                                        );
+                                    })}
+                                </ul>
+                                : null}
+                            {hpoElimWithTerms ? 
+                                <ul>
+                                    {hpoElimWithTerms.map((term, i) => {
+                                        return (
+                                            <div key={i}>
+                                                <li className="hpo-term-list">{term}</li>
+                                                <a className="delete-hpo" role="button" onClick={() => this.deleteElimHpo(i)}>
+                                                    <i className="icon icon-trash-o"></i>
+                                                </a>
+                                            </div>
+                                        );
+                                    })}
+                                </ul>
+                                : null}
+                        </div>
+                    </div>
+                    <div className="modal-footer">
+                        <Input type="button" inputClassName="btn-default btn-primary btn-inline-spacer" clickHandler={this.saveForm} title="Save" />
+                        <Input type="button" inputClassName="btn-default btn-inline-spacer" clickHandler={this.cancelForm} title="Cancel" />
+                    </div>
+                </ModalComponent>
+            </div>
+        )
+    }
+});
+
+export default HpoTermModal;

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -384,8 +384,8 @@ const IndividualCuration = createReactClass({
             var formError = false;
 
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
-            var hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : null;
-            var nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : null;
+            var hpoIds = this.state.hpoWithTerms ? this.state.hpoWithTerms : null;
+            var notHpoIds = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : null;
             let recessiveZygosity = this.state.recessiveZygosity;
             let variantUuid0 = this.getFormValue('variantUuid0'),
                 variantUuid1 = this.getFormValue('variantUuid1');
@@ -578,7 +578,7 @@ const IndividualCuration = createReactClass({
                     }
                 }).then(data => {
                     // Make a new individual object based on form fields.
-                    var newIndividual = this.createIndividual(individualDiseases, individualArticles, individualVariants, evidenceScores, hpoids, nothpoids);
+                    var newIndividual = this.createIndividual(individualDiseases, individualArticles, individualVariants, evidenceScores, hpoIds, notHpoIds);
                     return this.writeIndividualObj(newIndividual);
                 }).then(newIndividual => {
                     var promise;
@@ -666,7 +666,7 @@ const IndividualCuration = createReactClass({
 
     // Create a family object to be written to the database. Most values come from the values
     // in the form. The created object is returned from the function.
-    createIndividual: function(individualDiseases, individualArticles, individualVariants, individualScores, hpoids, nothpoids) {
+    createIndividual: function(individualDiseases, individualArticles, individualVariants, individualScores, hpoIds, notHpoIds) {
         var value;
         var currIndividual = this.state.individual;
         var family = this.state.family;
@@ -686,8 +686,8 @@ const IndividualCuration = createReactClass({
         }
 
         // Fill in the individual fields from the Diseases & Phenotypes panel
-        if (hpoids && hpoids.length) {
-            newIndividual.hpoIdInDiagnosis = hpoids;
+        if (hpoIds && hpoIds.length) {
+            newIndividual.hpoIdInDiagnosis = hpoIds;
         } else if (newIndividual.hpoIdInDiagnosis) {
             delete newIndividual.hpoIdInDiagnosis;
         }
@@ -697,8 +697,8 @@ const IndividualCuration = createReactClass({
         } else if (newIndividual.termsInDiagnosis) {
             delete newIndividual.termsInDiagnosis;
         }
-        if (nothpoids && nothpoids.length) {
-            newIndividual.hpoIdInElimination = nothpoids;
+        if (notHpoIds && notHpoIds.length) {
+            newIndividual.hpoIdInElimination = notHpoIds;
         }
         else if (newIndividual.hpoIdInElimination) {
             delete newIndividual.hpoIdInElimination
@@ -907,13 +907,13 @@ const IndividualCuration = createReactClass({
         this.loadData();
     },
 
-    passHpoToParent: function(hpoWithTerms) {
+    updateHpo: function(hpoWithTerms) {
         if (hpoWithTerms) {
             this.setState({ hpoWithTerms });
         }
     },
 
-    passElimHpoToParent: function(hpoElimWithTerms) {
+    updateElimHpo: function(hpoElimWithTerms) {
         if (hpoElimWithTerms) {
             this.setState({ hpoElimWithTerms });
         }
@@ -1215,8 +1215,8 @@ function IndividualCommonDiseases() {
     let probandLabel = (individual && individual.proband ? <i className="icon icon-proband"></i> : null);
 
     // If we're editing an individual, make editable values of the complex properties
-    const hpoidVal = individual && individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis : [];
-    const nothpoidVal = individual && individual.hpoIdInElimination ? individual.hpoIdInElimination : [];
+    const hpoIdVal = individual && individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis : [];
+    const notHpoIdVal = individual && individual.hpoIdInElimination ? individual.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
     const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
@@ -1275,7 +1275,7 @@ function IndividualCommonDiseases() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.updateHpo} savedHpo={hpoIdVal} inElim={false} />
             </div>   
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Individual', 'ft', 'Group')
@@ -1319,7 +1319,7 @@ function IndividualCommonDiseases() {
                         })}
                     </ul>
                     : null}
-                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.updateElimHpo} savedElimHpo={notHpoIdVal} inElim={true} />
             </div>     
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
                 curator.renderPhenotype(associatedGroups, 'Individual', 'notft', 'Group') 

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1258,14 +1258,16 @@ function IndividualCommonDiseases() {
                     <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
                 </span>
             </div>
-            <div className="form-group hpo-term-container"> 
-                <ul>
-                    {hpoWithTerms.map((term, i) => {
-                        return (
-                            <li key={i}>{term}</li>
-                        );
-                    })}
-                </ul>
+            <div className="form-group hpo-term-container">
+                {hpoWithTerms.length ?
+                    <ul>
+                        {hpoWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                    : null}
                 <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
             </div>   
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
@@ -1301,7 +1303,7 @@ function IndividualCommonDiseases() {
                 </span>
             </div>
             <div className="form-group hpo-term-container">
-                <span>
+                {hpoElimWithTerms.length ?
                     <ul>
                         {hpoElimWithTerms.map((term, i) => {
                             return (
@@ -1309,7 +1311,7 @@ function IndividualCommonDiseases() {
                             );
                         })}
                     </ul>
-                </span>
+                    : null}
                 <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
             </div>     
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -684,7 +684,7 @@ const IndividualCuration = createReactClass({
         // Fill in the individual fields from the Diseases & Phenotypes panel
         if (hpoids && hpoids.length) {
             newIndividual.hpoIdInDiagnosis = hpoids;
-        } else if (newIndividual.hpoIdInDiagnosis && newIndividual.hpoIdInDiagnosis.length) {
+        } else if (newIndividual.hpoIdInDiagnosis) {
             delete newIndividual.hpoIdInDiagnosis;
         }
         var phenoterms = this.getFormValue('phenoterms');
@@ -695,6 +695,9 @@ const IndividualCuration = createReactClass({
         }
         if (nothpoids && nothpoids.length) {
             newIndividual.hpoIdInElimination = nothpoids;
+        }
+        else if (newIndividual.hpoIdInElimination) {
+            delete newIndividual.hpoIdInElimination
         }
         phenoterms = this.getFormValue('notphenoterms');
         if (phenoterms) {
@@ -1212,8 +1215,8 @@ function IndividualCommonDiseases() {
     const nothpoidVal = individual && individual.hpoIdInElimination ? individual.hpoIdInElimination : [];
     const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
     const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
-    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
-    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addHpoTermButton = hpoWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = hpoElimWithTerms.length ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     // Make a list of diseases from the group, either from the given group,
     // or the individual if we're editing one that has associated groups.

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -16,7 +16,7 @@ import * as CuratorHistory from './curator_history';
 import * as methods from './methods';
 import { ScoreIndividual } from './score/individual_score';
 import { ScoreViewer } from './score/viewer';
-import ModalComponent from '../libs/bootstrap/modal';
+import HpoTermModal from './hpo_term_modal';
 import { IndividualDisease } from './disease';
 import { renderVariantLabelAndTitle } from '../libs/render_variant_label_title';
 import * as curator from './curator';
@@ -68,7 +68,9 @@ const IndividualCuration = createReactClass({
             diseaseUuid: null,
             diseaseError: null,
             scoreError: false,
-            scoreErrorMsg: ''
+            scoreErrorMsg: '',
+            hpoWithTerms: [],
+            hpoElimWithTerms: []
         };
     },
 
@@ -127,8 +129,8 @@ const IndividualCuration = createReactClass({
             if (obj.hpoIdInDiagnosis && obj.hpoIdInDiagnosis.length) {
                 hpoIds = obj.hpoIdInDiagnosis.map(function(hpoid, i) {
                     return (hpoid);
-                }).join(', ');
-                this.refs['hpoid'].setValue(hpoIds);
+                });
+                this.setState({ hpoWithTerms: hpoIds });
             }
             if (obj.termsInDiagnosis) {
                 this.refs['phenoterms'].setValue(obj.termsInDiagnosis);
@@ -149,8 +151,8 @@ const IndividualCuration = createReactClass({
             if (obj.hpoIdInElimination && obj.hpoIdInElimination.length) {
                 hpoElimIds = obj.hpoIdInElimination.map(function(elimhpo, i) {
                     return (elimhpo);
-                }).join(', ');
-                this.refs['nothpoid'].setValue(hpoElimIds);
+                });
+                this.setState({ hpoElimWithTerms: hpoElimIds });
             }
             if (obj.termsInElimination) {
                 this.refs['notphenoterms'].setValue(obj.termsInElimination);
@@ -220,6 +222,12 @@ const IndividualCuration = createReactClass({
 
                 if (stateObj.individual.diagnosis && stateObj.individual.diagnosis.length > 0) {
                     this.setState({diseaseObj: stateObj.individual['diagnosis'][0]});
+                }
+                if (stateObj.individual['hpoIdInDiagnosis'] && stateObj.individual['hpoIdInDiagnosis'].length > 0) {
+                    this.setState({ hpoWithTerms: stateObj.individual['hpoIdInDiagnosis'] });
+                }
+                if (stateObj.individual['hpoIdInElimination'] && stateObj.individual['hpoIdInElimination'].length > 0) {
+                    this.setState({ hpoElimWithTerms: stateObj.individual['hpoIdInElimination'] });
                 }
 
                 if (stateObj.individual.proband) {
@@ -372,8 +380,8 @@ const IndividualCuration = createReactClass({
             var formError = false;
 
             var pmids = curator.capture.pmids(this.getFormValue('otherpmids'));
-            var hpoids = curator.capture.hpoids(this.getFormValue('hpoid'));
-            var nothpoids = curator.capture.hpoids(this.getFormValue('nothpoid'));
+            var hpoids = this.state.hpoWithTerms ? this.state.hpoWithTerms : null;
+            var nothpoids = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : null;
             let recessiveZygosity = this.state.recessiveZygosity;
             let variantUuid0 = this.getFormValue('variantUuid0'),
                 variantUuid1 = this.getFormValue('variantUuid1');
@@ -391,20 +399,6 @@ const IndividualCuration = createReactClass({
                 // PMID list is bad
                 formError = true;
                 this.setFormErrors('otherpmids', 'Use PubMed IDs (e.g. 12345678) separated by commas');
-            }
-
-            // Check that all gene symbols have the proper format (will check for existence later)
-            if (hpoids && hpoids.length && _(hpoids).any(function(id) { return id === null; })) {
-                // HPOID list is bad
-                formError = true;
-                this.setFormErrors('hpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
-            }
-
-            // Check that all gene symbols have the proper format (will check for existence later)
-            if (nothpoids && nothpoids.length && _(nothpoids).any(function(id) { return id === null; })) {
-                // NOT HPOID list is bad
-                formError = true;
-                this.setFormErrors('nothpoid', 'Use HPO IDs (e.g. HP:0000001) separated by commas');
             }
 
             // Get variant uuid's if they were added via the modals
@@ -906,6 +900,18 @@ const IndividualCuration = createReactClass({
         this.loadData();
     },
 
+    passHpoToParent: function(hpoWithTerms) {
+        if (hpoWithTerms) {
+            this.setState({ hpoWithTerms });
+        }
+    },
+
+    passElimHpoToParent: function(hpoElimWithTerms) {
+        if (hpoElimWithTerms) {
+            this.setState({ hpoElimWithTerms });
+        }
+    },
+
     /**
      * Update the 'diseaseObj' state used to save data upon form submission
      */
@@ -1202,8 +1208,12 @@ function IndividualCommonDiseases() {
     let probandLabel = (individual && individual.proband ? <i className="icon icon-proband"></i> : null);
 
     // If we're editing an individual, make editable values of the complex properties
-    let hpoidVal = individual && individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis.join(', ') : '';
-    let nothpoidVal = individual && individual.hpoIdInElimination ? individual.hpoIdInElimination.join(', ') : '';
+    const hpoidVal = individual && individual.hpoIdInDiagnosis ? individual.hpoIdInDiagnosis : [];
+    const nothpoidVal = individual && individual.hpoIdInElimination ? individual.hpoIdInElimination : [];
+    const hpoWithTerms = this.state.hpoWithTerms ? this.state.hpoWithTerms : [];
+    const hpoElimWithTerms = this.state.hpoElimWithTerms ? this.state.hpoElimWithTerms : [];
+    const addHpoTermButton = (hpoWithTerms.length || hpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
+    const addElimTermButton = (hpoElimWithTerms.length || nothpoidVal.length) ? <span>HPO Terms <i className="icon icon-pencil"></i></span> : <span>HPO Terms <i className="icon icon-plus-circle"></i></span>;
 
     // Make a list of diseases from the group, either from the given group,
     // or the individual if we're editing one that has associated groups.
@@ -1242,9 +1252,22 @@ function IndividualCommonDiseases() {
                     curator.renderPhenotype(associatedFamilies, 'Individual', 'hpo', 'Family') : curator.renderPhenotype(null, 'Individual', 'hpo')
                 )
             }
-            <Input type="textarea" ref="hpoid" label={LabelHpoId()} rows="4" value={hpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('hpoid')} clearError={this.clrFormErrors.bind(null, 'hpoid')}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label>Phenotype(s) in Common&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container"> 
+                <ul>
+                    {hpoWithTerms.map((term, i) => {
+                        return (
+                            <li key={i}>{term}</li>
+                        );
+                    })}
+                </ul>
+                <HpoTermModal addHpoTermButton={addHpoTermButton} passHpoToParent={this.passHpoToParent} savedHpo={hpoidVal} inElim={false} />
+            </div>   
             {associatedGroups && ((associatedGroups[0].hpoIdInDiagnosis && associatedGroups[0].hpoIdInDiagnosis.length) || associatedGroups[0].termsInDiagnosis) ?
                 curator.renderPhenotype(associatedGroups, 'Individual', 'ft', 'Group')
                 :
@@ -1270,10 +1293,25 @@ function IndividualCommonDiseases() {
                 (associatedFamilies && ((associatedFamilies[0].hpoIdInElimination && associatedFamilies[0].hpoIdInElimination.length) || associatedFamilies[0].termsInElimination) ?
                     curator.renderPhenotype(associatedFamilies, 'Individual', 'nothpo', 'Family') : null
                 ) 
-            }  
-            <Input type="textarea" ref="nothpoid" label={LabelHpoId('not')} rows="4" value={nothpoidVal} placeholder="e.g. HP:0010704, HP:0030300"
-                error={this.getFormError('nothpoid')} clearError={this.clrFormErrors.bind(null, 'nothpoid')}
-                labelClassName="col-sm-5 control-label" wrapperClassName="col-sm-7" groupClassName="form-group" inputClassName="uppercase-input" />
+            }
+            <div className="col-sm-5 control-label">
+                <span>
+                    <label className="emphasis">NOT Phenotype(s)&nbsp;</label>
+                    <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
+                </span>
+            </div>
+            <div className="form-group hpo-term-container">
+                <span>
+                    <ul>
+                        {hpoElimWithTerms.map((term, i) => {
+                            return (
+                                <li key={i}>{term}</li>
+                            );
+                        })}
+                    </ul>
+                </span>
+                <HpoTermModal addHpoTermButton={addElimTermButton} passElimHpoToParent={this.passElimHpoToParent} savedElimHpo={nothpoidVal} inElim={true} />
+            </div>     
             {associatedGroups && ((associatedGroups[0].hpoIdInElimination && associatedGroups[0].hpoIdInElimination.length) || associatedGroups[0].termsInElimination) ?
                 curator.renderPhenotype(associatedGroups, 'Individual', 'notft', 'Group') 
                 :
@@ -1295,19 +1333,6 @@ function IndividualCommonDiseases() {
         </div>
     );
 }
-
-/**
- * HTML labels for inputs follow.
- * @param {string} bool - Value of 'not'
- */
-const LabelHpoId = bool => {
-    return (
-        <span>
-            {bool && bool === 'not' ? <span className="emphasis">NOT </span> : ''}
-            Phenotype(s) <span className="normal">(<a href={external_url_map['HPOBrowser']} target="_blank" title="Open HPO Browser in a new tab">HPO</a> ID(s))</span>:
-        </span>
-    );
-};
 
 /**
  * HTML labels for inputs follow.

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -131,6 +131,8 @@ const IndividualCuration = createReactClass({
                     return (hpoid);
                 });
                 this.setState({ hpoWithTerms: hpoIds });
+            } else {
+                this.setState({ hpoWithTerms: [] });
             }
             if (obj.termsInDiagnosis) {
                 this.refs['phenoterms'].setValue(obj.termsInDiagnosis);
@@ -153,6 +155,8 @@ const IndividualCuration = createReactClass({
                     return (elimhpo);
                 });
                 this.setState({ hpoElimWithTerms: hpoElimIds });
+            } else {
+                this.setState({ hpoElimWithTerms: [] });
             }
             if (obj.termsInElimination) {
                 this.refs['notphenoterms'].setValue(obj.termsInElimination);

--- a/src/clincoded/static/components/individual_curation.js
+++ b/src/clincoded/static/components/individual_curation.js
@@ -1988,7 +1988,8 @@ const IndividualViewer = createReactClass({
                                 <div>
                                     <dt>HPO IDs</dt>
                                     <dd>{individual.hpoIdInDiagnosis && individual.hpoIdInDiagnosis.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 
@@ -2000,7 +2001,8 @@ const IndividualViewer = createReactClass({
                                 <div>
                                     <dt>NOT HPO IDs</dt>
                                     <dd>{individual.hpoIdInElimination && individual.hpoIdInElimination.map(function(hpo, i) {
-                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + hpo} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
+                                        let id = hpo.match(/\HP:\d{7}/g);
+                                        return <span key={hpo}>{i > 0 ? ', ' : ''}<a href={external_url_map['HPO'] + id} title={"HPOBrowser entry for " + hpo + " in new tab"} target="_blank">{hpo}</a></span>;
                                     })}</dd>
                                 </div>
 

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -3070,6 +3070,10 @@ table.login-users-interpretations {
         padding: 30px 45px 20px 45px;
     }
 
+    .hpo-term {
+        padding-bottom: 5px;
+    }
+
     .section {
         h3 {
             border-bottom: solid 1px lighten(#486e82, 35%);

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -3631,29 +3631,37 @@ table.login-users-interpretations {
  * Styles for HPO Modal
  */
 
- .hpo-term-container {
+.hpo-term-container {
     display: flex;
     padding: 0.4rem 0 1.8rem 0;
- }
+}
+
+.hpo-text-area {
+    margin-top: 5px;
+}
 
 .input-group-hpo {
-    margin-left: 20px;
+    margin-left: 13px;
     margin-bottom: 15px;
 }
 
- .hpo-term-list {
-    display: inline-block;
- }
+.hpo-add-btn {
+    margin-top: 5px;
+}
 
- .delete-hpo {
+.hpo-term-list {
+    display: inline-block;
+}
+
+.delete-hpo {
     color: #d9534f;
     display: inline-block;
     margin: 5px;
- }
+}
 
- .delete-hpo:hover {
+.delete-hpo:hover {
     color: red;
- }
+}
 
 /**
  * Styles alerts to fade in and out

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -3624,6 +3624,34 @@ table.login-users-interpretations {
 }
 
 /**
+ * Styles for HPO Modal
+ */
+
+ .hpo-term-container {
+    display: flex;
+    padding: 0.4rem 0 1.8rem 0;
+ }
+
+.input-group-hpo {
+    margin-left: 15px;
+    margin-bottom: 15px;
+}
+
+ .hpo-term-list {
+    display: inline-block;
+ }
+
+ .delete-hpo {
+    color: #d9534f;
+    display: inline-block;
+    margin: 5px;
+ }
+
+ .delete-hpo:hover {
+    color: red;
+ }
+
+/**
  * Styles alerts to fade in and out
  */
 .feedback-message {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -3633,7 +3633,7 @@ table.login-users-interpretations {
  }
 
 .input-group-hpo {
-    margin-left: 15px;
+    margin-left: 20px;
     margin-bottom: 15px;
 }
 

--- a/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_gene_disease_summary.scss
@@ -150,20 +150,8 @@
             }
         }
 
-        .hpo-terms-list {
-            margin: 0;
-            padding: 0;
-            list-style: none;
-
-            .hpo-term-item {
-                span:after {
-                    content: ';';
-                }
-
-                &:last-child span:after {
-                    content: '';
-                }
-            }
+        .hpo-term-summary {
+            padding-bottom: 2px;
         }
 
         .summary-matrix-wrapper {


### PR DESCRIPTION
Issue #1585 

**Steps to test:**

- Curate a new Gene-Disease record, and save an article by adding PMID
- The Modal lives in the Group, Family, and Individual sections of the Case-Level Genetic Evidence for the article (right hand side of curation-central)
- Modal is rendered by clicking "HPO Terms +" button

**The Modal should:**
 - Validate that the user is entering an HPO (or comma separated list of IDs) with the correct format, if not, a red validation message should prompt the user
- Allow users to enter a full list of comma separated HPO IDs, as well as append to the list in the modal one-by-one by clicking "Add"
- Support the ability to delete fetched HPO terms by clicking the red trash icons 
- Save the list of HPO terms to the state of the parent (i.e Group, Family, Individual), if there are any accidental duplicates, these are filtered out upon save if the user does not catch the mistake and delete (EDIT: Users are now unable to add duplicate IDs to the list displayed inside modal, still unable to save duplicates)

If the user has added an associated Family or Individual to a Group, or an associated Individual to a Family, the ability to copy the HPO terms and Phenotype Free Text is still supported. However, the user will not be able to edit this list of copied terms. If they wish to edit, they must do so in the section where they copied down from or add new terms via the modal.

The Evidence Summary also displays the HPO terms that were saved. These are typically shown when the user has added scoring to the evidence. Let me know if you are having trouble getting those tables to display.
