### PR TITLE
Patch 2126: Fix Text Overflow

### DIFF
--- a/src/clincoded/static/components/variant_central/interpretation/basic_info.js
+++ b/src/clincoded/static/components/variant_central/interpretation/basic_info.js
@@ -218,7 +218,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
             return (
                 <tr key={key} className={isCanonicalTranscript || isMANETranscript ? "marked-transcript" : null}>
                     <td className="hgvs-term">
-                        <span className="title-ellipsis">{item.hgvsc || item.transcript_id} {item.gene_symbol && `(${item.gene_symbol})`}</span>
+                        <span>{item.hgvsc || item.transcript_id} {item.gene_symbol && `(${item.gene_symbol})`}</span>
                         {/* show label for canonical transcript */}
                         {isCanonicalTranscript && <span className="label label-primary" data-toggle="tooltip" data-placement="top" data-tooltip="Canonical Transcript">C</span>}
 
@@ -681,7 +681,7 @@ var CurationInterpretationBasicInfo = module.exports.CurationInterpretationBasic
                                 <tbody>
                                     <tr>
                                         <td className="hgvs-term">
-                                            <span className="title-ellipsis">{primary_transcript.nucleotide}</span>
+                                            <span>{primary_transcript.nucleotide}</span>
                                         </td>
                                         <td className="exon-column">
                                             {primary_transcript.exon}

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -702,7 +702,10 @@
 }
 
 .title-ellipsis {
-    word-break: break-all;
+    overflow: hidden;
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     max-width: 100%;
     vertical-align: bottom;
 
@@ -1570,6 +1573,8 @@
             .basic-info .table.refseq-transcript td,
             .basic-info .table.ensembl-transcript th,
             .basic-info .table.ensembl-transcript td {
+                word-break: break-all;
+
                 /* 4 columns, sum up with .exon-column's width to a total of 100% */
                 width: 28%;
                 &.hgvs-term {

--- a/src/clincoded/static/scss/clincoded/modules/_curator.scss
+++ b/src/clincoded/static/scss/clincoded/modules/_curator.scss
@@ -702,10 +702,7 @@
 }
 
 .title-ellipsis {
-    overflow: hidden;
-    display: inline-block;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    word-break: break-all;
     max-width: 100%;
     vertical-align: bottom;
 
@@ -1573,11 +1570,13 @@
             .basic-info .table.refseq-transcript td,
             .basic-info .table.ensembl-transcript th,
             .basic-info .table.ensembl-transcript td {
-                /* sum up with .exon-column's width to a total of 100% */
-                width: 29%;
-
+                /* 4 columns, sum up with .exon-column's width to a total of 100% */
+                width: 28%;
+                &.hgvs-term {
+                    width: 35%;
+                }
                 &.exon-column {
-                    width: 13%;
+                    width: 9%;
                 }
             }
 


### PR DESCRIPTION
### In this ticket

- Fix text overflow for super long nucleotide change, for refseq, ensembl and primary transcript table in basic info tab. Resolve overflow [reported by Matt in 1868](https://github.com/ClinGen/clincoded/issues/2126#issuecomment-622597404). You can test by adding variant Clinvar ID `90973` to verify the super long variant title displayed in VCI basic info tab.
- Let add variant modal elapses / "dot dot dot truncating" remain.

[Test instance](https://2126-sc-mane-visual-cue-rev07.demo.clinicalgenome.org).

Previous PR: #2195 