### PR TITLE
Retrieve Gene Information from HGNC (#1988)

### DIFF
--- a/src/clincoded/static/libs/parse-hgnc.js
+++ b/src/clincoded/static/libs/parse-hgnc.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Map gene properties to their counterparts in HGNC data
+const genePropertyMap = {
+    'symbol': 'symbol',
+    'hgncId': 'hgnc_id',
+    'entrezId': 'entrez_id',
+    'name': 'name',
+    'hgncStatus': 'status',
+    'synonyms': 'alias_symbol',
+    'nameSynonyms': 'alias_name',
+    'previousSymbols': 'prev_symbol',
+    'previousNames': 'prev_name',
+    'chromosome': 'location',
+    'locusType': 'locus_type',
+    'omimIds': 'omim_id',
+    'pmids': 'pubmed_id'
+};
+
+/**
+ * Function to parse JSON document of HGNC data for gene object creation
+ * @param {object} hgncJSON - JSON document containing HGNC data
+ * @returns {object} - object with mapped schema properties set to HGNC values
+ */
+export function parseHGNC(hgncJSON) {
+    let hgncGeneForDB = {};
+
+    Object.keys(genePropertyMap).forEach(property => {
+        if (hgncJSON.hasOwnProperty(genePropertyMap[property])) {
+
+            // Expecting PubMed IDs to be returned as numbers, need to convert them to strings
+            if (genePropertyMap[property] == 'pubmed_id') {
+                if (hgncJSON[genePropertyMap[property]].length) {
+                    hgncGeneForDB[property] = [];
+                }
+
+                hgncJSON[genePropertyMap[property]].forEach(pmid => {
+                    if (pmid || pmid === 0) {
+                        hgncGeneForDB[property].push(pmid.toString());
+                    }
+                });
+            } else {
+                hgncGeneForDB[property] = hgncJSON[genePropertyMap[property]];
+            }
+        }
+    });
+
+    return hgncGeneForDB;
+}
+
+/**
+ * Function to filter a gene object for comparison with HGNC data
+ * @param {object} geneObject - object containing gene data
+ * @returns {object} - object with just mapped schema properties
+ */
+export function filterGeneForHGNCComparison(geneObject) {
+    let geneForComparison = {};
+
+    Object.keys(genePropertyMap).forEach(property => {
+        // Intended to save non-empty strings and arrays
+        if (geneObject[property] && geneObject[property].length) {
+            geneForComparison[property] = geneObject[property];
+        }
+    });
+
+    return geneForComparison;
+}


### PR DESCRIPTION
Steps to test #1988:
1. Start a new gene curation.
2. Confirm that a gene-disease record can be created when:
- providing a symbol for a gene not present in the test dataset, such as AAAS, ZMYM6, NKX2-5 or C12ORF65
- providing a symbol for a gene in the test dataset, such as DICER1, FGFR3 or SMAD3 (for these examples, the process should update the locally-stored gene)
3. Confirm that a gene-disease record isn't created when providing data that matches an existing one, such as FANCM (gene), MONDO:0019391 (disease) and Other (mode of inheritance).