### PR TITLE
#1585 - HPO Terms in Evidence Summary

### DIFF
--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummaryCaseControl extends Component {
     constructor(props) {
@@ -66,7 +67,7 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                     {evidence.diseaseId && evidence.diseaseTerm ?
                         <span>{evidence.diseaseTerm}
                             <span> {!evidence.diseaseFreetext ? (<span>({evidence.diseaseId.replace('_', ':')})</span>)
-                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br/><strong>HPO term(s): </strong>{evidence.diseasePhenotypes.join(', ')}</span> : null)
+                                : (evidence.diseasePhenotypes && evidence.diseasePhenotypes.length ? <span><br/><strong>HPO term(s): </strong><HpoTerms hpoIds={evidence.diseasePhenotypes} /></span> : null)
                             }
                             </span>
                         </span>
@@ -79,7 +80,10 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                                         <div className="hpo-term-summary" key={i}>{term}</div>
                                     );
                                 })}
-                                </span> 
+                                </span>
+                                : null}
+                            {this.props.hpoTerms.length ?
+                                <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                                 : null}
                             {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                         </span>
@@ -232,7 +236,8 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseControl.propTypes = {
-    caseControlEvidenceList: PropTypes.array
+    caseControlEvidenceList: PropTypes.array,
+    hpoTerms: PropTypes.object
 };
 
 export default GeneDiseaseEvidenceSummaryCaseControl;

--- a/src/clincoded/static/components/gene_disease_summary/case_control.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_control.js
@@ -75,15 +75,8 @@ class GeneDiseaseEvidenceSummaryCaseControl extends Component {
                         <span>
                             {evidence.hpoIdInDiagnosis.length ?
                                 <span><strong>HPO term(s):</strong>
-                                {evidence.hpoIdInDiagnosis.map((term, i) => {
-                                    return (
-                                        <div className="hpo-term-summary" key={i}>{term}</div>
-                                    );
-                                })}
+                                    <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                                 </span>
-                                : null}
-                            {this.props.hpoTerms.length ?
-                                <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                                 : null}
                             {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                         </span>

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
 import { renderVariantTitle } from '../../libs/render_variant_title';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
     constructor(props) {
@@ -93,6 +94,9 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                                 );
                             })}
                         </span> 
+                        : null}
+                    {this.props.hpoTerms.length ?
+                        <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
@@ -260,7 +264,8 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
 }
 
 GeneDiseaseEvidenceSummaryCaseLevel.propTypes = {
-    caseLevelEvidenceList: PropTypes.array
+    caseLevelEvidenceList: PropTypes.array,
+    hpoTerms: PropTypes.object
 };
 
 export default GeneDiseaseEvidenceSummaryCaseLevel;

--- a/src/clincoded/static/components/gene_disease_summary/case_level.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level.js
@@ -88,15 +88,8 @@ class GeneDiseaseEvidenceSummaryCaseLevel extends Component {
                 <td className="evidence-phenotypes">
                     {evidence.hpoIdInDiagnosis.length ?
                         <span><strong>HPO term(s): </strong>
-                            {evidence.hpoIdInDiagnosis.map((term, i) => {
-                                return (
-                                    <div className="hpo-term-summary" key={i}>{term}</div>
-                                );
-                            })}
+                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         </span> 
-                        : null}
-                    {this.props.hpoTerms.length ?
-                        <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -69,15 +69,8 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                 <td className="evidence-phenotypes">
                     {evidence.hpoIdInDiagnosis.length ?
                         <span><strong>HPO term(s):</strong>
-                        {evidence.hpoIdInDiagnosis.map((term, i) => {
-                            return (
-                                <div className="hpo-term-summary" key={i}>{term}</div>
-                            );
-                        })}
+                            <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         </span> 
-                        : null}
-                    {this.props.hpoTerms.length ?
-                        <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>

--- a/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
+++ b/src/clincoded/static/components/gene_disease_summary/case_level_segregation.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { external_url_map } from '../globals';
+import HpoTerms from '../../libs/get_hpo_term';
 
 class GeneDiseaseEvidenceSummarySegregation extends Component {
     constructor(props) {
@@ -74,6 +75,9 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
                             );
                         })}
                         </span> 
+                        : null}
+                    {this.props.hpoTerms.length ?
+                        <HpoTerms hpoIds={evidence.hpoIdInDiagnosis} hpoTerms={this.props.hpoTerms} />
                         : null}
                     {evidence.termsInDiagnosis.length ? <span><strong>free text:</strong><br />{evidence.termsInDiagnosis}</span> : null}
                 </td>
@@ -209,7 +213,8 @@ class GeneDiseaseEvidenceSummarySegregation extends Component {
 }
 
 GeneDiseaseEvidenceSummarySegregation.propTypes = {
-    segregationEvidenceList: PropTypes.array
+    segregationEvidenceList: PropTypes.array,
+    hpoTerms: PropTypes.object
 };
 
 export default GeneDiseaseEvidenceSummarySegregation;

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -645,7 +645,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
         let hpoTermsCollection = this.state.hpoTermsCollection;
         uniqueHpoIds.forEach(id => {
-            id = hpo.match(/\HP:\d{7}/g);
+            id = id.match(/\HP:\d{7}/g);
             let url = external_url_map['HPOApi'] + id.replace(':', '_');
             // Make the OLS REST API call
             this.getRestData(url).then(result => {

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -642,10 +642,9 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                 }
             });
         }
-        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
+        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds.match(/\HP:\d{7}/g)))] : [];
         let hpoTermsCollection = this.state.hpoTermsCollection;
         uniqueHpoIds.forEach(id => {
-            id = id.match(/\HP:\d{7}/g);
             let url = external_url_map['HPOApi'] + id.replace(':', '_');
             // Make the OLS REST API call
             this.getRestData(url).then(result => {

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -389,10 +389,10 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     // Put object into array
                     segregationEvidenceList.push(segregationEvidence);
                     this.setState({segregationEvidenceList: segregationEvidenceList}, () => {
-                    if (this.state.segregationEvidenceList.length) {
-                        this.fetchHpoTerms(this.state.segregationEvidenceList, 'segregation');
-                    }
-                });
+                        if (this.state.segregationEvidenceList.length) {
+                            this.fetchHpoTerms(this.state.segregationEvidenceList, 'segregation');
+                        }
+                    });
                 }
             }
         });

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -646,7 +646,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         let hpoTermsCollection = this.state.hpoTermsCollection;
         uniqueHpoIds.forEach(id => {
             if (id.match(/\HP:\d{7}/g)) {
-                let url = external_url_map['HPOApi'] + id.replace(':', '_');
+                let url = external_url_map['HPOApi'] + id;
                 // Make the OLS REST API call
                 this.getRestData(url).then(result => {
                     let termLabel = result['_embedded']['terms'][0]['label'];

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -649,7 +649,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                 let url = external_url_map['HPOApi'] + id;
                 // Make the OLS REST API call
                 this.getRestData(url).then(result => {
-                    let termLabel = result['_embedded']['terms'][0]['label'];
+                    let termLabel = result['details']['name'];
                     if (evidenceType === 'caseLevel') {
                         hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
                     } else if (evidenceType === 'segregation') {

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -37,7 +37,12 @@ const GeneDiseaseEvidenceSummary = createReactClass({
             caseControlEvidenceList: [],
             experimentalEvidenceList: [],
             nonscorableEvidenceList: [],
-            preview: queryKeyValue('preview', this.props.href)
+            preview: queryKeyValue('preview', this.props.href),
+            hpoTermsCollection: {	
+                caseLevel: {},	
+                segregation: {},	
+                caseControl: {}	
+            }
         };
     },
 
@@ -278,7 +283,11 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                             caseLevelEvidence['sequencingMethod'] = segregation && segregation.sequencingMethod ? segregation.sequencingMethod : null;
                             // Put object into array
                             caseLevelEvidenceList.push(caseLevelEvidence);
-                            this.setState({caseLevelEvidenceList: caseLevelEvidenceList});
+                            this.setState({caseLevelEvidenceList: caseLevelEvidenceList}, () => {
+                                if (this.state.caseLevelEvidenceList.length) {
+                                    this.fetchHpoTerms(this.state.caseLevelEvidenceList, 'caseLevel');
+                                }
+                            });
                         }
                     }
                 });
@@ -379,7 +388,11 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     segregationEvidence['sequencingMethod'] = segregation && segregation.sequencingMethod ? segregation.sequencingMethod : null;
                     // Put object into array
                     segregationEvidenceList.push(segregationEvidence);
-                    this.setState({segregationEvidenceList: segregationEvidenceList});
+                    this.setState({segregationEvidenceList: segregationEvidenceList}, () => {
+                    if (this.state.segregationEvidenceList.length) {
+                        this.fetchHpoTerms(this.state.segregationEvidenceList, 'segregation');
+                    }
+                });
                 }
             }
         });
@@ -463,7 +476,11 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                                             caseControlEvidence['hpoIdInDiagnosis'] = caseControl.caseCohort.hpoIdInDiagnosis && caseControl.caseCohort.hpoIdInDiagnosis.length ? caseControl.caseCohort.hpoIdInDiagnosis : [];
                                             // Put object into array
                                             caseControlEvidenceList.push(caseControlEvidence);
-                                            this.setState({caseControlEvidenceList: caseControlEvidenceList});
+                                            this.setState({caseControlEvidenceList: caseControlEvidenceList}, () => {
+                                                if (this.state.caseControlEvidenceList.length) {
+                                                    this.fetchHpoTerms(this.state.caseControlEvidenceList, 'caseControl');
+                                                }
+                                            });
                                         }
                                     }
                                 }
@@ -616,6 +633,46 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         return explanation;
     },
 
+    fetchHpoTerms(evidenceList, evidenceType) {	
+        let allHpoIds = [];
+        if (evidenceList && evidenceList.length) {
+            evidenceList.forEach(evidence => {
+                if (evidence.hpoIdInDiagnosis && evidence.hpoIdInDiagnosis.length) {
+                    Array.prototype.push.apply(allHpoIds, evidence.hpoIdInDiagnosis);
+                }
+            });
+        }
+        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
+        let hpoTermsCollection = this.state.hpoTermsCollection;
+        uniqueHpoIds.forEach(id => {
+            id = hpo.match(/\HP:\d{7}/g);
+            let url = external_url_map['HPOApi'] + id.replace(':', '_');
+            // Make the OLS REST API call
+            this.getRestData(url).then(result => {
+                let termLabel = result['_embedded']['terms'][0]['label'];
+                if (evidenceType === 'caseLevel') {
+                    hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                } else if (evidenceType === 'segregation') {
+                    hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                } else if (evidenceType === 'caseControl') {
+                    hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                }
+                this.setState({hpoTermsCollection: hpoTermsCollection});
+            }).catch(err => {
+                // Unsuccessful retrieval
+                console.warn('Error in fetching HPO data =: %o', err);
+                if (evidenceType === 'caseLevel') {
+                    hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
+                } else if (evidenceType === 'segregation') {
+                    hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
+                } else if (evidenceType === 'caseControl') {
+                    hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
+                }
+                this.setState({hpoTermsCollection: hpoTermsCollection});
+            });
+        });
+    },
+
     /**
      * Method to close current window
      * @param {*} e - Window event
@@ -636,6 +693,7 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         const gdm = this.state.gdm;
         const provisional = this.state.provisional;
         const snapshotPublishDate = this.state.snapshotPublishDate;
+        const hpoTermsCollection = this.state.hpoTermsCollection;
 
         return (
             <div className="gene-disease-evidence-summary-wrapper">
@@ -650,9 +708,9 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                     {!this.state.preview && provisional && Object.keys(provisional).length ?
                         <GeneDiseaseEvidenceSummaryClassificationMatrix classification={provisional} />
                         : null}
-                    <GeneDiseaseEvidenceSummaryCaseLevel caseLevelEvidenceList={this.state.caseLevelEvidenceList} />
-                    <GeneDiseaseEvidenceSummarySegregation segregationEvidenceList={this.state.segregationEvidenceList} />
-                    <GeneDiseaseEvidenceSummaryCaseControl caseControlEvidenceList={this.state.caseControlEvidenceList} />
+                    <GeneDiseaseEvidenceSummaryCaseLevel caseLevelEvidenceList={this.state.caseLevelEvidenceList} hpoTerms={hpoTermsCollection.caseLevel} />
+                    <GeneDiseaseEvidenceSummarySegregation segregationEvidenceList={this.state.segregationEvidenceList} hpoTerms={hpoTermsCollection.segregation} />
+                    <GeneDiseaseEvidenceSummaryCaseControl caseControlEvidenceList={this.state.caseControlEvidenceList} hpoTerms={hpoTermsCollection.caseControl} />
                     <GeneDiseaseEvidenceSummaryExperimental experimentalEvidenceList={this.state.experimentalEvidenceList} />
                     <GeneDiseaseEvidenceSummaryNonscorableEvidence nonscorableEvidenceList={this.state.nonscorableEvidenceList} />
                 </div>

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -642,33 +642,35 @@ const GeneDiseaseEvidenceSummary = createReactClass({
                 }
             });
         }
-        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds.match(/\HP:\d{7}/g)))] : [];
+        let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
         let hpoTermsCollection = this.state.hpoTermsCollection;
         uniqueHpoIds.forEach(id => {
-            let url = external_url_map['HPOApi'] + id.replace(':', '_');
-            // Make the OLS REST API call
-            this.getRestData(url).then(result => {
-                let termLabel = result['_embedded']['terms'][0]['label'];
-                if (evidenceType === 'caseLevel') {
-                    hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                } else if (evidenceType === 'segregation') {
-                    hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                } else if (evidenceType === 'caseControl') {
-                    hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                }
-                this.setState({hpoTermsCollection: hpoTermsCollection});
-            }).catch(err => {
-                // Unsuccessful retrieval
-                console.warn('Error in fetching HPO data =: %o', err);
-                if (evidenceType === 'caseLevel') {
-                    hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
-                } else if (evidenceType === 'segregation') {
-                    hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
-                } else if (evidenceType === 'caseControl') {
-                    hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
-                }
-                this.setState({hpoTermsCollection: hpoTermsCollection});
-            });
+            if (id.match(/\HP:\d{7}/g)) {
+                let url = external_url_map['HPOApi'] + id.replace(':', '_');
+                // Make the OLS REST API call
+                this.getRestData(url).then(result => {
+                    let termLabel = result['_embedded']['terms'][0]['label'];
+                    if (evidenceType === 'caseLevel') {
+                        hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                    } else if (evidenceType === 'segregation') {
+                        hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                    } else if (evidenceType === 'caseControl') {
+                        hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                    }
+                    this.setState({hpoTermsCollection: hpoTermsCollection});
+                }).catch(err => {
+                    // Unsuccessful retrieval
+                    console.warn('Error in fetching HPO data =: %o', err);
+                    if (evidenceType === 'caseLevel') {
+                        hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
+                    } else if (evidenceType === 'segregation') {
+                        hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
+                    } else if (evidenceType === 'caseControl') {
+                        hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
+                    }
+                    this.setState({hpoTermsCollection: hpoTermsCollection});
+                });
+            }
         });
     },
 

--- a/src/clincoded/static/components/gene_disease_summary/index.js
+++ b/src/clincoded/static/components/gene_disease_summary/index.js
@@ -645,32 +645,31 @@ const GeneDiseaseEvidenceSummary = createReactClass({
         let uniqueHpoIds = allHpoIds.length ? [...(new Set(allHpoIds))] : [];
         let hpoTermsCollection = this.state.hpoTermsCollection;
         uniqueHpoIds.forEach(id => {
-            if (id.match(/\HP:\d{7}/g)) {
-                let url = external_url_map['HPOApi'] + id;
-                // Make the OLS REST API call
-                this.getRestData(url).then(result => {
-                    let termLabel = result['details']['name'];
-                    if (evidenceType === 'caseLevel') {
-                        hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                    } else if (evidenceType === 'segregation') {
-                        hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                    } else if (evidenceType === 'caseControl') {
-                        hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
-                    }
-                    this.setState({hpoTermsCollection: hpoTermsCollection});
-                }).catch(err => {
-                    // Unsuccessful retrieval
-                    console.warn('Error in fetching HPO data =: %o', err);
-                    if (evidenceType === 'caseLevel') {
-                        hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
-                    } else if (evidenceType === 'segregation') {
-                        hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
-                    } else if (evidenceType === 'caseControl') {
-                        hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
-                    }
-                    this.setState({hpoTermsCollection: hpoTermsCollection});
-                });
-            }
+            let checkedId = id.match(/\HP:\d{7}/g);
+            let url = external_url_map['HPOApi'] + checkedId;
+            // Make the OLS REST API call
+            this.getRestData(url).then(result => {
+                let termLabel = result['details']['name'];
+                if (evidenceType === 'caseLevel') {
+                    hpoTermsCollection['caseLevel'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                } else if (evidenceType === 'segregation') {
+                    hpoTermsCollection['segregation'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                } else if (evidenceType === 'caseControl') {
+                    hpoTermsCollection['caseControl'][id] = termLabel ? termLabel : id + ' (note: term not found)';
+                }
+                this.setState({hpoTermsCollection: hpoTermsCollection});
+            }).catch(err => {
+                // Unsuccessful retrieval
+                console.warn('Error in fetching HPO data =: %o', err);
+                if (evidenceType === 'caseLevel') {
+                    hpoTermsCollection['caseLevel'][id] = id + ' (note: term not found)';
+                } else if (evidenceType === 'segregation') {
+                    hpoTermsCollection['segregation'][id] = id + ' (note: term not found)';
+                } else if (evidenceType === 'caseControl') {
+                    hpoTermsCollection['caseControl'][id] = id + ' (note: term not found)';
+                }
+                this.setState({hpoTermsCollection: hpoTermsCollection});
+            });
         });
     },
 


### PR DESCRIPTION
#1585 Due to HPO Term Modal feature, fetch functionality for HPO Terms was removed from the Evidence Summary component. It is now being reintroduced so users will be able to see the terms for their old IDs, and can slowly transition to using the modal as they edit evidence.

Right now, Evidence Summaries are only returning the "bare" IDs, whereas before terms were being displayed. I have reverted the code in the Evidence Summary to again fetch the term names for HPOs. 

If a user has fetched the term name using the new modal, the request is made again inside the Summary for the sake of a consistent format for these terms.

PDF showing the bare ID issue:
[SCP2_LDMNS_Evidence Summary_20200323.pdf](https://github.com/ClinGen/clincoded/files/4377602/SCP2_LDMNS_Evidence.Summary_20200323.pdf)

Screenshot confirming that terms are now again being displayed:
<img width="1647" alt="Screen Shot 2020-03-24 at 1 28 06 PM" src="https://user-images.githubusercontent.com/45801431/77475584-48cc5100-6dd6-11ea-8c48-1a055baab6e1.png">

For some background/context: The only "new" edition to our code via this PR is the `checkedId` regex variable and accessing the name via API response (`let termLabel = result['details']['name'];`). Both are in `static/components/gene_disease_summary/index.js => fetchHpoTerms` The rest precedes the HPO Modal feature, and is being reintroduced.


Steps to test: Coordinate with me and I will start up an instance with prod data to check the Evidence Summaries
