### PR TITLE
#2136: Add Disease Page Fix

### DIFF
--- a/src/clincoded/static/components/add_curator.js
+++ b/src/clincoded/static/components/add_curator.js
@@ -101,7 +101,7 @@ var AddCurator = createReactClass({
         return (
             <div className="container">
                 <h1>{this.props.context.title}</h1>
-                <div className="col-md-8 col-md-offset-2 col-sm-9 col-sm-offset-1 form-create-gene-disease">
+                <div className="col-md-8 col-md-offset-2 col-sm-9 col-sm-offset-1 form-create-user">
                     <Panel panelClassName="panel-create-gene-disease">
                         <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                             <div className="row">

--- a/src/clincoded/static/components/add_disease.js
+++ b/src/clincoded/static/components/add_disease.js
@@ -60,7 +60,6 @@ var AddDisease = createReactClass({
             let diseaseId = this.getFormValue('disease_id');
             let term = this.getFormValue('disease_term');
             let description = this.getFormValue('disease_description');
-            let ontology = diseaseId.substr(0, diseaseId.indexOf('_')).toUpperCase();
             let synonyms = [];
             synonyms = this.getFormValue('disease_synonyms') && this.getFormValue('disease_synonyms').length ? this.getFormValue('disease_synonyms').split(', ') : [];
 
@@ -78,7 +77,6 @@ var AddDisease = createReactClass({
                         "diseaseId": diseaseId,
                         "term": term,
                         "description": description && description.length ? description : '',
-                        "ontology": ontology,
                         "synonyms": synonyms
                     };
                     return this.postRestData('/diseases/', newDisease).then(data => {
@@ -113,7 +111,7 @@ var AddDisease = createReactClass({
         return (
             <div className="container">
                 <h1>{this.props.context.title}</h1>
-                <div className="col-md-8 col-md-offset-2 col-sm-9 col-sm-offset-1 form-create-gene-disease">
+                <div className="col-md-8 col-md-offset-2 col-sm-9 col-sm-offset-1 form-create-disease">
                     <Panel panelClassName="panel-add-disease">
                         <Form submitHandler={this.submitForm} formClassName="form-horizontal form-std">
                             <div className="row">

--- a/src/clincoded/static/scss/clincoded/modules/_form.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_form.scss
@@ -9,10 +9,14 @@
     }
 }
 
+.form-create-user,
+.form-create-disease,
 .form-create-gene-disease {
     margin-top: 30px;
     margin-bottom: 50px;
+}
 
+.form-create-gene-disease {
     .submit-err {
         margin-right: -15px;
     }

--- a/src/clincoded/tests/features/select_variant.feature
+++ b/src/clincoded/tests/features/select_variant.feature
@@ -65,7 +65,7 @@ Feature: Select Variant
         When I press the button "Save and View Evidence"
         And I wait for 5 seconds
         Then I should see "Evidence View"
-        Then I should see " rs566967979"
+        Then I should see "NC_000003.11:g.184675256G>A"
         When I press "Logout ClinGen Test Curator"
         And I wait for 10 seconds
         Then I should see "Any user may explore the demo version of the ClinGen interfaces"


### PR DESCRIPTION
This ticket does not directly address #2136, but fixes an issue with the tool that's needed to make the data change. Also includes a small styling fix and a temporary automation test text change

**Steps to test /add-disease**

1. Login
2. Go to /add-disease
3. Find a disease to add from https://www.ebi.ac.uk/ols/index (I used MONDO:0011581)
4. Fill out the fields on the add disease page and click save.
5. Expect action to be successful. Ensure feedback text does not overlap with "Save" button.
