### PR TITLE
Affiliation Name Change (#2168)

### DIFF
--- a/src/clincoded/static/components/affiliation/affiliations.json
+++ b/src/clincoded/static/components/affiliation/affiliations.json
@@ -784,12 +784,12 @@
     },
     {
         "affiliation_id": "10060",
-        "affiliation_fullname": "Orphan Diseases",
+        "affiliation_fullname": "Syndromic Disorders",
         "publish_approval": true,
         "subgroups": {
             "gcep": {
                 "id": "40060",
-                "fullname": "Orphan Diseases GCEP"
+                "fullname": "Syndromic Disorders GCEP"
             }
         }
     },


### PR DESCRIPTION
Updates for #2168:
For affiliation 10060, the name should now appear as **Syndromic Disorders** (including existing curation data).